### PR TITLE
feat: per-CN rate limit on the signer's /v1/sign

### DIFF
--- a/cmd/signer/handlers_test.go
+++ b/cmd/signer/handlers_test.go
@@ -245,3 +245,61 @@ func TestHandleSignPropagatesPreflight(t *testing.T) {
 		t.Fatalf("unexpected session intent: %+v", cap.got)
 	}
 }
+
+// TestHandleSignRateLimitPerCN verifies the per-CN token bucket on /v1/sign:
+// requests beyond the per-minute budget get 429 with a Retry-After hint, other
+// CNs keep their own budget, and a zero limit disables the check entirely.
+func TestHandleSignRateLimitPerCN(t *testing.T) {
+	t.Parallel()
+	body := signer.WireRequest{
+		Host:    "web01",
+		Role:    signer.RoleTarget,
+		Purpose: signer.PurposeOneshot,
+		Command: "uptime",
+	}
+	newSrv := func(limit int) *server {
+		return &server{
+			local: &captureLocalSigner{},
+			hosts: signer.PolicyTable{
+				"web01": {Addr: "10.0.0.1:22", User: "deploy", Principal: "host:web01"},
+			},
+			audit:       testAudit(t),
+			signRateMin: limit,
+			rateLimiter: signer.NewRateLimiter(),
+		}
+	}
+
+	srv := newSrv(2)
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		srv.handleSign(rec, signRequestAs(t, "broker-1", body))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d within budget: status = %d, want 200: %s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	rec := httptest.NewRecorder()
+	srv.handleSign(rec, signRequestAs(t, "broker-1", body))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("request beyond budget: status = %d, want 429", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("429 must carry a Retry-After hint")
+	}
+
+	// Another CN has its own bucket.
+	rec = httptest.NewRecorder()
+	srv.handleSign(rec, signRequestAs(t, "broker-2", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("another CN must have its own budget: status = %d", rec.Code)
+	}
+
+	// Limit 0 disables the check (and must not touch the limiter).
+	srv = newSrv(0)
+	for i := 0; i < 10; i++ {
+		rec := httptest.NewRecorder()
+		srv.handleSign(rec, signRequestAs(t, "broker-1", body))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("limit 0 must never rate limit: status = %d", rec.Code)
+		}
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -61,6 +62,13 @@ type Config struct {
 	// POST /v1/reload, so a transiently-invalid in-progress save is rejected and
 	// the previous good state is kept. 0 or absent = disabled (default).
 	AutoReloadSeconds int `json:"auto_reload_seconds,omitempty"`
+
+	// SignRateLimitPerMin caps POST /v1/sign requests per authenticated client
+	// CN per minute (token bucket: burst up to the cap, continuous refill).
+	// Keyed on the mTLS peer CN — not on_behalf_of — and enforced before body
+	// parsing; excess requests get 429 with a Retry-After hint. Hot-reloadable.
+	// 0 or absent = disabled (backward compatible).
+	SignRateLimitPerMin int `json:"sign_rate_limit_per_min,omitempty"`
 
 	// MaxGrantTTLSeconds: optional upper bound on a runtime grant's TTL
 	// (POST /v1/policy/hosts/{host}/grants). 0 or absent = no cap.
@@ -147,9 +155,11 @@ func main() {
 		callers:     cfg.Callers,
 		reloadCN:    reloadSet(cfg.ReloadCallers),
 		forwarders:  reloadSet(cfg.TrustedForwarders),
+		signRateMin: cfg.SignRateLimitPerMin,
 		cfgPath:     *cfgPath,
 		grants:      grantStore,
 		maxGrantTTL: time.Duration(cfg.MaxGrantTTLSeconds) * time.Second,
+		rateLimiter: signer.NewRateLimiter(),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/sign", srv.handleSign)
@@ -292,12 +302,13 @@ func reloadSet(cns []string) map[string]struct{} {
 
 type server struct {
 	// mu protects hot-reloadable state.
-	mu         sync.RWMutex
-	local      localSigner
-	hosts      signer.PolicyTable
-	callers    signer.CallerTable
-	reloadCN   map[string]struct{}
-	forwarders map[string]struct{}
+	mu          sync.RWMutex
+	local       localSigner
+	hosts       signer.PolicyTable
+	callers     signer.CallerTable
+	reloadCN    map[string]struct{}
+	forwarders  map[string]struct{}
+	signRateMin int // per-CN /v1/sign requests per minute; 0 = disabled
 
 	// writeMu serialises config mutations (POST/DELETE /v1/policy) so two
 	// concurrent edits cannot interleave the file read-modify-write.
@@ -313,6 +324,18 @@ type server struct {
 	// grant's TTL at creation (0 = no cap).
 	grants      *signer.GrantStore
 	maxGrantTTL time.Duration
+
+	// rateLimiter holds the per-CN /v1/sign token buckets. Created once and
+	// kept across reloads (its own mutex makes it concurrency-safe); the limit
+	// itself lives in signRateMin so a reload applies instantly.
+	rateLimiter *signer.RateLimiter
+}
+
+// signRate returns the hot-reloadable per-CN /v1/sign rate limit.
+func (s *server) signRate() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.signRateMin
 }
 
 // snapshot returns the current state under RLock, so handlers do not read
@@ -354,6 +377,7 @@ func (s *server) reload() (int, error) {
 	s.callers = cfg.Callers
 	s.reloadCN = reloadSet(cfg.ReloadCallers)
 	s.forwarders = reloadSet(cfg.TrustedForwarders)
+	s.signRateMin = cfg.SignRateLimitPerMin
 	s.mu.Unlock()
 	return len(cfg.Hosts), nil
 }
@@ -366,6 +390,17 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	caller, err := auth.CallerCN(r)
 	if err != nil {
 		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+
+	// Per-CN rate limit (threat-model gap #4), keyed on the authenticated mTLS
+	// peer — not on_behalf_of, which arrives in the body from a single forwarder
+	// peer anyway — and checked before body parsing so a flooding client costs
+	// as little as possible. Deliberately NOT audited per rejection: the
+	// tamper-evident log must not become the flooding amplifier.
+	if limit := s.signRate(); limit > 0 && !s.rateLimiter.Allow(caller, limit) {
+		w.Header().Set("Retry-After", strconv.Itoa(signer.RetryAfter(limit)))
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 		return
 	}
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -109,6 +109,7 @@ scoped certificate.
 | `401 Unauthorized` | Missing or invalid mTLS client certificate. |
 | `403 Forbidden` | Host not in caller's allowed groups (RBAC); or policy denied (sudo not allowed, PTY not allowed, invalid `sudo_user`, `shell`/`pty` session requested on a host with `command_policy`, `role: "bastion"` requested for a host with a `command_policy`, `on_behalf_of` from a non-trusted forwarder, etc.). Note: a `ttl_seconds` above the host cap is silently clamped to the cap, not rejected. |
 | `405 Method Not Allowed` | Request method is not `POST`. |
+| `429 Too Many Requests` | Per-CN rate limit exceeded (`sign_rate_limit_per_min` > 0). Keyed on the authenticated mTLS CN, checked before the body is parsed; carries a `Retry-After` header (seconds). Not audited per rejection by design. |
 
 **Approval-required response (200 OK, no certificate):** when the command matches
 `command_policy.require_approval` and `approved` is not set (or not from a trusted

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.25.0] - 2026-07-02
+
+### Security
+- The signer enforces an optional per-CN rate limit on `POST /v1/sign`
+  (`sign_rate_limit_per_min`, hot-reloadable), closing threat-model gap #4 on
+  opt-in: a token bucket keyed on the authenticated mTLS peer CN — not
+  `on_behalf_of` — checked before body parsing. Excess requests get `429` with
+  a `Retry-After` hint; rejections are deliberately not audited so the
+  tamper-evident log cannot become the flooding amplifier. 0/absent = disabled
+  (backward compatible).
+
 ## [v1.24.0] - 2026-07-02
 
 ### Security

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -127,7 +127,10 @@ política, transporte, auditoría, CLI y documentación generada.
 ### Alta prioridad
 - [ ] **Clave CA en HSM/KMS** para PEM local (AKV ya soportado, v1.11.0). Punto
   de extensión listo: `ca.LoadCAFromPEM` → `ssh.NewSignerFromSigner(kmsClient)`.
-- [ ] **Rate limiting por CN de broker** en el signer (gap #4 del threat model).
+- [x] **Rate limiting por CN de broker** en el signer (v1.25.0, gap #4): token
+  bucket por CN mTLS en `POST /v1/sign` (`sign_rate_limit_per_min`, hot-reload),
+  429 + Retry-After, comprobado antes de parsear el body y sin auditar cada
+  rechazo (el log no debe ser el amplificador del flooding).
 - [x] **Command firewall en sesiones exec** vía dry-run por comando: `mode=exec`
   preflighted por `ssh_session_exec`; el preflight lleva `session_mode`, comando,
   sudo/sudo_user y PTY, y revalida tanto el target como cada bastion de la cadena.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -186,11 +186,15 @@ window is usable until it expires; there is no way to cut it short.
 - **Roadmap:** a `/v1/revoke` endpoint generating an OpenSSH KRL by serial, plus
   `RevokedKeys` in sshd. Tracked in [HANDOFF.md](https://github.com/luisgf/ssh-broker/blob/main/docs/HANDOFF.md).
 
-### 4. No rate limiting on the signer itself
-The only rate limit lives in the control plane (optional, and its subject is
-broker-asserted). The signer — the component that must not be DoS'd — has request
-body/timeout limits but no per-CN request-rate cap.
-- **Roadmap:** per-broker-CN rate limiting in the signer.
+### 4. Rate limiting on the signer is opt-in
+The signer supports a per-CN token-bucket rate limit on `POST /v1/sign`
+(`sign_rate_limit_per_min`, hot-reloadable): keyed on the authenticated mTLS
+peer CN, enforced before body parsing, excess requests get `429` with a
+`Retry-After` hint, and rejections are deliberately not audited so the
+tamper-evident log cannot become the flooding amplifier. The residual gap is
+that the cap is opt-in (0/absent = disabled, backward compatible) — set it in
+production. The control plane additionally applies its own per-subject
+behavioral rate limit on the forwarded path.
 
 ### 5. In-memory state → single instance
 Sessions, approvals, and behavior baselines live in process memory. Running

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -107,6 +107,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `audit_key` | `string` |  |
 | `max_ttl_seconds` | `int` | MaxTTLSeconds: global cap when the host policy does not set one. |
 | `auto_reload_seconds` | `int` | AutoReloadSeconds: if > 0, the signer polls signer.json's mtime every N seconds and hot-reloads on change — same validated, atomic path as SIGHUP / POST /v1/reload, so a transiently-invalid in-progress save is rejected and the previous good state is kept. 0 or absent = disabled (default). |
+| `sign_rate_limit_per_min` | `int` | SignRateLimitPerMin caps POST /v1/sign requests per authenticated client CN per minute (token bucket: burst up to the cap, continuous refill). Keyed on the mTLS peer CN — not on_behalf_of — and enforced before body parsing; excess requests get 429 with a Retry-After hint. Hot-reloadable. 0 or absent = disabled (backward compatible). |
 | `max_grant_ttl_seconds` | `int` | MaxGrantTTLSeconds: optional upper bound on a runtime grant's TTL (POST /v1/policy/hosts/{host}/grants). 0 or absent = no cap. |
 | `reload_callers` | `[]string` | ReloadCallers: client cert CNs authorised to invoke POST /v1/reload. Empty = HTTP endpoint disabled (403); SIGHUP still works locally. |
 | `trusted_forwarders` | `[]string` | TrustedForwarders: client cert CNs authorised to act on behalf of another broker (on_behalf_of field / X-On-Behalf-Of header). This is the control plane CN. Only these CNs may impersonate a broker for RBAC; any other CN sending on_behalf_of is rejected. |

--- a/internal/signer/ratelimit.go
+++ b/internal/signer/ratelimit.go
@@ -1,0 +1,94 @@
+package signer
+
+import (
+	"sync"
+	"time"
+)
+
+// maxRateLimitKeys bounds the bucket map. Keys are authenticated mTLS CNs, so
+// cardinality is naturally bounded by the client certificates the operator has
+// issued; the bound is a backstop against pathological CN churn, mirroring the
+// control plane's max_subjects guardrail.
+const maxRateLimitKeys = 4096
+
+// rateBucket is one token bucket. Tokens refill continuously at limit/60 per
+// second up to the limit (burst = one minute's budget); each allowed request
+// consumes one token.
+type rateBucket struct {
+	tokens float64
+	last   time.Time
+}
+
+// RateLimiter enforces a per-key token-bucket rate limit. The limit is passed
+// on every Allow call rather than stored, so a hot-reloaded config value takes
+// effect immediately without touching the limiter. The zero limit disables the
+// check. Safe for concurrent use.
+type RateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*rateBucket
+	now     func() time.Time // test seam
+}
+
+// NewRateLimiter creates an empty limiter.
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{buckets: make(map[string]*rateBucket), now: time.Now}
+}
+
+// Allow reports whether one request by key fits within perMin requests per
+// minute, consuming a token when it does. perMin <= 0 disables the limit
+// (always allowed).
+func (l *RateLimiter) Allow(key string, perMin int) bool {
+	if perMin <= 0 {
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	b, ok := l.buckets[key]
+	if !ok {
+		if len(l.buckets) >= maxRateLimitKeys {
+			l.prune(now)
+		}
+		b = &rateBucket{tokens: float64(perMin), last: now}
+		l.buckets[key] = b
+	}
+	capacity := float64(perMin)
+	b.tokens += now.Sub(b.last).Seconds() * capacity / 60
+	if b.tokens > capacity {
+		b.tokens = capacity
+	}
+	b.last = now
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// RetryAfter returns a conservative client hint, in whole seconds, for when
+// the next token becomes available at perMin requests per minute.
+func RetryAfter(perMin int) int {
+	if perMin <= 0 {
+		return 0
+	}
+	secs := 60 / perMin
+	if 60%perMin != 0 {
+		secs++
+	}
+	if secs < 1 {
+		secs = 1
+	}
+	return secs
+}
+
+// prune drops buckets idle long enough to be full again (they carry no state a
+// fresh bucket would not have). Called with l.mu held, only when the map is at
+// its bound; if every entry is active the map simply stays at the bound and
+// new keys are still admitted.
+func (l *RateLimiter) prune(now time.Time) {
+	for k, b := range l.buckets {
+		if now.Sub(b.last) > time.Minute {
+			delete(l.buckets, k)
+		}
+	}
+}

--- a/internal/signer/ratelimit_test.go
+++ b/internal/signer/ratelimit_test.go
@@ -1,0 +1,133 @@
+package signer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// fakeClock returns a limiter whose clock the test controls.
+func fakeClock(l *RateLimiter) *time.Time {
+	now := time.Unix(1_700_000_000, 0)
+	l.now = func() time.Time { return now }
+	return &now
+}
+
+func TestRateLimiterDisabled(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	for i := 0; i < 1000; i++ {
+		if !l.Allow("cn", 0) {
+			t.Fatal("perMin=0 must always allow")
+		}
+	}
+}
+
+func TestRateLimiterBurstThenDeny(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	fakeClock(l)
+	for i := 0; i < 5; i++ {
+		if !l.Allow("cn", 5) {
+			t.Fatalf("request %d within the burst must be allowed", i+1)
+		}
+	}
+	if l.Allow("cn", 5) {
+		t.Error("request beyond the burst must be denied")
+	}
+}
+
+func TestRateLimiterRefill(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	now := fakeClock(l)
+	for i := 0; i < 5; i++ {
+		l.Allow("cn", 5)
+	}
+	if l.Allow("cn", 5) {
+		t.Fatal("bucket must be empty")
+	}
+	*now = now.Add(12 * time.Second) // 5/min → one token per 12 s
+	if !l.Allow("cn", 5) {
+		t.Error("one token must have refilled after 12 s")
+	}
+	if l.Allow("cn", 5) {
+		t.Error("only one token must have refilled")
+	}
+}
+
+func TestRateLimiterRefillCapped(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	now := fakeClock(l)
+	l.Allow("cn", 5)
+	*now = now.Add(time.Hour)
+	for i := 0; i < 5; i++ {
+		if !l.Allow("cn", 5) {
+			t.Fatalf("refill must cap at the burst, request %d denied", i+1)
+		}
+	}
+	if l.Allow("cn", 5) {
+		t.Error("refill must not exceed the one-minute budget")
+	}
+}
+
+func TestRateLimiterPerKeyIsolation(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	fakeClock(l)
+	for i := 0; i < 5; i++ {
+		l.Allow("cn-a", 5)
+	}
+	if l.Allow("cn-a", 5) {
+		t.Fatal("cn-a must be exhausted")
+	}
+	if !l.Allow("cn-b", 5) {
+		t.Error("cn-b must have its own bucket")
+	}
+}
+
+func TestRateLimiterHotReloadedLimit(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	fakeClock(l)
+	for i := 0; i < 5; i++ {
+		l.Allow("cn", 5)
+	}
+	if l.Allow("cn", 5) {
+		t.Fatal("bucket must be exhausted at limit 5")
+	}
+	// A raised limit takes effect on the next call without resetting state:
+	// refill happens at the new rate against the same bucket.
+	if l.Allow("cn", 6) {
+		t.Error("raising the limit must not mint tokens retroactively")
+	}
+}
+
+func TestRateLimiterPruneBound(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	now := fakeClock(l)
+	for i := 0; i < maxRateLimitKeys; i++ {
+		l.Allow(fmt.Sprintf("cn-%d", i), 5)
+	}
+	if len(l.buckets) != maxRateLimitKeys {
+		t.Fatalf("expected %d buckets, got %d", maxRateLimitKeys, len(l.buckets))
+	}
+	*now = now.Add(2 * time.Minute) // all idle → prunable
+	l.Allow("cn-new", 5)
+	if len(l.buckets) != 1 {
+		t.Errorf("idle buckets must be pruned at the bound, got %d", len(l.buckets))
+	}
+}
+
+func TestRetryAfter(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ perMin, want int }{
+		{0, 0}, {5, 12}, {7, 9}, {60, 1}, {600, 1},
+	} {
+		if got := RetryAfter(tc.perMin); got != tc.want {
+			t.Errorf("RetryAfter(%d) = %d, want %d", tc.perMin, got, tc.want)
+		}
+	}
+}

--- a/signer.example.json
+++ b/signer.example.json
@@ -34,6 +34,9 @@
   "_auto_reload_comment": "Optional: if > 0, the signer polls this file's mtime every N seconds and hot-reloads on change (same validated, atomic path as SIGHUP / POST /v1/reload — a half-written file mid-save is rejected and the previous good state kept). 0 or absent = disabled. Convenient with GitOps or hand edits; pair with restrictive file permissions since any writer of this file then changes policy.",
   "auto_reload_seconds": 0,
 
+  "_sign_rate_limit_comment": "Optional per-CN rate limit on POST /v1/sign (threat-model gap #4): token bucket keyed on the authenticated mTLS peer CN — burst up to the cap, continuous refill — checked before the request body is parsed. Excess requests get 429 with a Retry-After hint; rejections are deliberately NOT written to the audit log (the log must not become the flooding amplifier). Hot-reloadable. 0 or absent = disabled. Recommended in production; size it to your busiest legitimate broker (each ssh_execute is one sign call, each ssh_session_exec one preflight call).",
+  "sign_rate_limit_per_min": 120,
+
   "_max_grant_ttl_comment": "Optional upper bound (seconds) on a runtime grant's TTL. Applies to BOTH widen-only grants (POST /v1/policy/hosts/{host}/grants, 'broker-ctl policy grant' — a longer request is rejected 400) AND approve-and-learn approval waivers ('broker-ctl approval allow <id> --learn --ttl' — a longer request is CLAMPED to this cap, never rejected, since the certificate was already issued). 0 or absent = no cap. Grants/waivers are in-memory (lost on restart, kept across reloads); grants are operator-only (reload_callers), waivers are minted only from a trusted_forwarder after an approval and scoped to the approved broker/end-user subject.",
   "max_grant_ttl_seconds": 0,
 


### PR DESCRIPTION
Closes #22 — threat-model gap #4 (no rate limiting on the signer itself).

## What

- `internal/signer/ratelimit.go`: per-key token bucket (`RateLimiter.Allow(key, perMin)`) — burst up to the cap, continuous refill, limit passed per call so a hot-reloaded value applies instantly, bucket map bounded at 4096 keys with idle pruning.
- `cmd/signer`: new `sign_rate_limit_per_min` config key (hot-reloadable, 0/absent = disabled). `handleSign` checks it right after mTLS authentication and **before body parsing**, keyed on the peer CN (not `on_behalf_of`). Excess → `429` + `Retry-After`.
- No audit entry per rejection by design: the tamper-evident log must not become the flooding amplifier.

## Docs

THREAT_MODEL gap #4 rewritten (residual: the cap is opt-in), API.md 429 row on `/v1/sign`, `signer.example.json` ships `sign_rate_limit_per_min: 120` with sizing guidance, HANDOFF checkbox, CHANGELOG v1.25.0, regenerated `docs/reference/config.md`.

## Tests

Limiter: burst/deny, refill timing, refill cap, per-key isolation, hot-reload semantics, prune bound, Retry-After. Handler: 429 + Retry-After beyond budget, per-CN isolation, limit 0 disabled. `gofmt`/`go vet`/`go test -race ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)