### PR TITLE
feat: /healthz and /metrics monitoring listener on every service

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -14,6 +15,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/auth"
 	"github.com/luisgf/ssh-broker/internal/broker"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
+	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
 
@@ -56,6 +58,9 @@ func main() {
 		log.Fatalf("initialising broker: %v", err)
 	}
 	defer eng.Close()
+
+	// Optional monitoring listener (/healthz, /metrics); lives with the process.
+	go monitor.Serve(context.Background(), cfg.MonitorListen, "broker")
 
 	tlsCfg, err := auth.ServerTLSConfig(cfg.ServerCert, cfg.ServerKey, cfg.ClientCA)
 	if err != nil {

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/json"
 	"flag"
@@ -34,6 +35,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/confcheck"
 	"github.com/luisgf/ssh-broker/internal/control"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
+	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/signer"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
@@ -92,6 +94,11 @@ type Config struct {
 	// Audit log for the control plane (independent of broker and signer).
 	AuditLog string `json:"audit_log"`
 	AuditKey string `json:"audit_key"`
+
+	// MonitorListen: optional plain-HTTP monitoring listener serving /healthz
+	// (liveness) and /metrics (Prometheus text format). No authentication —
+	// bind to localhost or a private scrape interface. Empty = disabled.
+	MonitorListen string `json:"monitor_listen,omitempty"`
 }
 
 type server struct {
@@ -211,6 +218,21 @@ func main() {
 	mux.HandleFunc("GET /v1/sign/result/{id}", srv.handleResult)
 	mux.HandleFunc("GET /v1/approvals", srv.handleApprovalsList)
 	mux.HandleFunc("POST /v1/approvals/{id}", srv.handleApprovalDecide)
+
+	// Optional monitoring listener (/healthz, /metrics). Plain HTTP on its own
+	// address; lives for the whole process, so no ctx wiring. The pending gauge
+	// is read at scrape time from the in-memory approval registry.
+	monitor.SetGaugeFunc("controlplane_approvals_pending",
+		"Approval requests currently pending a human decision.", func() float64 {
+			n := 0
+			for _, a := range srv.registry.List() {
+				if a.Status == control.StatusPending {
+					n++
+				}
+			}
+			return float64(n)
+		})
+	go monitor.Serve(context.Background(), cfg.MonitorListen, "control-plane")
 
 	httpSrv := &http.Server{
 		Addr:         cfg.Listen,
@@ -594,7 +616,14 @@ func (s *server) isApprover(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
+// eventsTotal counts every control-plane audit event by outcome (forwarded,
+// denied, anomaly, rate-limited, approval-*, error). Fed by auditE, the single
+// audit funnel.
+var eventsTotal = monitor.GetCounterVec("controlplane_events_total",
+	"Control-plane audit events by outcome.", "outcome")
+
 func (s *server) auditE(e audit.Entry) {
+	eventsTotal.With(e.Outcome).Inc()
 	if err := s.audit.Append(e); err != nil {
 		log.Printf("warning: error writing control plane audit log: %v", err)
 	}

--- a/cmd/mcp-broker-http/main.go
+++ b/cmd/mcp-broker-http/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/broker"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
 	"github.com/luisgf/ssh-broker/internal/mcpserver"
+	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/oauth"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
@@ -70,6 +71,9 @@ func main() {
 		log.Fatalf("initialising broker: %v", err)
 	}
 	defer eng.Close()
+
+	// Optional monitoring listener (/healthz, /metrics); lives with the process.
+	go monitor.Serve(context.Background(), cfg.MonitorListen, "mcp-broker-http")
 
 	mux, err := newMux(context.Background(), eng, cfg)
 	if err != nil {

--- a/cmd/mcp-broker/main.go
+++ b/cmd/mcp-broker/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/luisgf/ssh-broker/internal/broker"
 	"github.com/luisgf/ssh-broker/internal/mcpserver"
+	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
 
@@ -52,6 +53,9 @@ func main() {
 		log.Fatalf("initialising broker: %v", err)
 	}
 	defer eng.Close()
+
+	// Optional monitoring listener (/healthz, /metrics); lives with the process.
+	go monitor.Serve(context.Background(), cfg.MonitorListen, "mcp-broker")
 
 	srv := mcpserver.New(eng, stdioCaller)
 

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/ca"
 	"github.com/luisgf/ssh-broker/internal/confcheck"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
+	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/signer"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
@@ -69,6 +70,11 @@ type Config struct {
 	// parsing; excess requests get 429 with a Retry-After hint. Hot-reloadable.
 	// 0 or absent = disabled (backward compatible).
 	SignRateLimitPerMin int `json:"sign_rate_limit_per_min,omitempty"`
+
+	// MonitorListen: optional plain-HTTP monitoring listener serving /healthz
+	// (liveness) and /metrics (Prometheus text format). No authentication —
+	// bind to localhost or a private scrape interface. Empty = disabled.
+	MonitorListen string `json:"monitor_listen,omitempty"`
 
 	// MaxGrantTTLSeconds: optional upper bound on a runtime grant's TTL
 	// (POST /v1/policy/hosts/{host}/grants). 0 or absent = no cap.
@@ -198,6 +204,10 @@ func main() {
 	if cfg.AutoReloadSeconds > 0 {
 		go watchConfig(*cfgPath, time.Duration(cfg.AutoReloadSeconds)*time.Second, srv)
 	}
+
+	// Optional monitoring listener (/healthz, /metrics). Plain HTTP on its own
+	// address; lives for the whole process (dies with it), so no ctx wiring.
+	go monitor.Serve(context.Background(), cfg.MonitorListen, "signer")
 
 	// Periodically drop expired runtime grants/waivers so they do not linger in
 	// memory until the next list call (they are also filtered out at decision time).
@@ -399,6 +409,7 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// as little as possible. Deliberately NOT audited per rejection: the
 	// tamper-evident log must not become the flooding amplifier.
 	if limit := s.signRate(); limit > 0 && !s.rateLimiter.Allow(caller, limit) {
+		signRequestsTotal.With("rate-limited").Inc()
 		w.Header().Set("Retry-After", strconv.Itoa(signer.RetryAfter(limit)))
 		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 		return
@@ -646,7 +657,14 @@ func (s *server) auditReload(caller string, hosts int, outcome string, err error
 	}
 }
 
+// signRequestsTotal counts /v1/sign requests by outcome. Fed by auditEmission
+// (the single audit funnel) plus the rate-limit rejection, which is counted
+// here but deliberately not audited.
+var signRequestsTotal = monitor.GetCounterVec("signer_sign_requests_total",
+	"POST /v1/sign requests by outcome.", "outcome")
+
 func (s *server) auditEmission(caller string, req signer.WireRequest, hosts signer.PolicyTable, serial uint64, outcome string, dec *signer.DecisionInfo, err error) {
+	signRequestsTotal.With(outcome).Inc()
 	cmd := "role=" + req.Role + " purpose=" + req.Purpose
 	if req.SessionMode != "" {
 		cmd += " session_mode=" + req.SessionMode

--- a/config.example.json
+++ b/config.example.json
@@ -27,6 +27,9 @@
   "_recording_comment": "Optional session recording. When set, shell and pty sessions are recorded to ASCIIcast v2 files in this directory. One file per session: <session_id>.cast. Files are playable with 'asciinema play'. Correlate with audit log via session_id. Empty or absent = recording disabled.",
   "session_recording_dir": "",
 
+  "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format), started by every frontend (broker, mcp-broker, mcp-broker-http). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: broker_events_total{outcome}, broker_sessions_active, audit_append_failures_total.",
+  "monitor_listen": "127.0.0.1:9180",
+
   "listen": ":8443",
   "server_cert": "pki/broker.crt",
   "server_key": "pki/broker.key",

--- a/control-plane.example.json
+++ b/control-plane.example.json
@@ -39,5 +39,8 @@
   "trusted_forwarders": [],
 
   "audit_log": "control_plane_audit.log",
-  "audit_key": "pki/control_plane_audit.seed"
+  "audit_key": "pki/control_plane_audit.seed",
+
+  "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: controlplane_events_total{outcome}, controlplane_approvals_pending, audit_append_failures_total.",
+  "monitor_listen": "127.0.0.1:9170"
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,7 @@ request/response schema changes.
 - [MCP HTTP API](#mcp-http-api) — `cmd/mcp-broker-http` · HTTPS + OAuth2/OIDC · default `:8443`
   - [GET /.well-known/oauth-protected-resource](#get-well-knownoauth-protected-resource)
   - [MCP Streamable HTTP — tools](#mcp-streamable-http--tools)
+- [Monitoring endpoints](#monitoring-endpoints) — every service · plain HTTP · `monitor_listen`
 
 ---
 
@@ -854,6 +855,24 @@ after `session_idle_seconds` or `session_max_seconds` (configured in
 `shell` and `pty` sessions are recorded to ASCIIcast v2 files in that directory.
 Each file is named `<session_id>.cast` and contains stdin, stdout, and stderr
 events with millisecond timestamps. See USAGE.md §8 for details.
+
+---
+
+## Monitoring endpoints
+
+Every service accepts an optional `monitor_listen` config key that starts a
+**separate plain-HTTP listener** (no TLS, no authentication — bind to
+localhost or a private scrape interface):
+
+| Route | Purpose |
+|---|---|
+| `GET /healthz` | Liveness. `200` with body `ok` while the process serves. |
+| `GET /metrics` | Prometheus text exposition format. |
+
+The broker `monitor_listen` key applies to all three broker frontends
+(`broker`, `mcp-broker`, `mcp-broker-http`). See
+[OPERATIONS.md §7](OPERATIONS.md#7-monitoring) for the metric inventory and
+alerting guidance (`audit_append_failures_total` in particular).
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v1.26.0] - 2026-07-02
+
+### Added
+- Every service accepts an optional `monitor_listen` config key that starts a
+  separate plain-HTTP listener with `/healthz` (liveness) and `/metrics`
+  (Prometheus text exposition format, no new dependencies). The broker key
+  covers all three broker frontends.
+- Initial metric inventory, fed from the existing audit funnels:
+  `signer_sign_requests_total{outcome}` (including the un-audited
+  `rate-limited` outcome), `controlplane_events_total{outcome}`,
+  `controlplane_approvals_pending`, `broker_events_total{outcome}`,
+  `broker_sessions_active`, and `audit_append_failures_total` — the
+  machine-readable signal for threat-model gap #9 (audit is fail-open); alert
+  on any increase.
+
 ## [v1.25.0] - 2026-07-02
 
 ### Security

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -145,7 +145,9 @@ política, transporte, auditoría, CLI y documentación generada.
   guardan verbatim (un `mysql -psecret` queda en texto plano). Lista de patrones
   de enmascarado configurable (gap #8 del threat model).
 - [ ] **Audit fail-closed (opcional)**: hoy si falla el `Append` la operación
-  continúa; toggle para bloquear emisión/ejecución sin traza (gap #9).
+  continúa; toggle para bloquear emisión/ejecución sin traza (gap #9). Desde
+  v1.26.0 el fallo es observable: contador `audit_append_failures_total` en
+  `/metrics` (`monitor_listen`) — alertar sobre cualquier incremento.
 - [ ] **Logs a almacenamiento WORM** (S3/GCS/Loki/SIEM).
 - [ ] **Sesiones/aprobaciones multi-instancia**: externalizar estado a Redis (gap #5).
 - [x] **`default_deny` en `callers`** (v1.24.0): entrada reservada `"_default"` en

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -14,6 +14,7 @@ for the security posture see [THREAT_MODEL.md](THREAT_MODEL.md).
 4. [broker-ctl](#4-broker-ctl)
 5. [Local PKI](#5-local-pki)
 6. [Reference config files](#6-reference-config-files)
+7. [Monitoring](#7-monitoring)
 
 ---
 
@@ -537,3 +538,41 @@ it must be revoked before expiry.
    (e.g. `sign_caller` instead of `sign_callers`) is rejected at startup/reload
    rather than silently ignored, so a typo cannot quietly leave a setting open.
    `_*` comment keys and the reserved `_default` group are still accepted.
+
+---
+
+## 7. Monitoring
+
+Every service accepts an optional `monitor_listen` config key (empty or absent
+= disabled) that starts a **separate plain-HTTP listener** with two endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `/healthz` | Liveness: `200 ok` while the process is serving. Use it for load-balancer/systemd/container health checks. |
+| `/metrics` | Metrics in the Prometheus text exposition format. |
+
+The broker config key covers all three broker frontends (`broker`,
+`mcp-broker`, `mcp-broker-http`); the signer and control plane have their own
+key in `signer.json` / `control-plane.json`.
+
+> **Security:** the listener has **no authentication and no TLS**. Bind it to
+> `127.0.0.1` or a private scrape interface, never a public address. It is
+> deliberately a separate listener so the mTLS/OAuth service ports stay clean.
+
+### Metrics
+
+| Metric | Service | Meaning |
+|---|---|---|
+| `signer_sign_requests_total{outcome}` | signer | `POST /v1/sign` requests by audit outcome (`issued`, `denied`, `approval-required`, `dry_run_*`, …) plus `rate-limited`, which is counted here but deliberately **not** audited. |
+| `controlplane_events_total{outcome}` | control plane | Audit events by outcome (`forwarded`, `denied`, `anomaly`, `rate-limited`, `approval-*`, `error`). |
+| `controlplane_approvals_pending` | control plane | Approval requests currently awaiting a human decision (gauge, read at scrape time). |
+| `broker_events_total{outcome}` | broker frontends | Audit events by outcome (`executed`, `denied`, `session_open`, `session_exec`, `session_close`, `error`, …). |
+| `broker_sessions_active` | broker frontends | Persistent SSH sessions currently open (gauge). |
+| `audit_append_failures_total` | all | Audit-log `Append` errors. **Alert on any increase**: the operation continues by design (threat-model gap #9), so this counter is the only machine-readable signal that the audit trail has a gap. |
+
+Example scrape check:
+
+```bash
+curl -s http://127.0.0.1:9160/healthz
+curl -s http://127.0.0.1:9160/metrics | grep signer_sign_requests_total
+```

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -243,8 +243,11 @@ but the operation **still proceeds** — issuance and execution are not blocked.
 This favors availability over a hard guarantee that every action is recorded. A
 compliance deployment that requires "no audit, no action" would need a
 fail-closed toggle (not yet implemented).
-- **Mitigation today:** monitor the process log for `error writing audit log`
-  warnings and alert on audit-write failures; keep the audit volume healthy.
+- **Mitigation today:** every service exposes the
+  `audit_append_failures_total` counter on its `monitor_listen` endpoint
+  (`/metrics`) — alert on any increase; it is the machine-readable signal that
+  the trail has a gap. The process log also carries `error writing audit log`
+  warnings. Keep the audit volume healthy.
 
 ### 10. Out of scope entirely
 - Confidentiality of command **output** beyond transport TLS (the model sees it

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -28,6 +28,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `hosts` | `map[string]HostConfig` | Hosts: used only in local mode (single-binary). In remote mode the host list is fetched from the signer via /v1/hosts and refreshed periodically. |
 | `command_policies` | `map[string]signer.CommandPolicy` | CommandPolicies (local mode) is a named library of command policies, attachable to groups. GroupCommandPolicies maps a group name to the policy names that apply to its hosts; the reserved group "_default" applies to every host. A host's effective firewall is the composition of its inline command_policy and the policies of all its groups (additive union; deny wins). |
 | `group_command_policies` | `map[string][]string` |  |
+| `monitor_listen` | `string` | MonitorListen: optional plain-HTTP monitoring listener serving /healthz (liveness) and /metrics (Prometheus text format), started by every frontend (broker, mcp-broker, mcp-broker-http). No authentication — bind to localhost or a private scrape interface. Empty = disabled. |
 | `oauth` | `*OAuthConfig` | OAuth and ResourceURL are used only by the HTTP+OAuth frontend (cmd/mcp-broker-http); other frontends ignore them. |
 | `resource_url` | `string` | ResourceURL is the canonical URL of this MCP server, used in the Protected Resource Metadata document (RFC 9728) and the WWW-Authenticate header. |
 
@@ -108,6 +109,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `max_ttl_seconds` | `int` | MaxTTLSeconds: global cap when the host policy does not set one. |
 | `auto_reload_seconds` | `int` | AutoReloadSeconds: if > 0, the signer polls signer.json's mtime every N seconds and hot-reloads on change — same validated, atomic path as SIGHUP / POST /v1/reload, so a transiently-invalid in-progress save is rejected and the previous good state is kept. 0 or absent = disabled (default). |
 | `sign_rate_limit_per_min` | `int` | SignRateLimitPerMin caps POST /v1/sign requests per authenticated client CN per minute (token bucket: burst up to the cap, continuous refill). Keyed on the mTLS peer CN — not on_behalf_of — and enforced before body parsing; excess requests get 429 with a Retry-After hint. Hot-reloadable. 0 or absent = disabled (backward compatible). |
+| `monitor_listen` | `string` | MonitorListen: optional plain-HTTP monitoring listener serving /healthz (liveness) and /metrics (Prometheus text format). No authentication — bind to localhost or a private scrape interface. Empty = disabled. |
 | `max_grant_ttl_seconds` | `int` | MaxGrantTTLSeconds: optional upper bound on a runtime grant's TTL (POST /v1/policy/hosts/{host}/grants). 0 or absent = no cap. |
 | `reload_callers` | `[]string` | ReloadCallers: client cert CNs authorised to invoke POST /v1/reload. Empty = HTTP endpoint disabled (403); SIGHUP still works locally. |
 | `trusted_forwarders` | `[]string` | TrustedForwarders: client cert CNs authorised to act on behalf of another broker (on_behalf_of field / X-On-Behalf-Of header). This is the control plane CN. Only these CNs may impersonate a broker for RBAC; any other CN sending on_behalf_of is rejected. |
@@ -143,6 +145,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `trusted_forwarders` | `[]string` | TrustedForwarders: broker client cert CNs whose end_user claim is trusted (brokers that authenticate end users, e.g. via OIDC). Mirrors the signer's trusted_forwarders semantics. Behaviour guardrails key on "<broker CN>:<end_user>" only for these CNs; for any other CN the client-supplied end_user is ignored and the authenticated broker CN alone is used, so a client cannot evade rate limits or anomaly detection by rotating end_user. Empty/absent = end_user never qualifies the subject. |
 | `audit_log` | `string` | Audit log for the control plane (independent of broker and signer). |
 | `audit_key` | `string` |  |
+| `monitor_listen` | `string` | MonitorListen: optional plain-HTTP monitoring listener serving /healthz (liveness) and /metrics (Prometheus text format). No authentication — bind to localhost or a private scrape interface. Empty = disabled. |
 
 ## Control-plane behaviour guardrails (`behavior`)
 

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/luisgf/ssh-broker/internal/monitor"
 )
 
 // logFile is the subset of *os.File that Log needs. It is an interface so tests
@@ -238,9 +240,23 @@ func (l *Log) ensureOpen() error {
 	return nil
 }
 
+// appendFailures counts Append errors across every log this process holds, so
+// operators can alert on audit-trail gaps (the call sites only log a warning —
+// the operation deliberately continues).
+var appendFailures = monitor.GetCounter("audit_append_failures_total",
+	"Audit log Append errors (the operation continues; the trail has a gap).")
+
 // Append signs and writes an entry. It computes prev_hash/seq and signs over
 // the canonical content (with the Sig field empty).
 func (l *Log) Append(e Entry) error {
+	err := l.doAppend(e)
+	if err != nil {
+		appendFailures.Inc()
+	}
+	return err
+}
+
+func (l *Log) doAppend(e Entry) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -22,6 +22,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/auth"
 	"github.com/luisgf/ssh-broker/internal/ca"
 	"github.com/luisgf/ssh-broker/internal/confcheck"
+	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/signer"
 	sshrun "github.com/luisgf/ssh-broker/internal/ssh"
 )
@@ -95,6 +96,12 @@ type Config struct {
 	// command_policy and the policies of all its groups (additive union; deny wins).
 	CommandPolicies      map[string]signer.CommandPolicy `json:"command_policies,omitempty"`
 	GroupCommandPolicies map[string][]string             `json:"group_command_policies,omitempty"`
+
+	// MonitorListen: optional plain-HTTP monitoring listener serving /healthz
+	// (liveness) and /metrics (Prometheus text format), started by every
+	// frontend (broker, mcp-broker, mcp-broker-http). No authentication — bind
+	// to localhost or a private scrape interface. Empty = disabled.
+	MonitorListen string `json:"monitor_listen,omitempty"`
 
 	// OAuth and ResourceURL are used only by the HTTP+OAuth frontend
 	// (cmd/mcp-broker-http); other frontends ignore them.
@@ -315,6 +322,11 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		e.auditE(audit.Entry{Caller: s.caller, Host: s.host, Serial: s.serial,
 			SessionID: s.id, Outcome: "session_close", Err: "reaped (idle/lifetime)"})
 	})
+	// Scrape-time gauge over the live session map. SetGaugeFunc replaces any
+	// previous registration, so a rebuilt engine (tests, restarts of the
+	// embedding frontend) simply rebinds the gauge to itself.
+	monitor.SetGaugeFunc("broker_sessions_active",
+		"Persistent SSH sessions currently open.", e.sessions.count)
 
 	// Remote mode: initial host load and start the refresh goroutine.
 	if fetcher != nil {
@@ -908,7 +920,14 @@ func (e *Engine) Close() error {
 	return e.closeErr
 }
 
+// eventsTotal counts every broker audit event by outcome (executed, denied,
+// error, session_open, session_exec, session_close, …). Fed by auditE, the
+// single audit funnel.
+var eventsTotal = monitor.GetCounterVec("broker_events_total",
+	"Broker audit events by outcome.", "outcome")
+
 func (e *Engine) auditE(ent audit.Entry) {
+	eventsTotal.With(ent.Outcome).Inc()
 	if hi, ok := e.hostInfo(ent.Host); ok {
 		if ent.User == "" {
 			ent.User = hi.User

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -107,6 +107,13 @@ func newSessionManager(idle, maxLife time.Duration, onReap func(*liveSession)) *
 	return m
 }
 
+// count returns the number of live sessions, for the monitoring gauge.
+func (m *sessionManager) count() float64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return float64(len(m.sessions))
+}
+
 func (m *sessionManager) reaper() {
 	t := time.NewTicker(30 * time.Second)
 	defer t.Stop()

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,214 @@
+// Package monitor provides a minimal process-wide metrics registry and the
+// plain-HTTP /healthz + /metrics listener the services expose when
+// monitor_listen is configured. Metrics are exposed in the Prometheus text
+// exposition format without external dependencies.
+//
+// The registry is package-level (like expvar): any package increments its
+// counters directly and the binary decides whether to serve them. Registration
+// is get-or-create by name, so instrumented code paths are safe to construct
+// repeatedly (e.g. in tests); a GaugeFunc re-registration replaces the
+// callback, so a rebuilt component (broker engine, approval registry) simply
+// rebinds its gauge.
+//
+// The listener speaks plain HTTP and has no authentication: bind it to
+// localhost or a private scrape interface, never to a public address.
+package monitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Counter is a monotonically increasing metric.
+type Counter struct {
+	v atomic.Int64
+}
+
+// Inc adds one.
+func (c *Counter) Inc() { c.v.Add(1) }
+
+// Add adds n (negative deltas are ignored — counters only go up).
+func (c *Counter) Add(n int64) {
+	if n > 0 {
+		c.v.Add(n)
+	}
+}
+
+// Value returns the current count.
+func (c *Counter) Value() int64 { return c.v.Load() }
+
+// Vec is a family of counters sharing a name and differing in one label value.
+type Vec struct {
+	label string
+	mu    sync.Mutex
+	elems map[string]*Counter
+}
+
+// With returns the counter for the given label value, creating it on first use.
+func (v *Vec) With(value string) *Counter {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	c, ok := v.elems[value]
+	if !ok {
+		c = &Counter{}
+		v.elems[value] = c
+	}
+	return c
+}
+
+type registry struct {
+	mu       sync.Mutex
+	order    []string // names in registration order (exposition sorts anyway)
+	counters map[string]*Counter
+	vecs     map[string]*Vec
+	gauges   map[string]func() float64
+	help     map[string]string
+}
+
+var std = &registry{
+	counters: map[string]*Counter{},
+	vecs:     map[string]*Vec{},
+	gauges:   map[string]func() float64{},
+	help:     map[string]string{},
+}
+
+// GetCounter returns the counter registered under name, creating it if needed.
+func GetCounter(name, help string) *Counter {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	c, ok := std.counters[name]
+	if !ok {
+		c = &Counter{}
+		std.counters[name] = c
+		std.order = append(std.order, name)
+		std.help[name] = help
+	}
+	return c
+}
+
+// GetCounterVec returns the labelled counter family registered under name,
+// creating it if needed. The label name is fixed at first registration.
+func GetCounterVec(name, help, label string) *Vec {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	v, ok := std.vecs[name]
+	if !ok {
+		v = &Vec{label: label, elems: map[string]*Counter{}}
+		std.vecs[name] = v
+		std.order = append(std.order, name)
+		std.help[name] = help
+	}
+	return v
+}
+
+// SetGaugeFunc registers (or replaces) a gauge whose value is read at scrape
+// time. Replacement is deliberate: a rebuilt component rebinds its gauge.
+func SetGaugeFunc(name, help string, f func() float64) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	if _, ok := std.gauges[name]; !ok {
+		std.order = append(std.order, name)
+	}
+	std.gauges[name] = f
+	std.help[name] = help
+}
+
+// escapeLabel makes a label value safe for the text exposition format.
+func escapeLabel(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
+	return r.Replace(s)
+}
+
+// writeMetrics renders the registry in the Prometheus text exposition format,
+// sorted by metric name (and by label value within a family) so the output is
+// deterministic.
+func writeMetrics(w *strings.Builder) {
+	std.mu.Lock()
+	defer std.mu.Unlock()
+	names := make([]string, len(std.order))
+	copy(names, std.order)
+	sort.Strings(names)
+	for _, name := range names {
+		if c, ok := std.counters[name]; ok {
+			fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n%s %d\n", name, std.help[name], name, name, c.Value())
+			continue
+		}
+		if v, ok := std.vecs[name]; ok {
+			fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n", name, std.help[name], name)
+			v.mu.Lock()
+			labels := make([]string, 0, len(v.elems))
+			for lv := range v.elems {
+				labels = append(labels, lv)
+			}
+			sort.Strings(labels)
+			for _, lv := range labels {
+				fmt.Fprintf(w, "%s{%s=\"%s\"} %d\n", name, v.label, escapeLabel(lv), v.elems[lv].Value())
+			}
+			v.mu.Unlock()
+			continue
+		}
+		if f, ok := std.gauges[name]; ok {
+			fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n%s %g\n", name, std.help[name], name, name, f())
+		}
+	}
+}
+
+// Handler serves the /metrics text exposition.
+func Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b strings.Builder
+		writeMetrics(&b)
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		fmt.Fprint(w, b.String())
+	})
+}
+
+// Mux returns the monitoring mux: /healthz (liveness, always 200 while the
+// process serves) and /metrics.
+func Mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintln(w, "ok")
+	})
+	mux.Handle("/metrics", Handler())
+	return mux
+}
+
+// Serve starts the monitoring listener on addr (plain HTTP — bind to localhost
+// or a private interface) and blocks until ctx is cancelled, then shuts down
+// gracefully. An empty addr is a no-op. Serve failures are logged, not fatal:
+// monitoring must never take the service down.
+func Serve(ctx context.Context, addr, name string) {
+	if addr == "" {
+		return
+	}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           Mux(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	errc := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errc <- err
+		}
+	}()
+	log.Printf("%s: monitoring on http://%s (/healthz, /metrics)", name, addr)
+	select {
+	case err := <-errc:
+		log.Printf("%s: monitoring listener failed: %v", name, err)
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}
+}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,74 @@
+package monitor
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCounterAndVec(t *testing.T) {
+	t.Parallel()
+	c := GetCounter("test_counter_total", "help text")
+	c.Inc()
+	c.Add(2)
+	c.Add(-5) // ignored: counters only go up
+	if got := c.Value(); got != 3 {
+		t.Errorf("counter = %d, want 3", got)
+	}
+	if again := GetCounter("test_counter_total", "other"); again != c {
+		t.Error("GetCounter must be get-or-create by name")
+	}
+
+	v := GetCounterVec("test_vec_total", "help", "outcome")
+	v.With("ok").Inc()
+	v.With("ok").Inc()
+	v.With("error").Inc()
+	if got := v.With("ok").Value(); got != 2 {
+		t.Errorf("vec[ok] = %d, want 2", got)
+	}
+}
+
+func TestGaugeFuncReplacement(t *testing.T) {
+	t.Parallel()
+	SetGaugeFunc("test_gauge", "help", func() float64 { return 1 })
+	SetGaugeFunc("test_gauge", "help", func() float64 { return 42 })
+	var b strings.Builder
+	writeMetrics(&b)
+	if !strings.Contains(b.String(), "test_gauge 42") {
+		t.Errorf("re-registered gauge must expose the new callback, got:\n%s", b.String())
+	}
+}
+
+func TestExposition(t *testing.T) {
+	t.Parallel()
+	GetCounter("test_expo_total", "a counter").Inc()
+	GetCounterVec("test_expo_vec_total", "a vec", "outcome").With(`quo"te`).Inc()
+
+	rec := httptest.NewRecorder()
+	Handler().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"# HELP test_expo_total a counter",
+		"# TYPE test_expo_total counter",
+		"test_expo_total 1",
+		"# TYPE test_expo_vec_total counter",
+		`test_expo_vec_total{outcome="quo\"te"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("exposition missing %q, got:\n%s", want, body)
+		}
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("unexpected content type %q", ct)
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	Mux().ServeHTTP(rec, httptest.NewRequest("GET", "/healthz", nil))
+	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "ok") {
+		t.Errorf("healthz = %d %q, want 200 ok", rec.Code, rec.Body.String())
+	}
+}

--- a/signer.example.json
+++ b/signer.example.json
@@ -34,6 +34,9 @@
   "_auto_reload_comment": "Optional: if > 0, the signer polls this file's mtime every N seconds and hot-reloads on change (same validated, atomic path as SIGHUP / POST /v1/reload — a half-written file mid-save is rejected and the previous good state kept). 0 or absent = disabled. Convenient with GitOps or hand edits; pair with restrictive file permissions since any writer of this file then changes policy.",
   "auto_reload_seconds": 0,
 
+  "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: signer_sign_requests_total{outcome} (includes outcome='rate-limited', which is not audited by design), audit_append_failures_total.",
+  "monitor_listen": "127.0.0.1:9160",
+
   "_sign_rate_limit_comment": "Optional per-CN rate limit on POST /v1/sign (threat-model gap #4): token bucket keyed on the authenticated mTLS peer CN — burst up to the cap, continuous refill — checked before the request body is parsed. Excess requests get 429 with a Retry-After hint; rejections are deliberately NOT written to the audit log (the log must not become the flooding amplifier). Hot-reloadable. 0 or absent = disabled. Recommended in production; size it to your busiest legitimate broker (each ssh_execute is one sign call, each ssh_session_exec one preflight call).",
   "sign_rate_limit_per_min": 120,
 


### PR DESCRIPTION
Closes #24 — observability gap: no health or metrics endpoints anywhere.

## What

- **`internal/monitor`**: minimal registry (counters, one-label counter families, scrape-time gauges) + Prometheus text exposition, **zero new dependencies**. Get-or-create registration makes instrumented code safe to construct repeatedly; gauge re-registration replaces the callback so a rebuilt engine/registry rebinds.
- **`monitor_listen`** key on signer / control-plane / broker configs (broker key covers `broker`, `mcp-broker`, `mcp-broker-http`). Separate plain-HTTP listener with `/healthz` + `/metrics`; no auth — docs say bind to localhost or a private scrape interface. Empty/absent = disabled.
- **Metrics**, fed from the existing single audit funnels: `signer_sign_requests_total{outcome}` (includes the deliberately un-audited `rate-limited`), `controlplane_events_total{outcome}`, `controlplane_approvals_pending`, `broker_events_total{outcome}`, `broker_sessions_active`, and `audit_append_failures_total` counted inside `audit.Append` — the machine-readable alerting signal for threat-model gap #9 (audit is fail-open).

## Docs

New OPERATIONS §7 Monitoring (metric inventory + alerting guidance), API.md monitoring section, THREAT_MODEL gap #9 mitigation updated, all three example configs ship a localhost `monitor_listen`, CHANGELOG v1.26.0, regenerated `docs/reference/config.md`.

## Tests

monitor package: counter/vec semantics, gauge replacement, exposition format (incl. label escaping), healthz. Full `gofmt`/`go vet`/`go test -race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)