### PR TITLE
docs: corregir drift documentación ↔ código (#18)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,9 @@ scoped certificate.
 | `approved` | bool | | Marks a `require_approval` command as approved. Honored **only** from a trusted forwarder. Without it, a `require_approval` command returns 200 with no certificate (see below). |
 | `end_user` | string | | OIDC identity of the end user (propagated by the HTTP frontend). Recorded in the audit log and embedded in the cert `KeyId` for `sshd` traceability. |
 | `end_user_groups` | []string | | OIDC groups of the end user. When non-nil, activates per-user RBAC: the host's `groups` field must intersect with this list. |
+| `learn_ttl_seconds` | int | | Approve-and-learn: ask the signer to mint a TTL'd approval waiver for this approved command/elevation/caller/end-user scope. Honored **only** from a trusted forwarder (the control plane), exactly like `approved`. |
+| `learn_approver` | string | | Audit metadata: approver of the decision that authorized the learning. Trusted forwarder only. |
+| `learn_approval_id` | string | | Audit metadata: approval id that authorized the learning. Trusted forwarder only. |
 
 **Response body (200 OK):**
 
@@ -102,9 +105,9 @@ scoped certificate.
 
 | Status | Condition |
 |---|---|
-| `400 Bad Request` | Malformed JSON body or invalid `public_key` format. |
+| `400 Bad Request` | Malformed JSON body or invalid `public_key` format; or control/whitespace characters in `end_user`, `role`, `purpose`, `session_mode`, `sudo_user`, or in the resolved caller identity (rejected before any audit emission). |
 | `401 Unauthorized` | Missing or invalid mTLS client certificate. |
-| `403 Forbidden` | Host not in caller's allowed groups (RBAC); or policy denied (sudo not allowed, PTY not allowed, invalid `sudo_user`, `shell`/`pty` session requested on a host with `command_policy`, `role: "bastion"` requested for a host with a `command_policy`, control characters in `caller`/`end_user`, etc.). Note: a `ttl_seconds` above the host cap is silently clamped to the cap, not rejected. |
+| `403 Forbidden` | Host not in caller's allowed groups (RBAC); or policy denied (sudo not allowed, PTY not allowed, invalid `sudo_user`, `shell`/`pty` session requested on a host with `command_policy`, `role: "bastion"` requested for a host with a `command_policy`, `on_behalf_of` from a non-trusted forwarder, etc.). Note: a `ttl_seconds` above the host cap is silently clamped to the cap, not rejected. |
 | `405 Method Not Allowed` | Request method is not `POST`. |
 
 **Approval-required response (200 OK, no certificate):** when the command matches
@@ -168,6 +171,7 @@ JSON object mapping host name → host info object.
 | Status | Condition |
 |---|---|
 | `401 Unauthorized` | Missing or invalid mTLS client certificate. |
+| `403 Forbidden` | `X-On-Behalf-Of` header sent by a caller that is not a trusted forwarder. |
 | `405 Method Not Allowed` | Request method is not `GET`. |
 
 ---
@@ -407,8 +411,11 @@ forwards to the signer on behalf of the calling broker (`on_behalf_of` = broker 
 |---|---|
 | `200 OK` | Issued (allowed, no approval needed) — body is the signer's `WireResponse` with `certificate`. Or, for `dry_run`, the `decision`. |
 | `202 Accepted` | Approval required (command policy `require_approval`, or a behavior anomaly in `enforce` mode). Body: `{"approval_id": "...", "status": "pending"}`. The broker must poll `/v1/sign/result/{id}`. |
-| `403 Forbidden` | Denied by policy/RBAC at the signer. |
+| `400 Bad Request` | Malformed JSON body or invalid `public_key`. |
+| `401 Unauthorized` | Missing or invalid mTLS client certificate. |
+| `403 Forbidden` | Denied by policy/RBAC at the signer; or the CN is not authorised for the sign path (`sign_callers`, or an approver CN). |
 | `429 Too Many Requests` | Behavioral rate limit exceeded for the subject (`behavior.mode=enforce`). |
+| `502 Bad Gateway` | Signer reachable but its response carried no certificate in a non-approval state (unexpected signer condition). |
 
 **Behavioral guardrails:** when `behavior.mode` is `observe` or `enforce`, the
 control plane checks each request against the subject's baseline (rate spike, new
@@ -433,12 +440,14 @@ mTLS CN) may read it.
 
 | Status | Meaning |
 |---|---|
-| `202 Accepted` | Still pending. Body: `{"status":"pending"}`. Keep polling. |
+| `202 Accepted` | Still pending. Body: `{"status":"pending"}`. Keep polling. Body is `{"status":"issuing"}` when another poll of the same approval is already collecting the certificate from the signer. |
 | `200 OK` | Approved and signed — body is the `WireResponse` with `certificate`. Served once (the approval is then consumed). |
+| `400 Bad Request` | Invalid `pubkey` query parameter. |
 | `403 Forbidden` | Approval denied, or caller is not the request owner. |
 | `408 Request Timeout` | Approval expired: pending requests expire after `approval.timeout_seconds` from creation; approved-but-uncollected requests expire after the same TTL from the decision. |
 | `410 Gone` | Approval already consumed (certificate already issued). |
 | `404 Not Found` | Unknown approval id — including requests purged from memory ~2× `approval.timeout_seconds` after creation. |
+| `502 Bad Gateway` | Signing after approval failed (signer error, missing decision, or missing certificate). |
 
 ---
 
@@ -446,7 +455,7 @@ mTLS CN) may read it.
 
 Lists approval requests. **Auth:** CN must be in `approval.callers`.
 
-**Response (200 OK):** JSON array of `{id, caller, end_user, host, command, sudo, sudo_user, rule, status, created_at, decided_by, decided_at}` (the ephemeral public key is never exposed). Includes non-pending entries (approved/denied/expired) still held in memory.
+**Response (200 OK):** JSON array of `{id, caller, end_user, host, command, sudo, sudo_user, rule, status, created_at, decided_by, decided_at, learn_ttl}` (the ephemeral public key is never exposed; `learn_ttl` appears only when an approve-and-learn TTL was set). Includes non-pending entries (approved/denied/expired) still held in memory.
 
 ---
 
@@ -472,7 +481,7 @@ waiver expires; revoke it early with `broker-ctl policy revoke <id>`.
 |---|---|
 | `200 OK` | Decision recorded; body is the updated approval object. |
 | `400 Bad Request` | `learn` without `ttl_seconds > 0`. |
-| `403 Forbidden` | Caller not in `approval.callers`. |
+| `403 Forbidden` | Caller not in `approval.callers`; or the caller tries to decide a request it originated itself (four-eyes self-approval guard, audit outcome `self-approval-rejected`). |
 | `409 Conflict` | Request not pending (already decided or expired). |
 
 **Audit outcomes (control plane log):** `forwarded`, `approval-required`, `approval-decision-allow`, `approval-decision-allow-learn`, `approval-denied`, `approval-granted`, `approval-timeout`, `denied`. The signer additionally logs `approval-waiver-created` when the waiver is minted.
@@ -709,8 +718,9 @@ mTLS) see every host.
 
 **Parameters:** none.
 
-**Returns:** array of objects. Connectivity data (`addr`, `user`, `host_key`)
-is **not** exposed to the model — only the logical name and capabilities.
+**Returns:** an object `{"servers": [...]}` whose array elements are described
+below. Connectivity data (`addr`, `user`, `host_key`) is **not** exposed to the
+model — only the logical name and capabilities.
 
 | Field | Type | Description |
 |---|---|---|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -486,7 +486,7 @@ rejects the token.
 |---|---|---|---|
 | `cmd/mcp-broker` (stdio) | no | sessions | local MCP frontend for the model |
 | `cmd/mcp-broker-http` | no | sessions | network MCP frontend (OAuth2/OIDC) |
-| `cmd/broker` | no | sessions | HTTP+mTLS one-shot frontend |
+| `cmd/broker` | no | none | HTTP+mTLS one-shot frontend (no session endpoints) |
 | `cmd/control-plane` | **no** | approvals, behavior | optional PEP (approval + guardrails) |
 | `cmd/signer` | **yes** | none | sole CA custodian; policy + RBAC + signing |
 | `cmd/broker-ctl` | no | none | operator CLI for `signer.json` + audit + approvals |

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -99,7 +99,10 @@ ssh-broker/
 │   ├── control/              # approval Registry, notifier, teams, behavior tracker
 │   ├── recording/            # Recorder ASCIIcast v2
 │   ├── httpserve/            # RunTLS: serve + graceful shutdown (SIGINT/SIGTERM)
-│   └── auth/                 # mtls (ServerTLSConfig, ClientTLSConfig, CallerCN)
+│   ├── auth/                 # mtls (ServerTLSConfig, ClientTLSConfig, CallerCN)
+│   ├── confcheck/            # validación estricta de los *.example.json (DisallowUnknownFields)
+│   ├── policyrec/            # motor de broker-ctl policy recommend (minería del audit log)
+│   └── version/              # versión embebida en build (git describe via Makefile)
 ├── lab/                      # labs e2e (run_*.sh) + mcpclient
 ├── pki/                      # PKI local (NO git) — ver OPERATIONS.md §5
 ├── deploy/sshd_config.snippet
@@ -114,7 +117,7 @@ ssh-broker/
 conocidas). La suite de tests cubre los paquetes con lógica de seguridad,
 política, transporte, auditoría, CLI y documentación generada.
 
-**Binarios:** `~/bin/{mcp-broker,mcp-broker-http,signer,broker-ctl}`.
+**Binarios:** `~/bin/{mcp-broker,mcp-broker-http,signer,broker-ctl,broker,control-plane}`.
 **MCP registrado:** `~/.claude.json` / config de OpenCode.
 
 ---

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -39,7 +39,7 @@ make signer                  # or just one
 ```
 
 Compiled binaries: `~/bin/mcp-broker` · `~/bin/mcp-broker-http` · `~/bin/signer`
-· `~/bin/broker-ctl`. `make install` injects the version from `git describe
+· `~/bin/broker-ctl` · `~/bin/broker` · `~/bin/control-plane`. `make install` injects the version from `git describe
 --tags`; a plain `go build ./cmd/...` still works but reports a `dev-<commit>`
 version. Run `make version` to see what would be embedded.
 
@@ -226,7 +226,7 @@ broker-ctl host remove web01
 | `--bastion` | | false | `allow_as_bastion=true` |
 | `--force` | | false | Update if it exists, preserving every field whose flag you don't pass (see note) |
 | `--policy-mode` | | — | `allowlist` \| `denylist` \| `off` |
-| `--policy-enforcement` | | `enforce` | `enforce` \| `audit`; audit allows commands but emits would-deny / would-require-approval warnings |
+| `--policy-enforcement` | | — (empty = `enforce`) | `enforce` \| `audit`; audit allows commands but emits would-deny / would-require-approval warnings |
 | `--allow` | | — | Allowlist patterns (RE2 regex, comma-separated) |
 | `--deny` | | — | Denylist patterns (RE2 regex, comma-separated) |
 | `--require-approval` | | — | Require-approval patterns (RE2 regex, comma-separated) |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -802,7 +802,7 @@ FAIL: 1234 entries checked, 1 error(s) found
 | `command` | string | Command executed (one-shot) or session mode |
 | `ttl` | string | Certificate TTL granted |
 | `serial` | uint64 | Certificate serial — correlates broker ↔ signer ↔ sshd |
-| `session_id` | string | Session UUID (session events only) |
+| `session_id` | string | Session id — 24-char random hex token (session events only) |
 | `outcome` | string | See table in §7.2 |
 | `exit_code` | int | Remote exit code (execution events) |
 | `err` | string | Error detail (on failure) |
@@ -835,7 +835,7 @@ One file per session: `<session_id>.cast`
 
 ```
 /var/log/ssh-broker/recordings/
-  a3f1b2c4d5e6789a.cast
+  a3f1b2c4d5e60718293a4b5c.cast
   b7c8d9e0f1a2b3c4.cast
 ```
 
@@ -860,9 +860,9 @@ The file is **ASCIIcast v2** JSONL — one JSON line per event:
 
 ```
 {"version":2,"width":220,"height":40,"timestamp":1749470400,
- "title":"session a3f1b2c4 — alice@web01",
+ "title":"session a3f1b2c4d5e60718293a4b5c — alice@web01",
  "env":{"TERM":"xterm-256color"},
- "ssh_broker":{"session_id":"a3f1b2c4","caller":"alice","host":"web01",
+ "ssh_broker":{"session_id":"a3f1b2c4d5e60718293a4b5c","caller":"alice","host":"web01",
                "serial":1042,"started_at":"2026-06-09T14:00:01Z"}}
 [0.000, "i", "df -h /\n"]
 [0.012, "o", "Filesystem      Size  Used Avail Use% Mounted on\n"]
@@ -891,13 +891,13 @@ Any tool that supports ASCIIcast v2 can replay the recording:
 pip install asciinema   # or: brew install asciinema
 
 # Play a session recording
-asciinema play /var/log/ssh-broker/recordings/a3f1b2c4d5e6789a.cast
+asciinema play /var/log/ssh-broker/recordings/a3f1b2c4d5e60718293a4b5c.cast
 
 # Print the recording as plain text (no timing)
-asciinema cat /var/log/ssh-broker/recordings/a3f1b2c4d5e6789a.cast
+asciinema cat /var/log/ssh-broker/recordings/a3f1b2c4d5e60718293a4b5c.cast
 
 # Stream new events as they are written (live tail)
-tail -f /var/log/ssh-broker/recordings/a3f1b2c4d5e6789a.cast \
+tail -f /var/log/ssh-broker/recordings/a3f1b2c4d5e60718293a4b5c.cast \
   | asciinema cat /dev/stdin
 ```
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -4,6 +4,93 @@
 
 Every configuration field, extracted from the Go structs (field · JSON key · type · doc comment). See [Operations](../OPERATIONS.md) for worked examples and the `*.example.json` files.
 
+## Broker / MCP config (`config.json`)
+
+`Config` in `internal/broker/engine.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `listen` | `string` | HTTP only: e.g. ":8443" |
+| `server_cert` | `string` | TLS / mTLS for the HTTP frontend (not used by the MCP, which runs over stdio). |
+| `server_key` | `string` |  |
+| `client_ca` | `string` |  |
+| `ca_key` | `string` | CAKey — LOCAL mode ONLY (in-process signing). When the Signer block is present, this field is ignored and the broker holds no CA key. ca_keys: per-group CA key overrides. "_default" overrides ca_key when present. See ca.CAKeyConfig for supported backends ("pem" for local files, "akv" for Azure Key Vault). Local mode only; ignored when Signer is set. |
+| `ca_keys` | `map[string]ca.CAKeyConfig` |  |
+| `signer` | `*SignerClientConfig` | Signer, when present, externalises signing to a remote service (HTTP+mTLS). The broker no longer holds the CA key or the policy. |
+| `audit_log` | `string` | Audit. |
+| `audit_key` | `string` | Ed25519 seed (>=32 bytes) |
+| `source_address` | `string` | SourceAddress: broker egress IP/CIDR, used in local mode. |
+| `max_ttl_seconds` | `int` | MaxTTLSeconds caps the maximum requestable TTL. |
+| `hosts_refresh_seconds` | `int` | HostsRefreshSeconds: host-list reload interval from the signer. Remote mode only. Default: 300 (5 minutes). |
+| `session_idle_seconds` | `int` | Persistent session idle-close and maximum lifetime. |
+| `session_max_seconds` | `int` | default 1800 |
+| `session_recording_dir` | `string` | SessionRecordingDir: directory for session recordings in ASCIIcast v2 format (.cast files). One file per session: <session_id>.cast. Empty = recording disabled. |
+| `hosts` | `map[string]HostConfig` | Hosts: used only in local mode (single-binary). In remote mode the host list is fetched from the signer via /v1/hosts and refreshed periodically. |
+| `command_policies` | `map[string]signer.CommandPolicy` | CommandPolicies (local mode) is a named library of command policies, attachable to groups. GroupCommandPolicies maps a group name to the policy names that apply to its hosts; the reserved group "_default" applies to every host. A host's effective firewall is the composition of its inline command_policy and the policies of all its groups (additive union; deny wins). |
+| `group_command_policies` | `map[string][]string` |  |
+| `oauth` | `*OAuthConfig` | OAuth and ResourceURL are used only by the HTTP+OAuth frontend (cmd/mcp-broker-http); other frontends ignore them. |
+| `resource_url` | `string` | ResourceURL is the canonical URL of this MCP server, used in the Protected Resource Metadata document (RFC 9728) and the WWW-Authenticate header. |
+
+## Broker signer client (`signer`, remote mode)
+
+`SignerClientConfig` in `internal/broker/engine.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `url` | `string` |  |
+| `client_cert` | `string` |  |
+| `client_key` | `string` |  |
+| `ca` | `string` |  |
+| `approval_wait_seconds` | `int` | ApprovalWaitSeconds: maximum time the broker waits for a human approval to be resolved (202 response from the control plane). 0 = do not wait. |
+
+## Broker OAuth (`oauth`, `cmd/mcp-broker-http` only)
+
+`OAuthConfig` in `internal/broker/engine.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `issuer` | `string` | Issuer is the OIDC provider URL (e.g. https://keycloak.example/realms/x). |
+| `audience` | `string` | Audience is the expected value of the aud claim (this resource server). |
+| `required_scopes` | `[]string` | RequiredScopes are the scopes the token must carry to be accepted. |
+| `user_claim` | `string` | UserClaim is the claim used as user identity (default "sub"). |
+| `groups_claim` | `string` | GroupsClaim is the claim that carries groups/roles to propagate to the signer. Empty = groups are not propagated (no per-user RBAC). |
+| `max_token_age_seconds` | `int` | MaxTokenAgeSeconds limits the age of the token since issuance (iat claim). 0 = no limit (accepts any token within its exp). Recommended: 3600 (1h). M3: reduces the replay risk of leaked tokens within their exp window. |
+| `clock_skew_seconds` | `int` | ClockSkewSeconds is the tolerance applied to the nbf and iat claims to absorb small clock differences between the IdP and this host. 0 selects a 1-minute default; a negative value disables the tolerance. |
+
+## Broker host (`hosts.<name>`, local mode)
+
+`HostConfig` in `internal/broker/engine.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `addr` | `string` |  |
+| `user` | `string` |  |
+| `principal` | `string` |  |
+| `host_key` | `string` |  |
+| `jump` | `string` |  |
+| `source_address` | `string` | SourceAddress: per-host override of the global value for THIS host's cert. LOCAL mode only. |
+| `allow_sudo` | `bool` | Elevation (NOPASSWD) — local mode. |
+| `allowed_sudo_users` | `[]string` |  |
+| `allow_pty` | `bool` | AllowPTY — local mode. |
+| `groups` | `[]string` | Groups lists the RBAC groups this host belongs to. When ca_keys are configured (multi-CA), the first matching group determines which CA signs certificates for this host. Also used for per-user RBAC in local mode. |
+| `allow_as_bastion` | `bool` | AllowAsBastion authorises this host to be used as a ProxyJump hop (permit-port-forwarding in its cert). Local mode only; default false to match the remote-signer default-deny gate (ARCHITECTURE.md § routing). A host referenced as another host's Jump target is enabled automatically (see policyFromHosts), so existing jump chains keep working without per-host config. |
+| `command_policy` | `signer.CommandPolicy` | CommandPolicy — local mode (AI-action firewall). In remote mode this is defined by the signer in signer.json. |
+
+## CA key (`ca_keys.<name>`)
+
+`CAKeyConfig` in `internal/ca/loader.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `type` | `string` | "pem" \| "akv" |
+| `path` | `string` | PEM backend. |
+| `vault_url` | `string` | Azure Key Vault backend. |
+| `key_name` | `string` |  |
+| `key_version` | `string` | empty = latest version |
+| `tenant_id` | `string` | AKV authentication overrides. When TenantID and ClientID are both empty, DefaultAzureCredential is used (recommended for production: picks up managed identity, workload identity, AZURE_* env vars, and Azure CLI). |
+| `client_id` | `string` |  |
+| `client_secret_env` | `string` | ClientSecretEnv is the name of the environment variable holding the client secret. The secret is never stored in the config file. |
+
 ## Signer config (`signer.json`)
 
 `Config` in `cmd/signer/main.go`
@@ -40,11 +127,33 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `client_ca` | `string` |  |
 | `sign_callers` | `[]string` | SignCallers: client cert CNs authorised to use the signing path (/v1/sign, /v1/hosts, /v1/sign/result) — i.e. the brokers. This separates the broker role from the approver role (approval.callers) when both are signed by the same client_ca. If non-empty, only these CNs may request signing. If empty/absent, any authenticated broker may — EXCEPT a CN that is in approval.callers, which is an approver, not a broker, and is denied the sign path (role separation, secure by default). |
 | `signer` | `(object)` | Signer: mTLS client toward the signing service. |
+| `signer.url` | `string` |  |
+| `signer.client_cert` | `string` |  |
+| `signer.client_key` | `string` |  |
+| `signer.ca` | `string` |  |
 | `approval` | `(object)` | Approval: human-approval orchestration. |
+| `approval.notifier` | `string` | ""/"log" (default) \| "webhook" \| "teams" |
+| `approval.webhook_url` | `string` | required when notifier=webhook or teams |
+| `approval.timeout_seconds` | `int` | TTL for pending requests |
+| `approval.callers` | `[]string` | CNs authorised to approve/deny |
+| `approval.teams_format` | `string` | Teams-specific fields (notifier=teams). |
+| `approval.approval_url_template` | `string` | URL with "{id}" to link the request |
 | `behavior` | `control.BehaviorConfig` | Behavior: behaviour guardrails (anomaly detection + rate limiting). |
 | `trusted_forwarders` | `[]string` | TrustedForwarders: broker client cert CNs whose end_user claim is trusted (brokers that authenticate end users, e.g. via OIDC). Mirrors the signer's trusted_forwarders semantics. Behaviour guardrails key on "<broker CN>:<end_user>" only for these CNs; for any other CN the client-supplied end_user is ignored and the authenticated broker CN alone is used, so a client cannot evade rate limits or anomaly detection by rotating end_user. Empty/absent = end_user never qualifies the subject. |
 | `audit_log` | `string` | Audit log for the control plane (independent of broker and signer). |
 | `audit_key` | `string` |  |
+
+## Control-plane behaviour guardrails (`behavior`)
+
+`BehaviorConfig` in `internal/control/behavior.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `mode` | `string` | Mode: "off"\|"observe"\|"enforce". |
+| `rate_limit_per_min` | `int` | RateLimitPerMin: maximum requests per subject per minute (0 = no limit). |
+| `max_subjects` | `int` | MaxSubjects caps how many subjects are tracked before the least-recently -seen one is evicted (0 = defaultMaxSubjects). |
+| `subject_ttl_minutes` | `int` | SubjectTTLMinutes evicts subjects idle for longer than this (0 = defaultSubjectTTL). |
+| `max_distinct_per_subject` | `int` | MaxDistinctPerSubject caps the distinct hosts and command fingerprints retained per subject (0 = defaults). Once full, novelty detection for that dimension degrades to "seen" rather than growing without bound. |
 
 ## Host policy (`hosts.<name>`)
 

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -46,3 +46,4 @@ Every route registered across the services, extracted from the `mux.HandleFunc` 
 | Route | Handler |
 |---|---|
 | `/` | `protected` |
+| `/.well-known/oauth-protected-resource` | `prm` |

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -82,6 +82,7 @@ func routesIn(dir string) []route {
 	}
 	var routes []route
 	for _, pkg := range pkgs {
+		consts := packageStringConsts(pkg)
 		for _, file := range pkg.Files {
 			ast.Inspect(file, func(n ast.Node) bool {
 				call, ok := n.(*ast.CallExpr)
@@ -92,12 +93,19 @@ func routesIn(dir string) []route {
 				if !ok || (sel.Sel.Name != "HandleFunc" && sel.Sel.Name != "Handle") || len(call.Args) < 1 {
 					return true
 				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					return true
+				pattern := ""
+				switch arg := call.Args[0].(type) {
+				case *ast.BasicLit:
+					if arg.Kind != token.STRING {
+						return true
+					}
+					if p, err := strconv.Unquote(arg.Value); err == nil {
+						pattern = p
+					}
+				case *ast.Ident:
+					pattern = consts[arg.Name] // route named via a package const
 				}
-				pattern, err := strconv.Unquote(lit.Value)
-				if err != nil || pattern == "" {
+				if pattern == "" {
 					return true
 				}
 				handler := ""
@@ -115,6 +123,34 @@ func routesIn(dir string) []route {
 	}
 	sort.Slice(routes, func(i, j int) bool { return routes[i].pattern < routes[j].pattern })
 	return routes
+}
+
+// packageStringConsts maps package-level string const names to their values, so
+// routes registered via a named const (e.g. mux.Handle(prmPath, ...)) resolve.
+func packageStringConsts(pkg *ast.Package) map[string]string {
+	out := map[string]string{}
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != len(vs.Values) {
+					continue
+				}
+				for i, name := range vs.Names {
+					if lit, ok := vs.Values[i].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+						if v, err := strconv.Unquote(lit.Value); err == nil {
+							out[name.Name] = v
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
 }
 
 // ── MCP tools ────────────────────────────────────────────────────────────────
@@ -192,8 +228,14 @@ func schemaProps(schema any) []prop {
 // ── config ───────────────────────────────────────────────────────────────────
 
 var configStructs = []struct{ file, name, title string }{
+	{"internal/broker/engine.go", "Config", "Broker / MCP config (`config.json`)"},
+	{"internal/broker/engine.go", "SignerClientConfig", "Broker signer client (`signer`, remote mode)"},
+	{"internal/broker/engine.go", "OAuthConfig", "Broker OAuth (`oauth`, `cmd/mcp-broker-http` only)"},
+	{"internal/broker/engine.go", "HostConfig", "Broker host (`hosts.<name>`, local mode)"},
+	{"internal/ca/loader.go", "CAKeyConfig", "CA key (`ca_keys.<name>`)"},
 	{"cmd/signer/main.go", "Config", "Signer config (`signer.json`)"},
 	{"cmd/control-plane/main.go", "Config", "Control-plane config (`control-plane.json`)"},
+	{"internal/control/behavior.go", "BehaviorConfig", "Control-plane behaviour guardrails (`behavior`)"},
 	{"internal/signer/signer.go", "HostPolicy", "Host policy (`hosts.<name>`)"},
 	{"internal/signer/cmdpolicy.go", "CommandPolicy", "Command policy (`command_policy`)"},
 }
@@ -244,35 +286,44 @@ func structFields(file, name string) []field {
 		if !ok {
 			return true
 		}
-		for _, fl := range st.Fields.List {
-			if len(fl.Names) == 0 || !fl.Names[0].IsExported() {
-				continue
-			}
-			jsonKey := fl.Names[0].Name
-			if fl.Tag != nil {
-				tag := reflect.StructTag(strings.Trim(fl.Tag.Value, "`"))
-				if jt := tag.Get("json"); jt != "" {
-					k := strings.Split(jt, ",")[0]
-					if k == "-" {
-						continue // not serialised — internal/computed, not a config key
-					}
-					if k != "" {
-						jsonKey = k
-					}
-				}
-			}
-			doc := commentText(fl.Doc)
-			if doc == "" {
-				doc = commentText(fl.Comment)
-			}
-			typ := "(object)"
-			if _, nested := fl.Type.(*ast.StructType); !nested {
-				typ = renderExpr(fset, fl.Type)
-			}
-			out = append(out, field{json: jsonKey, typ: mdCell(typ), doc: mdCell(doc)})
-		}
+		out = walkStructFields(fset, st, "")
 		return false
 	})
+	return out
+}
+
+// walkStructFields flattens a struct's exported fields into doc rows, recursing
+// into anonymous nested structs with a dotted key prefix (e.g. `approval.notifier`).
+func walkStructFields(fset *token.FileSet, st *ast.StructType, prefix string) []field {
+	var out []field
+	for _, fl := range st.Fields.List {
+		if len(fl.Names) == 0 || !fl.Names[0].IsExported() {
+			continue
+		}
+		jsonKey := fl.Names[0].Name
+		if fl.Tag != nil {
+			tag := reflect.StructTag(strings.Trim(fl.Tag.Value, "`"))
+			if jt := tag.Get("json"); jt != "" {
+				k := strings.Split(jt, ",")[0]
+				if k == "-" {
+					continue // not serialised — internal/computed, not a config key
+				}
+				if k != "" {
+					jsonKey = k
+				}
+			}
+		}
+		doc := commentText(fl.Doc)
+		if doc == "" {
+			doc = commentText(fl.Comment)
+		}
+		if nested, ok := fl.Type.(*ast.StructType); ok {
+			out = append(out, field{json: prefix + jsonKey, typ: "(object)", doc: mdCell(doc)})
+			out = append(out, walkStructFields(fset, nested, prefix+jsonKey+".")...)
+			continue
+		}
+		out = append(out, field{json: prefix + jsonKey, typ: mdCell(renderExpr(fset, fl.Type)), doc: mdCell(doc)})
+	}
 	return out
 }
 


### PR DESCRIPTION
Corrige el drift documentación ↔ código detectado en la auditoría de #18.

## Cambios

**`tools/docgen` (commit 1)** — causa raíz del mayor drift:
- Añade a `configStructs` el config completo del broker/MCP (`internal/broker/engine.go`: `Config`, `SignerClientConfig`, `OAuthConfig`, `HostConfig`), `CAKeyConfig` y `BehaviorConfig`.
- Recurre en structs anónimos anidados con claves con puntos (`signer.url`, `approval.notifier`, …) en lugar de un `(object)` opaco.
- Resuelve constantes string del paquete en los registros de rutas, con lo que `/.well-known/oauth-protected-resource` (registrada vía `prmPath`) aparece en `endpoints.md`.
- Regenera `docs/reference/{config,endpoints}.md` (+110 líneas de referencia nueva).

**Docs manuales (commit 2)**:
- `API.md`: códigos de estado corregidos/añadidos (400 por caracteres de control en el signer, 403 de `X-On-Behalf-Of` en `/v1/hosts`, 400/401/502 del control-plane en `/v1/sign`, 202 `issuing`/400/502 en `/v1/sign/result/{id}`, 403 del guard de auto-aprobación), campo `learn_ttl` del objeto approval, campos wire `learn_*`, y forma de retorno real de `ssh_list_servers` (`{"servers":[...]}`).
- `USAGE.md`: `session_id` es un token hex aleatorio de 24 caracteres, no un UUID; ejemplos `.cast` ajustados.
- `OPERATIONS.md`: default literal de `--policy-enforcement` (vacío = enforce) y lista de binarios completa (6, no 4).
- `HANDOFF.md`: árbol de `internal/` completado (`confcheck/`, `policyrec/`, `version/`) y binarios.
- `ARCHITECTURE.md`: `cmd/broker` no mantiene estado de sesiones (frontend one-shot).

## No incluido

Las etiquetas de versión desfasadas en ARCHITECTURE/OPERATIONS (llegan a v1.18.0) y THREAT_MODEL (v1.14.0) — el comportamiento descrito es correcto; retocar los metadatos de versión en todo el doc-set es un cambio editorial aparte.

## Verificación

`go build ./...`, `go test ./...` en verde, y `go run ./tools/docgen && git diff --exit-code docs/reference` estable (el check de CI de docs generadas pasa).

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
