### PR TITLE
feat: ssh_put_file / ssh_get_file behind a per-host allow_file_transfer gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This README is a landing page. The detail lives in focused, single-source docs:
 | [THREAT_MODEL.md](docs/THREAT_MODEL.md) | Actors, trust boundaries, security controls, and explicit non-goals/gaps |
 | [OPERATIONS.md](docs/OPERATIONS.md) | Runbook: startup, adding hosts, hot-reload, `broker-ctl`, PKI rotation, configs |
 | [API.md](docs/API.md) | HTTP endpoint reference for all services |
-| [USAGE.md](docs/USAGE.md) | Guide to the 5 MCP tools, dry-run, and audit review (for the model / operator) |
+| [USAGE.md](docs/USAGE.md) | Guide to the 7 MCP tools, dry-run, and audit review (for the model / operator) |
 | [SECURITY.md](docs/SECURITY.md) | Vulnerability disclosure policy |
 | [CONTRIBUTING.md](docs/CONTRIBUTING.md) · [CODING_STYLE.md](docs/CODING_STYLE.md) | Workflow, versioning, Go style |
 

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -197,6 +197,7 @@ func cmdHostAdd(args []string) {
 	sudo := fs.Bool("sudo", false, "allow_sudo=true")
 	sudoUsers := fs.String("sudo-users", "", "allowed_sudo_users comma-separated")
 	pty := fs.Bool("pty", false, "allow_pty=true")
+	fileTransfer := fs.Bool("file-transfer", false, "allow_file_transfer=true (ssh_put_file / ssh_get_file)")
 	groups := fs.String("groups", "", "RBAC groups comma-separated")
 	callers := fs.String("callers", "", "allowed CNs comma-separated (per-host restriction)")
 	bastion := fs.Bool("bastion", false, "allow_as_bastion=true")
@@ -259,6 +260,9 @@ func cmdHostAdd(args []string) {
 	}
 	if *pty {
 		hp.AllowPTY = true
+	}
+	if *fileTransfer {
+		hp.AllowFileTransfer = true
 	}
 	if *groups != "" {
 		hp.Groups = splitComma(*groups)
@@ -355,6 +359,9 @@ func mergeUnsetHostFields(hp *hostEntry, existing hostEntry, set map[string]bool
 	}
 	if !set["pty"] {
 		hp.AllowPTY = existing.AllowPTY
+	}
+	if !set["file-transfer"] {
+		hp.AllowFileTransfer = existing.AllowFileTransfer
 	}
 	if !set["groups"] {
 		hp.Groups = existing.Groups
@@ -515,7 +522,7 @@ func cmdHostList(args []string) {
 	sort.Strings(names)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tADDR\tUSER\tPRINCIPAL\tTTL\tJUMP\tSRC_ADDR\tSUDO\tSUDO_USERS\tPTY\tBASTION\tGROUPS\tCALLERS\tPOLICY")
+	fmt.Fprintln(w, "NAME\tADDR\tUSER\tPRINCIPAL\tTTL\tJUMP\tSRC_ADDR\tSUDO\tSUDO_USERS\tPTY\tFT\tBASTION\tGROUPS\tCALLERS\tPOLICY")
 	for _, n := range names {
 		h := hosts[n]
 		jump := dash(h.Jump)
@@ -524,12 +531,12 @@ func cmdHostList(args []string) {
 		grps := dashJoin(h.Groups)
 		callers := dashJoin(h.AllowedCallers)
 		policy := commandPolicyLabel(h.CommandPolicy)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			n, h.Addr, h.User, h.Principal,
 			strconv.Itoa(h.MaxTTLSeconds)+"s",
 			jump, srcAddr,
 			boolStr(h.AllowSudo), sudoUsers,
-			boolStr(h.AllowPTY), boolStr(h.AllowAsBastion),
+			boolStr(h.AllowPTY), boolStr(h.AllowFileTransfer), boolStr(h.AllowAsBastion),
 			grps, callers, policy)
 	}
 	w.Flush()
@@ -1143,20 +1150,21 @@ func cmdApprovalDecide(args []string, approve bool) {
 // preserved verbatim through add/update round-trips, without broker-ctl
 // needing to understand its internal structure.
 type hostEntry struct {
-	Addr             string          `json:"addr"`
-	User             string          `json:"user"`
-	HostKey          string          `json:"host_key"`
-	Jump             string          `json:"jump,omitempty"`
-	Principal        string          `json:"principal"`
-	SourceAddress    string          `json:"source_address,omitempty"`
-	MaxTTLSeconds    int             `json:"max_ttl_seconds,omitempty"`
-	AllowAsBastion   bool            `json:"allow_as_bastion,omitempty"`
-	AllowedCallers   []string        `json:"allowed_callers,omitempty"`
-	AllowSudo        bool            `json:"allow_sudo,omitempty"`
-	AllowedSudoUsers []string        `json:"allowed_sudo_users,omitempty"`
-	AllowPTY         bool            `json:"allow_pty,omitempty"`
-	Groups           []string        `json:"groups,omitempty"`
-	CommandPolicy    json.RawMessage `json:"command_policy,omitempty"`
+	Addr              string          `json:"addr"`
+	User              string          `json:"user"`
+	HostKey           string          `json:"host_key"`
+	Jump              string          `json:"jump,omitempty"`
+	Principal         string          `json:"principal"`
+	SourceAddress     string          `json:"source_address,omitempty"`
+	MaxTTLSeconds     int             `json:"max_ttl_seconds,omitempty"`
+	AllowAsBastion    bool            `json:"allow_as_bastion,omitempty"`
+	AllowedCallers    []string        `json:"allowed_callers,omitempty"`
+	AllowSudo         bool            `json:"allow_sudo,omitempty"`
+	AllowedSudoUsers  []string        `json:"allowed_sudo_users,omitempty"`
+	AllowPTY          bool            `json:"allow_pty,omitempty"`
+	AllowFileTransfer bool            `json:"allow_file_transfer,omitempty"`
+	Groups            []string        `json:"groups,omitempty"`
+	CommandPolicy     json.RawMessage `json:"command_policy,omitempty"`
 }
 
 // loadRaw reads signer.json as a RawMessage map to preserve unknown fields.

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -647,6 +647,7 @@ func intentFrom(req signer.WireRequest, onBehalfOf string, approved bool) (signe
 		Sudo:          req.Sudo,
 		SudoUser:      req.SudoUser,
 		PTY:           req.PTY,
+		FileTransfer:  req.FileTransfer,
 		DryRun:        req.DryRun,
 		Preflight:     req.Preflight,
 		OnBehalfOf:    onBehalfOf,

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -492,6 +492,7 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 		Sudo:          req.Sudo,
 		SudoUser:      req.SudoUser,
 		PTY:           req.PTY,
+		FileTransfer:  req.FileTransfer,
 		DryRun:        req.DryRun,
 		Preflight:     req.Preflight,
 		Approved:      effectiveApproved,
@@ -574,13 +575,14 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 	result := make(map[string]signer.WireHostInfo, len(hosts))
 	for name, hp := range hosts {
 		result[name] = signer.WireHostInfo{
-			Addr:      hp.Addr,
-			User:      hp.User,
-			HostKey:   hp.HostKey,
-			Jump:      hp.Jump,
-			AllowSudo: hp.AllowSudo,
-			AllowPTY:  hp.AllowPTY,
-			Groups:    hp.Groups,
+			Addr:              hp.Addr,
+			User:              hp.User,
+			HostKey:           hp.HostKey,
+			Jump:              hp.Jump,
+			AllowSudo:         hp.AllowSudo,
+			AllowPTY:          hp.AllowPTY,
+			AllowFileTransfer: hp.AllowFileTransfer,
+			Groups:            hp.Groups,
 		}
 	}
 
@@ -681,6 +683,9 @@ func (s *server) auditEmission(caller string, req signer.WireRequest, hosts sign
 	}
 	if req.PTY {
 		cmd += " pty=1"
+	}
+	if req.FileTransfer {
+		cmd += " ft=1"
 	}
 	// Use the real address (FQDN) and policy metadata instead of the logical
 	// name, which does not uniquely identify the target in the log.

--- a/docs/API.md
+++ b/docs/API.md
@@ -63,6 +63,7 @@ scoped certificate.
 | `sudo` | bool | | Request NOPASSWD elevation via `sudo -n`. Requires `allow_sudo: true` on the host policy. |
 | `sudo_user` | string | | Target user for sudo. Empty = `root`. Must match `allowed_sudo_users` if that list is set. |
 | `pty` | bool | | Request `permit-pty` in the certificate. Requires `allow_pty: true` on the host policy. |
+| `file_transfer` | bool | | Marks the request as a file transfer (`ssh_put_file` / `ssh_get_file`). Requires `allow_file_transfer: true` on the host policy; rejected 403 otherwise. The transfer command itself travels in `command`. |
 | `dry_run` | bool | | If true, resolve policy and return the `decision` **without** issuing a usable certificate. The response carries `decision` and omits `certificate`/`serial`. A policy denial in dry-run is reported as `decision.allowed=false` (HTTP 200), not a 403. |
 | `preflight` | bool | | Internal broker/control-plane signal, only meaningful with `dry_run=true`: this decision authorizes an imminent execution such as `ssh_session_exec`. The signer still issues no certificate, but the control plane applies behavioral guardrails and rate limits as it would for execution. |
 | `on_behalf_of` | string | | CN of the broker a trusted forwarder (control plane) is acting for. Honored **only** if the mTLS CN is in `trusted_forwarders`; otherwise the request is rejected (403). Used as the effective caller for RBAC. |
@@ -108,7 +109,7 @@ scoped certificate.
 |---|---|
 | `400 Bad Request` | Malformed JSON body or invalid `public_key` format; or control/whitespace characters in `end_user`, `role`, `purpose`, `session_mode`, `sudo_user`, or in the resolved caller identity (rejected before any audit emission). |
 | `401 Unauthorized` | Missing or invalid mTLS client certificate. |
-| `403 Forbidden` | Host not in caller's allowed groups (RBAC); or policy denied (sudo not allowed, PTY not allowed, invalid `sudo_user`, `shell`/`pty` session requested on a host with `command_policy`, `role: "bastion"` requested for a host with a `command_policy`, `on_behalf_of` from a non-trusted forwarder, etc.). Note: a `ttl_seconds` above the host cap is silently clamped to the cap, not rejected. |
+| `403 Forbidden` | Host not in caller's allowed groups (RBAC); or policy denied (sudo not allowed, PTY not allowed, file transfer not allowed (`allow_file_transfer=false`), invalid `sudo_user`, `shell`/`pty` session requested on a host with `command_policy`, `role: "bastion"` requested for a host with a `command_policy`, `on_behalf_of` from a non-trusted forwarder, etc.). Note: a `ttl_seconds` above the host cap is silently clamped to the cap, not rejected. |
 | `405 Method Not Allowed` | Request method is not `POST`. |
 | `429 Too Many Requests` | Per-CN rate limit exceeded (`sign_rate_limit_per_min` > 0). Keyed on the authenticated mTLS CN, checked before the body is parsed; carries a `Retry-After` header (seconds). Not audited per rejection by design. |
 
@@ -151,6 +152,7 @@ JSON object mapping host name → host info object.
 | `jump` | string | Logical name of the bastion host to use as ProxyJump. Empty if the host is direct. |
 | `allow_sudo` | bool | Whether NOPASSWD sudo elevation is allowed on this host. |
 | `allow_pty` | bool | Whether PTY allocation is allowed on this host. |
+| `allow_file_transfer` | bool | Whether the file-transfer tools (`ssh_put_file` / `ssh_get_file`) are allowed on this host. |
 | `groups` | []string | RBAC groups the host belongs to. The broker uses them to filter the host list shown to an end user by the user's OIDC groups (consistent with the per-user check at signing time). |
 
 **Notes:**
@@ -855,6 +857,65 @@ after `session_idle_seconds` or `session_max_seconds` (configured in
 `shell` and `pty` sessions are recorded to ASCIIcast v2 files in that directory.
 Each file is named `<session_id>.cast` and contains stdin, stdout, and stderr
 events with millisecond timestamps. See USAGE.md §8 for details.
+
+---
+
+#### Tool: `ssh_put_file`
+
+Write a file on a host. Issues a one-shot certificate whose `force-command` is
+`cat > 'path'` (plus an optional `chmod`), with the content streamed over
+stdin. Requires `allow_file_transfer: true` on the host policy; the transfer
+command is also subject to the host's `command_policy` like any one-shot. Runs
+as the host's configured SSH user (no sudo).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `server` | string | ✓ | Logical host name. |
+| `path` | string | ✓ | Destination path. Created or **overwritten**. |
+| `content` | string | ✓ | File content (text, or base64 with `content_base64: true`). Capped by the broker's `file_transfer_max_bytes` (default 512 KiB). |
+| `content_base64` | bool | | Decode `content` from base64 before writing (binary files). |
+| `mode` | string | | Octal permissions to `chmod` after writing (e.g. `"0644"`). |
+| `ttl_seconds` | int | | Certificate TTL override. |
+
+**Returns:**
+
+| Field | Type | Description |
+|---|---|---|
+| `bytes_written` | int | Bytes written to the remote file. |
+| `sha256` | string | Hex sha256 of the written content; also recorded in the broker audit log (`file_put` entry, same serial). |
+| `serial` | uint64 | Certificate serial for audit correlation. |
+| `warnings` | []string | Optional command-policy audit-mode warnings. |
+
+---
+
+#### Tool: `ssh_get_file`
+
+Read a file from a host. Issues a one-shot certificate whose `force-command`
+is a bounded read (`head -c max+1 < 'path'`); a file larger than the limit is
+an error, not a truncation. Requires `allow_file_transfer: true` on the host
+policy. Runs as the host's configured SSH user (no sudo).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `server` | string | ✓ | Logical host name. |
+| `path` | string | ✓ | File to read. |
+| `max_bytes` | int | | Size limit for this read. Defaults to (and is capped by) the broker's `file_transfer_max_bytes`. |
+| `ttl_seconds` | int | | Certificate TTL override. |
+
+**Returns:**
+
+| Field | Type | Description |
+|---|---|---|
+| `content` | string | File content: text as-is, or base64 when `base64` is `true` (file is not valid UTF-8). |
+| `base64` | bool | Whether `content` is base64-encoded. |
+| `size` | int | File size in bytes (decoded). |
+| `sha256` | string | Hex sha256 of the content; also recorded in the broker audit log (`file_get` entry, same serial). |
+| `serial` | uint64 | Certificate serial for audit correlation. |
+| `warnings` | []string | Optional command-policy audit-mode warnings. |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,7 @@ AI model (Claude / OpenCode)
     │                           │  Authorization: Bearer <OIDC token>
     ▼                           ▼
 cmd/mcp-broker                cmd/mcp-broker-http        ← never hold the CA key
-    │  same 5 tools            │  validates JWT via JWKS (go-oidc)
+    │  same 7 tools            │  validates JWT via JWKS (go-oidc)
     │  caller="mcp-stdio"      │  caller={sub, groups from token}
     │                          │  propagates EndUser+EndUserGroups to the signer
     └─────────────┬────────────┘

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v1.27.0] - 2026-07-02
+
+### Added
+- Two new MCP tools, `ssh_put_file` and `ssh_get_file`, built on the one-shot
+  certificate machinery (no SFTP subsystem, no new dependency): the transfer is
+  a force-command one-shot (`cat > path` / bounded `head -c` read) with content
+  streamed over stdin/stdout; binary data via base64. A file larger than the
+  cap is an error, not a truncation. The content's sha256, size, and path are
+  recorded in dedicated `file_put`/`file_get` audit entries correlated with the
+  `executed` entry by serial.
+- New per-host gate `allow_file_transfer` (default **false**, secure by
+  default) in the signer HostPolicy and broker local-mode HostConfig, enforced
+  at signing time via the new `file_transfer` intent/wire flag, exposed in
+  `GET /v1/hosts` and `ssh_list_servers`, and manageable with
+  `broker-ctl host add --file-transfer`. The generated transfer command remains
+  subject to the host's `command_policy`.
+- Broker config `file_transfer_max_bytes` caps transfer size (default 512 KiB;
+  the HTTP MCP frontend's 1 MiB body bound must fit base64-encoded content).
+
 ## [v1.26.0] - 2026-07-02
 
 ### Added

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -56,7 +56,7 @@
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Ramas, versionado X.Y.Z, checklist pre-commit, idioma |
 | [CODING_STYLE.md](CODING_STYLE.md) | Reglas Go con verificación mecánica |
 | [API.md](API.md) | Referencia de endpoints HTTP de todos los servicios |
-| [USAGE.md](USAGE.md) | Guía de las 5 tools MCP para el modelo |
+| [USAGE.md](USAGE.md) | Guía de las 7 tools MCP para el modelo |
 
 ---
 
@@ -92,7 +92,7 @@ ssh-broker/
 │   ├── ca/                   # loader (PEM/AKV), akv, sign (BuildAndSign), GenerateEphemeralKey
 │   ├── signer/               # Signer/Local, PolicyTable.Resolve, cmdpolicy, remote (Wire*)
 │   ├── broker/               # Engine, Caller, ExecOptions, sessionManager, session
-│   ├── mcpserver/            # New + Register (5 tools compartidas stdio/HTTP)
+│   ├── mcpserver/            # New + Register (7 tools compartidas stdio/HTTP)
 │   ├── oauth/                # Verifier OIDC (JWKS, fail-closed groups/iat)
 │   ├── ssh/                  # Dial/ExecOnce/Run, OpenShell/OpenShellPTY
 │   ├── audit/                # log append-only encadenado y firmado (Ed25519)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -226,6 +226,7 @@ broker-ctl host remove web01
 | `--sudo-users` | | — | `allowed_sudo_users` (comma-separated) |
 | `--pty` | | false | `allow_pty=true` |
 | `--groups` | | — | RBAC groups (comma-separated) |
+| `--file-transfer` | | false | `allow_file_transfer=true` (`ssh_put_file` / `ssh_get_file`) |
 | `--callers` | | — | CNs allowed on this host (comma-separated) |
 | `--bastion` | | false | `allow_as_bastion=true` |
 | `--force` | | false | Update if it exists, preserving every field whose flag you don't pass (see note) |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Guide — ssh-broker MCP Tools
 
-This document covers practical usage of the five MCP tools exposed by
+This document covers practical usage of the seven MCP tools exposed by
 `cmd/mcp-broker` (stdio) and `cmd/mcp-broker-http` (HTTP+OAuth2/OIDC).
 
 Keep this file up to date whenever a tool is added, removed, renamed, or its
@@ -18,6 +18,7 @@ parameters or behaviour change.
 6. [Quick reference](#6-quick-reference)
 7. [Reviewing audit logs](#7-reviewing-audit-logs)
 8. [Session recording](#8-session-recording)
+9. [ssh\_put\_file / ssh\_get\_file — file transfer](#9-ssh_put_file--ssh_get_file--file-transfer)
 
 ---
 
@@ -36,10 +37,10 @@ params: (none)
 Example response:
 
 ```
-web01 (sudo=true pty=true)
-db01  (sudo=false pty=false)
-bastion (sudo=false pty=false)
-app02 (sudo=true pty=true via=bastion)
+web01 (sudo=true pty=true file_transfer=true)
+db01  (sudo=false pty=false file_transfer=false)
+bastion (sudo=false pty=false file_transfer=false)
+app02 (sudo=true pty=true file_transfer=false via=bastion)
 ```
 
 What the fields mean:
@@ -50,6 +51,8 @@ What the fields mean:
 | `allow_sudo` | `false` | Do **not** pass `sudo=true`. The signer will reject it. Do not retry. |
 | `allow_pty` | `true` | You may use `pty=true` (execute) or `mode=pty` (session). |
 | `allow_pty` | `false` | Do **not** request a PTY. Do not retry. |
+| `allow_file_transfer` | `true` | You may use `ssh_put_file` / `ssh_get_file` (see [§9](#9-ssh_put_file--ssh_get_file--file-transfer)). |
+| `allow_file_transfer` | `false` | Do **not** attempt file transfers. The signer will reject them. Do not retry. |
 | `jump` | `"bastion"` | The host is reached via a ProxyJump hop through `bastion`. Transparent — no extra action needed. |
 
 **Operator note — host groups, CA keys and broker-ctl (v1.11.1):** each host in `signer.json` belongs to one or more `groups`. Those groups determine both RBAC visibility (which broker CN can reach the host) and, if the operator has configured `ca_keys`, which CA key signs its certificates. From the model's perspective this is transparent — the tools and their parameters are unchanged. Operators manage hosts, CA keys, callers, and command policy via `broker-ctl`; see [OPERATIONS.md §4](OPERATIONS.md#4-broker-ctl). Per-host command policy (allowlist, denylist, require-approval) is configured with `broker-ctl host add --policy-mode` flags and takes effect after the next `broker-ctl reload`.
@@ -635,6 +638,8 @@ tool: ssh_session_exec  command: "echo bar"
 | Multiple commands with `cd` or env state | `ssh_session_open` (`mode=shell`) + `ssh_session_exec` |
 | Program that requires a TTY | `ssh_execute` (`pty=true`) or `ssh_session_open` (`mode=pty`) |
 | Lowest latency for many commands | `ssh_session_open` (`mode=exec`) + `ssh_session_exec` |
+| Write a file (config, script) | `ssh_put_file` (requires `allow_file_transfer=true`) |
+| Read a file (log, config) | `ssh_get_file` (requires `allow_file_transfer=true`) |
 
 ### Parameter constraints
 
@@ -646,6 +651,7 @@ tool: ssh_session_exec  command: "echo bar"
 | `command` | Must not contain `\n` or `\r` for one-shot `ssh_execute` and `shell`/`pty` session exec; use `;` or `&&`. Every session command is preflighted against the current signer policy: target and bastion access, end-user groups, sudo, sudo_user, PTY, and the physical host route are revalidated; when a host has `command_policy`, `mode=exec` must satisfy the allowlist/denylist and `shell`/`pty` commands are rejected. |
 | `ttl_seconds` | Optional. Omit to use the host policy maximum. |
 | `dry_run=true` | `ssh_execute` only. Simulates policy (allow/deny + approval) without executing. Nothing runs. |
+| `ssh_put_file` / `ssh_get_file` | Only when `allow_file_transfer=true` (from `ssh_list_servers`). Never retry if `false`. Content capped by `file_transfer_max_bytes` (default 512 KiB). See [§9](#9-ssh_put_file--ssh_get_file--file-transfer). |
 
 ### Recommended workflow
 
@@ -703,7 +709,8 @@ Filter by outcome:
 
 ```bash
 # Broker outcomes: executed, denied, error, session_open, session_exec,
-#                  session_close, dry_run_allowed, dry_run_denied
+#                  session_close, dry_run_allowed, dry_run_denied,
+#                  file_put, file_get
 broker-ctl audit show --log audit.log --outcome denied
 
 # Signer outcomes: issued, denied, approval-required, dry_run_allowed,
@@ -916,3 +923,68 @@ retention:
 # Delete recordings older than 90 days
 find /var/log/ssh-broker/recordings -name "*.cast" -mtime +90 -delete
 ```
+
+---
+
+## 9. ssh_put_file / ssh_get_file — file transfer
+
+Write and read files on a host without heredoc tricks. Both tools use the same
+ephemeral-certificate machinery as `ssh_execute`: each transfer is a one-shot
+command (`cat > path` for writes, a bounded read for downloads) locked into the
+certificate's `force-command`, with the content streamed over stdin/stdout.
+
+**Requires `allow_file_transfer=true` on the host** (check `ssh_list_servers`
+first). If it is `false`, the signer rejects the transfer — do **not** retry;
+inform the user. Transfers run as the host's configured SSH user (no sudo):
+the path must be readable/writable by that user.
+
+### 9.1 Write a file
+
+```
+tool: ssh_put_file
+params:
+  server:  "web01"
+  path:    "/etc/myapp/config.yaml"
+  content: "listen: :8080\nworkers: 4\n"
+  mode:    "0644"
+```
+
+Response:
+
+```
+wrote 28 bytes to /etc/myapp/config.yaml (sha256=9f86d0…) [serial=1044]
+```
+
+- The destination is created or **overwritten**. Read it first if you need to
+  preserve content.
+- `mode` is optional (octal, e.g. `0644`, `0755`); without it the file keeps
+  the remote user's default umask.
+- For binary data pass `content_base64: true` and base64-encode `content`.
+- Content is capped by the broker's `file_transfer_max_bytes`
+  (default 512 KiB).
+
+### 9.2 Read a file
+
+```
+tool: ssh_get_file
+params:
+  server: "web01"
+  path:   "/var/log/myapp/error.log"
+```
+
+- Text files come back as-is in `content`; binary files come back
+  base64-encoded with `base64: true` in the result.
+- A file larger than `max_bytes` (default: the broker cap) is an **error**,
+  not a truncation — lower your expectations or fetch a slice with
+  `ssh_execute` (`tail -c`, `sed -n`).
+
+### 9.3 Policy and audit interaction
+
+- On hosts with a `command_policy`, the generated transfer command
+  (`cat > 'path'` / `head -c N < 'path'`) is evaluated like any one-shot: an
+  allowlist host denies transfers unless a pattern allows them, and a
+  `shell_parse` policy in enforce mode rejects the stream redirects these
+  commands use (deliberately conservative).
+- Every transfer writes two correlated audit entries (same `serial`): the
+  regular `executed` entry with the transfer command, and a `file_put` /
+  `file_get` entry carrying `path=… bytes=… sha256=…` for content integrity.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -29,6 +29,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `command_policies` | `map[string]signer.CommandPolicy` | CommandPolicies (local mode) is a named library of command policies, attachable to groups. GroupCommandPolicies maps a group name to the policy names that apply to its hosts; the reserved group "_default" applies to every host. A host's effective firewall is the composition of its inline command_policy and the policies of all its groups (additive union; deny wins). |
 | `group_command_policies` | `map[string][]string` |  |
 | `monitor_listen` | `string` | MonitorListen: optional plain-HTTP monitoring listener serving /healthz (liveness) and /metrics (Prometheus text format), started by every frontend (broker, mcp-broker, mcp-broker-http). No authentication — bind to localhost or a private scrape interface. Empty = disabled. |
+| `file_transfer_max_bytes` | `int` | FileTransferMaxBytes caps ssh_put_file content and ssh_get_file reads. Default 524288 (512 KiB). The HTTP MCP frontend additionally bounds the whole request body at 1 MiB, which base64-encoded content must fit. |
 | `oauth` | `*OAuthConfig` | OAuth and ResourceURL are used only by the HTTP+OAuth frontend (cmd/mcp-broker-http); other frontends ignore them. |
 | `resource_url` | `string` | ResourceURL is the canonical URL of this MCP server, used in the Protected Resource Metadata document (RFC 9728) and the WWW-Authenticate header. |
 
@@ -73,6 +74,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `allow_sudo` | `bool` | Elevation (NOPASSWD) — local mode. |
 | `allowed_sudo_users` | `[]string` |  |
 | `allow_pty` | `bool` | AllowPTY — local mode. |
+| `allow_file_transfer` | `bool` | AllowFileTransfer authorises ssh_put_file / ssh_get_file on this host — local mode. Default false (secure by default). In remote mode this is defined by the signer in signer.json. |
 | `groups` | `[]string` | Groups lists the RBAC groups this host belongs to. When ca_keys are configured (multi-CA), the first matching group determines which CA signs certificates for this host. Also used for per-user RBAC in local mode. |
 | `allow_as_bastion` | `bool` | AllowAsBastion authorises this host to be used as a ProxyJump hop (permit-port-forwarding in its cert). Local mode only; default false to match the remote-signer default-deny gate (ARCHITECTURE.md § routing). A host referenced as another host's Jump target is enabled automatically (see policyFromHosts), so existing jump chains keep working without per-host config. |
 | `command_policy` | `signer.CommandPolicy` | CommandPolicy — local mode (AI-action firewall). In remote mode this is defined by the signer in signer.json. |
@@ -177,6 +179,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `allow_sudo` | `bool` | Elevation (sudo NOPASSWD). AllowSudo enables privilege elevation for this host. |
 | `allowed_sudo_users` | `[]string` | AllowedSudoUsers lists the permitted target users (e.g. ["root","deploy"]). Empty = root only. "root" is always implied when AllowSudo=true. |
 | `allow_pty` | `bool` | AllowPTY authorises the permit-pty extension in certificates for this host. If false, PTY requests are rejected. |
+| `allow_file_transfer` | `bool` | AllowFileTransfer authorises the file-transfer tools (ssh_put_file / ssh_get_file) for this host. If false (the default — secure by default), signing requests flagged file_transfer are rejected. The generated transfer command is still subject to the host's command policy. |
 | `groups` | `[]string` | Groups lists the RBAC groups this host belongs to. A caller restricted by groups can only access hosts that share at least one of its allowed_groups. Empty = host belongs to no group. |
 | `command_policy` | `CommandPolicy` | CommandPolicy restricts which commands may run on this host (AI-action firewall). Empty/off = no command restriction. Session commands are preflighted against the current signer policy before each exec, so reloads affect already-open sessions: target and bastion access, end-user groups, sudo, sudo_user and PTY are revalidated; the broker also rejects already-open sessions if the host's physical SSH route changed. mode=exec is allowed, while shell/pty sessions are rejected when rules are present because stateful commands are not independently verifiable. |
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -16,10 +16,30 @@ Execute a single command on a Linux host via SSH with an ephemeral credential. P
 - `sudo_user` (string) — target user for sudo (empty = root). Must be in the host's allowed_sudo_users list.
 - `ttl_seconds` (integer) — ephemeral certificate validity in seconds; omit to use the maximum allowed by the host policy
 
+## `ssh_get_file`
+
+Read a file from a Linux host via SSH with an ephemeral credential. Returns the content as text, or base64 (base64=true in the result) when the file is not valid UTF-8. REQUIRES allow_file_transfer=true on the host (see ssh_list_servers); if false DO NOT retry, the signer will reject it. The read runs as the host's configured SSH user (no sudo); the file must be readable by that user. A file larger than max_bytes (default: the broker's file_transfer_max_bytes, 512 KiB) is an ERROR, not a truncation. The content's sha256 is recorded in the audit log.
+
+- `max_bytes` (integer) — read at most this many bytes; a larger file is an error, not a truncation. Omit for the broker's configured limit.
+- `path` (string) *(required)* — absolute path of the file to read on the host
+- `server` (string) *(required)* — logical name of the target host (see ssh_list_servers)
+- `ttl_seconds` (integer) — ephemeral certificate validity in seconds; omit to use the maximum allowed by the host policy
+
 ## `ssh_list_servers`
 
-List the hosts accessible to the caller with their capabilities (hosts outside the user's RBAC groups are not listed). ALWAYS call before ssh_execute or ssh_session_open. Fields per host: allow_sudo=true → the host accepts NOPASSWD sudo elevation (sudo=true may be used); allow_sudo=false → DO NOT attempt sudo, the signer will reject it. allow_pty=true → the host accepts PTY (pty=true or mode=pty may be used); allow_pty=false → DO NOT attempt PTY. jump → name of the bastion through which the host is reached (informational).
+List the hosts accessible to the caller with their capabilities (hosts outside the user's RBAC groups are not listed). ALWAYS call before ssh_execute or ssh_session_open. Fields per host: allow_sudo=true → the host accepts NOPASSWD sudo elevation (sudo=true may be used); allow_sudo=false → DO NOT attempt sudo, the signer will reject it. allow_pty=true → the host accepts PTY (pty=true or mode=pty may be used); allow_pty=false → DO NOT attempt PTY. allow_file_transfer=true → ssh_put_file and ssh_get_file may be used; allow_file_transfer=false → DO NOT attempt file transfers, the signer will reject them. jump → name of the bastion through which the host is reached (informational).
 
+
+## `ssh_put_file`
+
+Write a file on a Linux host via SSH with an ephemeral credential. Creates or OVERWRITES the destination file with the given content. Use content_base64=true for binary data (the content field is decoded before writing). REQUIRES allow_file_transfer=true on the host (see ssh_list_servers); if false DO NOT retry, the signer will reject it. The write runs as the host's configured SSH user (no sudo); the destination must be writable by that user. On hosts with a command policy the transfer command (cat > path) must also be allowed by the policy. Content is limited by the broker's file_transfer_max_bytes (default 512 KiB). The content's sha256 is recorded in the audit log.
+
+- `content` (string) *(required)* — file content. Text as-is, or base64 with content_base64=true for binary data.
+- `content_base64` (boolean) — if true, content is base64-encoded and is decoded before writing (required for binary files)
+- `mode` (string) — optional octal permissions to chmod after writing, e.g. 0644 or 0755
+- `path` (string) *(required)* — absolute destination path on the host; the file is created or overwritten
+- `server` (string) *(required)* — logical name of the target host (see ssh_list_servers)
+- `ttl_seconds` (integer) — ephemeral certificate validity in seconds; omit to use the maximum allowed by the host policy
 
 ## `ssh_session_close`
 

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -103,6 +103,11 @@ type Config struct {
 	// to localhost or a private scrape interface. Empty = disabled.
 	MonitorListen string `json:"monitor_listen,omitempty"`
 
+	// FileTransferMaxBytes caps ssh_put_file content and ssh_get_file reads.
+	// Default 524288 (512 KiB). The HTTP MCP frontend additionally bounds the
+	// whole request body at 1 MiB, which base64-encoded content must fit.
+	FileTransferMaxBytes int `json:"file_transfer_max_bytes,omitempty"`
+
 	// OAuth and ResourceURL are used only by the HTTP+OAuth frontend
 	// (cmd/mcp-broker-http); other frontends ignore them.
 	OAuth *OAuthConfig `json:"oauth,omitempty"`
@@ -152,6 +157,11 @@ type HostConfig struct {
 
 	// AllowPTY — local mode.
 	AllowPTY bool `json:"allow_pty,omitempty"`
+
+	// AllowFileTransfer authorises ssh_put_file / ssh_get_file on this host —
+	// local mode. Default false (secure by default). In remote mode this is
+	// defined by the signer in signer.json.
+	AllowFileTransfer bool `json:"allow_file_transfer,omitempty"`
 
 	// Groups lists the RBAC groups this host belongs to. When ca_keys are
 	// configured (multi-CA), the first matching group determines which CA signs
@@ -204,6 +214,13 @@ type ExecOptions struct {
 	// connecting or executing. Allows the model to preview whether a command
 	// would be permitted.
 	DryRun bool
+
+	// Stdin, when non-empty, is streamed to the remote command's standard
+	// input (file uploads). One-shot only; ignored for sessions and PTY.
+	Stdin []byte
+	// FileTransfer marks the intent as a file transfer: the signer rejects it
+	// unless the host policy has allow_file_transfer=true.
+	FileTransfer bool
 }
 
 // elevationLabel builds the audit label for the elevation.
@@ -424,18 +441,19 @@ func policyFromHosts(cfg *Config) signer.PolicyTable {
 			src = hc.SourceAddress
 		}
 		pt[name] = signer.HostPolicy{
-			Addr:             hc.Addr,
-			User:             hc.User,
-			HostKey:          hc.HostKey,
-			Jump:             hc.Jump,
-			Principal:        hc.Principal,
-			SourceAddress:    src,
-			AllowAsBastion:   hc.AllowAsBastion || jumpTargets[name],
-			AllowSudo:        hc.AllowSudo,
-			AllowedSudoUsers: hc.AllowedSudoUsers,
-			AllowPTY:         hc.AllowPTY,
-			Groups:           hc.Groups,
-			CommandPolicy:    hc.CommandPolicy,
+			Addr:              hc.Addr,
+			User:              hc.User,
+			HostKey:           hc.HostKey,
+			Jump:              hc.Jump,
+			Principal:         hc.Principal,
+			SourceAddress:     src,
+			AllowAsBastion:    hc.AllowAsBastion || jumpTargets[name],
+			AllowSudo:         hc.AllowSudo,
+			AllowedSudoUsers:  hc.AllowedSudoUsers,
+			AllowPTY:          hc.AllowPTY,
+			AllowFileTransfer: hc.AllowFileTransfer,
+			Groups:            hc.Groups,
+			CommandPolicy:     hc.CommandPolicy,
 		}
 	}
 	return pt
@@ -456,7 +474,8 @@ func (e *Engine) hostInfo(name string) (signer.HostInfo, bool) {
 	if !ok {
 		return signer.HostInfo{}, false
 	}
-	return signer.HostInfo{Addr: hc.Addr, User: hc.User, HostKey: hc.HostKey, Jump: hc.Jump, AllowSudo: hc.AllowSudo, AllowPTY: hc.AllowPTY, Groups: hc.Groups}, true
+	return signer.HostInfo{Addr: hc.Addr, User: hc.User, HostKey: hc.HostKey, Jump: hc.Jump,
+		AllowSudo: hc.AllowSudo, AllowPTY: hc.AllowPTY, AllowFileTransfer: hc.AllowFileTransfer, Groups: hc.Groups}, true
 }
 
 // refreshHostsNow reloads the remote signer host view immediately. It is used
@@ -525,10 +544,11 @@ func writeSignaturePart(b *strings.Builder, s string) {
 // ServerInfo contains the logical name and capabilities of a host, so the
 // model can choose the appropriate execution strategy.
 type ServerInfo struct {
-	Name      string
-	AllowSudo bool
-	AllowPTY  bool
-	Jump      string // bastion name, if any
+	Name              string
+	AllowSudo         bool
+	AllowPTY          bool
+	AllowFileTransfer bool
+	Jump              string // bastion name, if any
 }
 
 // ServerInfos returns the hosts visible to the caller with their capabilities
@@ -546,7 +566,7 @@ func (e *Engine) ServerInfos(c Caller) []ServerInfo {
 			if c.Groups != nil && !groupsIntersect(h.Groups, c.Groups) {
 				continue
 			}
-			infos = append(infos, ServerInfo{Name: name, AllowSudo: h.AllowSudo, AllowPTY: h.AllowPTY, Jump: h.Jump})
+			infos = append(infos, ServerInfo{Name: name, AllowSudo: h.AllowSudo, AllowPTY: h.AllowPTY, AllowFileTransfer: h.AllowFileTransfer, Jump: h.Jump})
 		}
 		e.mu.RUnlock()
 	} else {
@@ -555,7 +575,7 @@ func (e *Engine) ServerInfos(c Caller) []ServerInfo {
 			if c.Groups != nil && !groupsIntersect(hc.Groups, c.Groups) {
 				continue
 			}
-			infos = append(infos, ServerInfo{Name: name, AllowSudo: hc.AllowSudo, AllowPTY: hc.AllowPTY, Jump: hc.Jump})
+			infos = append(infos, ServerInfo{Name: name, AllowSudo: hc.AllowSudo, AllowPTY: hc.AllowPTY, AllowFileTransfer: hc.AllowFileTransfer, Jump: hc.Jump})
 		}
 	}
 	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
@@ -629,7 +649,7 @@ func (e *Engine) Execute(ctx context.Context, c Caller, host, command string, tt
 	}
 	defer conn.Close()
 
-	execOpts := sshrun.ExecOptions{PTY: opts.PTY}
+	execOpts := sshrun.ExecOptions{PTY: opts.PTY, Stdin: opts.Stdin}
 	res, err := sshrun.ExecOnce(ctx, conn.Client, command, execOpts)
 	if err != nil {
 		e.auditE(audit.Entry{Caller: c.ID, Host: host, Command: command, Serial: serial, Outcome: "error", Err: err.Error()})
@@ -771,10 +791,11 @@ func (e *Engine) buildHops(ctx context.Context, c Caller, host string, ttl time.
 		if isTarget {
 			in.Role = signer.RoleTarget
 			in.Command = command
-			// Elevation and PTY only at the target hop.
+			// Elevation, PTY, and the file-transfer gate only at the target hop.
 			in.Sudo = opts.Sudo
 			in.SudoUser = opts.SudoUser
 			in.PTY = opts.PTY
+			in.FileTransfer = opts.FileTransfer
 		}
 		issued, err := e.sgn.SignIntent(ctx, in)
 		if err != nil {

--- a/internal/broker/filetransfer.go
+++ b/internal/broker/filetransfer.go
@@ -1,0 +1,128 @@
+// File transfer (ssh_put_file / ssh_get_file) built on the one-shot
+// certificate machinery: the transfer is a force-command one-shot whose
+// content travels over stdin (upload) or stdout (download), so no SFTP
+// subsystem or extra dependency is involved. The signer gates the capability
+// per host via allow_file_transfer (default false), and the generated command
+// is subject to the host's command policy like any other one-shot — note that
+// a shell_parse policy in enforce mode rejects the stream redirects these
+// commands use, which is the deliberately conservative outcome.
+
+package broker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/luisgf/ssh-broker/internal/audit"
+)
+
+// DefaultFileTransferMaxBytes caps transfer content when
+// file_transfer_max_bytes is not configured. Sized so that base64-encoded
+// content plus the MCP envelope fits the HTTP frontend's 1 MiB body bound.
+const DefaultFileTransferMaxBytes = 512 * 1024
+
+// FileTransferMaxBytes returns the effective per-transfer size cap.
+func (e *Engine) FileTransferMaxBytes() int {
+	if e.cfg.FileTransferMaxBytes > 0 {
+		return e.cfg.FileTransferMaxBytes
+	}
+	return DefaultFileTransferMaxBytes
+}
+
+// FileTransferResult is the outcome of a PutFile or GetFile.
+type FileTransferResult struct {
+	Content  []byte // downloaded content (GetFile only)
+	Size     int    // bytes written (put) or read (get)
+	SHA256   string // hex sha256 of the transferred content
+	Serial   uint64 // certificate serial, correlates the audit entries
+	Warnings []string
+}
+
+// modeRe validates the optional chmod mode: 3-4 octal digits.
+var modeRe = regexp.MustCompile(`^[0-7]{3,4}$`)
+
+// validateTransferPath rejects paths the transfer commands cannot quote into a
+// single-line force-command safely.
+func validateTransferPath(path string) error {
+	switch {
+	case path == "":
+		return fmt.Errorf("%w: path is required", ErrBadRequest)
+	case strings.ContainsRune(path, 0):
+		return fmt.Errorf("%w: path contains null bytes", ErrBadRequest)
+	case strings.ContainsAny(path, "\n\r"):
+		return fmt.Errorf("%w: path contains newline characters", ErrBadRequest)
+	}
+	return nil
+}
+
+// PutFile uploads content to path on host: a one-shot `cat > path` (plus an
+// optional chmod) with the bytes streamed over stdin. The signer must allow
+// file transfer on the host (allow_file_transfer=true). mode, when non-empty,
+// is an octal chmod mode like "0644".
+func (e *Engine) PutFile(ctx context.Context, c Caller, host, path string, content []byte, mode string, ttlSeconds int) (*FileTransferResult, error) {
+	if err := validateTransferPath(path); err != nil {
+		return nil, err
+	}
+	if max := e.FileTransferMaxBytes(); len(content) > max {
+		return nil, fmt.Errorf("%w: content is %d bytes, the transfer limit is %d", ErrBadRequest, len(content), max)
+	}
+	q := shellQuoteSession(path)
+	command := "cat > " + q
+	if mode != "" {
+		if !modeRe.MatchString(mode) {
+			return nil, fmt.Errorf("%w: invalid mode %q (expect 3-4 octal digits)", ErrBadRequest, mode)
+		}
+		command += " && chmod " + mode + " " + q
+	}
+	res, err := e.Execute(ctx, c, host, command, ttlSeconds, ExecOptions{Stdin: content, FileTransfer: true})
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode != 0 {
+		return nil, fmt.Errorf("%w: remote write failed (exit %d): %s", ErrUpstream, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+	e.auditE(audit.Entry{
+		Caller: c.ID, Host: host, Serial: res.Serial, Outcome: "file_put",
+		Command: fmt.Sprintf("path=%s bytes=%d sha256=%s", path, len(content), digest),
+	})
+	return &FileTransferResult{Size: len(content), SHA256: digest, Serial: res.Serial, Warnings: res.Warnings}, nil
+}
+
+// GetFile downloads up to maxBytes of path from host via a one-shot
+// `head -c maxBytes+1 < path`. A file larger than the cap is an error rather
+// than a silent truncation (the extra byte detects it). maxBytes <= 0 or above
+// the configured cap selects the cap.
+func (e *Engine) GetFile(ctx context.Context, c Caller, host, path string, maxBytes, ttlSeconds int) (*FileTransferResult, error) {
+	if err := validateTransferPath(path); err != nil {
+		return nil, err
+	}
+	max := e.FileTransferMaxBytes()
+	if maxBytes > 0 && maxBytes < max {
+		max = maxBytes
+	}
+	command := fmt.Sprintf("head -c %d < %s", max+1, shellQuoteSession(path))
+	res, err := e.Execute(ctx, c, host, command, ttlSeconds, ExecOptions{FileTransfer: true})
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode != 0 {
+		return nil, fmt.Errorf("%w: remote read failed (exit %d): %s", ErrUpstream, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	data := []byte(res.Stdout)
+	if len(data) > max {
+		return nil, fmt.Errorf("%w: file exceeds the transfer limit of %d bytes", ErrBadRequest, max)
+	}
+	sum := sha256.Sum256(data)
+	digest := hex.EncodeToString(sum[:])
+	e.auditE(audit.Entry{
+		Caller: c.ID, Host: host, Serial: res.Serial, Outcome: "file_get",
+		Command: fmt.Sprintf("path=%s bytes=%d sha256=%s", path, len(data), digest),
+	})
+	return &FileTransferResult{Content: data, Size: len(data), SHA256: digest, Serial: res.Serial, Warnings: res.Warnings}, nil
+}

--- a/internal/broker/filetransfer_test.go
+++ b/internal/broker/filetransfer_test.go
@@ -1,0 +1,61 @@
+package broker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// transferTestEngine builds an engine sufficient for the validation paths that
+// fail before any signing or connection is attempted.
+func transferTestEngine(maxBytes int) *Engine {
+	return &Engine{cfg: &Config{FileTransferMaxBytes: maxBytes}}
+}
+
+func TestFileTransferMaxBytesDefault(t *testing.T) {
+	t.Parallel()
+	if got := transferTestEngine(0).FileTransferMaxBytes(); got != DefaultFileTransferMaxBytes {
+		t.Errorf("default cap = %d, want %d", got, DefaultFileTransferMaxBytes)
+	}
+	if got := transferTestEngine(1024).FileTransferMaxBytes(); got != 1024 {
+		t.Errorf("configured cap = %d, want 1024", got)
+	}
+}
+
+func TestPutFileValidation(t *testing.T) {
+	t.Parallel()
+	e := transferTestEngine(8)
+	c := Caller{ID: "test"}
+
+	for name, tc := range map[string]struct {
+		path, mode string
+		content    []byte
+		wantSubstr string
+	}{
+		"empty path":       {path: "", content: []byte("x"), wantSubstr: "path is required"},
+		"null byte":        {path: "/tmp/\x00f", content: []byte("x"), wantSubstr: "null bytes"},
+		"newline in path":  {path: "/tmp/a\nb", content: []byte("x"), wantSubstr: "newline"},
+		"oversized":        {path: "/tmp/f", content: bytes.Repeat([]byte("a"), 9), wantSubstr: "transfer limit is 8"},
+		"bad mode":         {path: "/tmp/f", mode: "rwx", content: []byte("x"), wantSubstr: "invalid mode"},
+		"mode with prefix": {path: "/tmp/f", mode: "u+x", content: []byte("x"), wantSubstr: "invalid mode"},
+	} {
+		_, err := e.PutFile(context.Background(), c, "web01", tc.path, tc.content, tc.mode, 0)
+		if err == nil || !strings.Contains(err.Error(), tc.wantSubstr) {
+			t.Errorf("%s: err = %v, want substring %q", name, err, tc.wantSubstr)
+		}
+		if !errors.Is(err, ErrBadRequest) {
+			t.Errorf("%s: err must wrap ErrBadRequest, got %v", name, err)
+		}
+	}
+}
+
+func TestGetFileValidation(t *testing.T) {
+	t.Parallel()
+	e := transferTestEngine(8)
+	_, err := e.GetFile(context.Background(), Caller{ID: "test"}, "web01", "", 0, 0)
+	if err == nil || !errors.Is(err, ErrBadRequest) {
+		t.Errorf("empty path must be ErrBadRequest, got %v", err)
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -6,9 +6,12 @@
 package mcpserver
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -60,10 +63,11 @@ type executeOutput struct {
 type listInput struct{}
 
 type serverEntry struct {
-	Name      string `json:"name"`
-	AllowSudo bool   `json:"allow_sudo"`
-	AllowPTY  bool   `json:"allow_pty"`
-	Jump      string `json:"jump,omitempty"`
+	Name              string `json:"name"`
+	AllowSudo         bool   `json:"allow_sudo"`
+	AllowPTY          bool   `json:"allow_pty"`
+	AllowFileTransfer bool   `json:"allow_file_transfer"`
+	Jump              string `json:"jump,omitempty"`
 }
 
 type listOutput struct {
@@ -91,12 +95,44 @@ type okOutput struct {
 	OK bool `json:"ok"`
 }
 
+type putFileInput struct {
+	Server        string `json:"server"                   jsonschema:"logical name of the target host (see ssh_list_servers)"`
+	Path          string `json:"path"                     jsonschema:"absolute destination path on the host; the file is created or overwritten"`
+	Content       string `json:"content"                  jsonschema:"file content. Text as-is, or base64 with content_base64=true for binary data."`
+	ContentBase64 bool   `json:"content_base64,omitempty" jsonschema:"if true, content is base64-encoded and is decoded before writing (required for binary files)"`
+	Mode          string `json:"mode,omitempty"           jsonschema:"optional octal permissions to chmod after writing, e.g. 0644 or 0755"`
+	TTLSeconds    int    `json:"ttl_seconds,omitempty"    jsonschema:"ephemeral certificate validity in seconds; omit to use the maximum allowed by the host policy"`
+}
+
+type putFileOutput struct {
+	BytesWritten int      `json:"bytes_written"      jsonschema:"number of bytes written to the remote file"`
+	SHA256       string   `json:"sha256"             jsonschema:"hex sha256 of the written content, recorded in the audit log"`
+	Serial       uint64   `json:"serial"             jsonschema:"audit identifier; ignore when reasoning about the result"`
+	Warnings     []string `json:"warnings,omitempty" jsonschema:"advisory command-policy warnings"`
+}
+
+type getFileInput struct {
+	Server     string `json:"server"                jsonschema:"logical name of the target host (see ssh_list_servers)"`
+	Path       string `json:"path"                  jsonschema:"absolute path of the file to read on the host"`
+	MaxBytes   int    `json:"max_bytes,omitempty"   jsonschema:"read at most this many bytes; a larger file is an error, not a truncation. Omit for the broker's configured limit."`
+	TTLSeconds int    `json:"ttl_seconds,omitempty" jsonschema:"ephemeral certificate validity in seconds; omit to use the maximum allowed by the host policy"`
+}
+
+type getFileOutput struct {
+	Content  string   `json:"content"            jsonschema:"file content: text as-is, or base64 when base64=true (binary file)"`
+	Base64   bool     `json:"base64"             jsonschema:"true when content is base64-encoded because the file is not valid UTF-8 text"`
+	Size     int      `json:"size"               jsonschema:"file size in bytes (decoded)"`
+	SHA256   string   `json:"sha256"             jsonschema:"hex sha256 of the file content, recorded in the audit log"`
+	Serial   uint64   `json:"serial"             jsonschema:"audit identifier; ignore when reasoning about the result"`
+	Warnings []string `json:"warnings,omitempty" jsonschema:"advisory command-policy warnings"`
+}
+
 type sessionOpenOutput struct {
 	SessionID string `json:"session_id"`
 	Serial    uint64 `json:"serial"`
 }
 
-// Register adds the 5 broker tools to the MCP server. callerFn provides the
+// Register adds the 7 broker tools to the MCP server. callerFn provides the
 // caller identity for each invocation (audit and signer RBAC).
 func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
@@ -139,14 +175,16 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			"allow_sudo=false → DO NOT attempt sudo, the signer will reject it. " +
 			"allow_pty=true → the host accepts PTY (pty=true or mode=pty may be used); " +
 			"allow_pty=false → DO NOT attempt PTY. " +
+			"allow_file_transfer=true → ssh_put_file and ssh_get_file may be used; " +
+			"allow_file_transfer=false → DO NOT attempt file transfers, the signer will reject them. " +
 			"jump → name of the bastion through which the host is reached (informational).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listInput) (*mcp.CallToolResult, listOutput, error) {
 		infos := eng.ServerInfos(callerFn(ctx))
 		entries := make([]serverEntry, len(infos))
 		var sb strings.Builder
 		for i, s := range infos {
-			entries[i] = serverEntry{Name: s.Name, AllowSudo: s.AllowSudo, AllowPTY: s.AllowPTY, Jump: s.Jump}
-			fmt.Fprintf(&sb, "%s (sudo=%v pty=%v", s.Name, s.AllowSudo, s.AllowPTY)
+			entries[i] = serverEntry{Name: s.Name, AllowSudo: s.AllowSudo, AllowPTY: s.AllowPTY, AllowFileTransfer: s.AllowFileTransfer, Jump: s.Jump}
+			fmt.Fprintf(&sb, "%s (sudo=%v pty=%v file_transfer=%v", s.Name, s.AllowSudo, s.AllowPTY, s.AllowFileTransfer)
 			if s.Jump != "" {
 				fmt.Fprintf(&sb, " via=%s", s.Jump)
 			}
@@ -213,6 +251,66 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, okOutput{}, nil
 		}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "closed"}}}, okOutput{OK: true}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "ssh_put_file",
+		Description: "Write a file on a Linux host via SSH with an ephemeral credential. " +
+			"Creates or OVERWRITES the destination file with the given content. " +
+			"Use content_base64=true for binary data (the content field is decoded before writing). " +
+			"REQUIRES allow_file_transfer=true on the host (see ssh_list_servers); if false DO NOT retry, the signer will reject it. " +
+			"The write runs as the host's configured SSH user (no sudo); the destination must be writable by that user. " +
+			"On hosts with a command policy the transfer command (cat > path) must also be allowed by the policy. " +
+			"Content is limited by the broker's file_transfer_max_bytes (default 512 KiB). " +
+			"The content's sha256 is recorded in the audit log.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in putFileInput) (*mcp.CallToolResult, putFileOutput, error) {
+		if err := validateInput(map[string]string{"server": in.Server, "path": in.Path, "mode": in.Mode}); err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, putFileOutput{}, nil
+		}
+		content := []byte(in.Content)
+		if in.ContentBase64 {
+			decoded, err := base64.StdEncoding.DecodeString(in.Content)
+			if err != nil {
+				return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: "invalid base64 content: " + err.Error()}}}, putFileOutput{}, nil
+			}
+			content = decoded
+		}
+		res, err := eng.PutFile(ctx, callerFn(ctx), in.Server, in.Path, content, in.Mode, in.TTLSeconds)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, putFileOutput{}, nil
+		}
+		out := putFileOutput{BytesWritten: res.Size, SHA256: res.SHA256, Serial: res.Serial, Warnings: res.Warnings}
+		text := fmt.Sprintf("wrote %d bytes to %s (sha256=%s) [serial=%d]", res.Size, in.Path, res.SHA256, res.Serial)
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, out, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "ssh_get_file",
+		Description: "Read a file from a Linux host via SSH with an ephemeral credential. " +
+			"Returns the content as text, or base64 (base64=true in the result) when the file is not valid UTF-8. " +
+			"REQUIRES allow_file_transfer=true on the host (see ssh_list_servers); if false DO NOT retry, the signer will reject it. " +
+			"The read runs as the host's configured SSH user (no sudo); the file must be readable by that user. " +
+			"A file larger than max_bytes (default: the broker's file_transfer_max_bytes, 512 KiB) is an ERROR, not a truncation. " +
+			"The content's sha256 is recorded in the audit log.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getFileInput) (*mcp.CallToolResult, getFileOutput, error) {
+		if err := validateInput(map[string]string{"server": in.Server, "path": in.Path}); err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, getFileOutput{}, nil
+		}
+		res, err := eng.GetFile(ctx, callerFn(ctx), in.Server, in.Path, in.MaxBytes, in.TTLSeconds)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, getFileOutput{}, nil
+		}
+		out := getFileOutput{Size: res.Size, SHA256: res.SHA256, Serial: res.Serial, Warnings: res.Warnings}
+		var text string
+		if utf8.Valid(res.Content) && !bytes.ContainsRune(res.Content, 0) {
+			out.Content = string(res.Content)
+			text = out.Content + fmt.Sprintf("\n[%d bytes sha256=%s serial=%d]", res.Size, res.SHA256, res.Serial)
+		} else {
+			out.Content = base64.StdEncoding.EncodeToString(res.Content)
+			out.Base64 = true
+			text = fmt.Sprintf("[binary content: %d bytes, returned base64-encoded; sha256=%s serial=%d]", res.Size, res.SHA256, res.Serial)
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, out, nil
 	})
 }
 

--- a/internal/signer/remote.go
+++ b/internal/signer/remote.go
@@ -40,6 +40,10 @@ type WireRequest struct {
 	// PTY: requests permit-pty in the certificate.
 	PTY bool `json:"pty,omitempty"`
 
+	// FileTransfer marks the request as a file transfer (ssh_put_file /
+	// ssh_get_file); the host policy must have allow_file_transfer=true.
+	FileTransfer bool `json:"file_transfer,omitempty"`
+
 	// DryRun: resolves the policy and returns the decision without issuing a
 	// usable cert.
 	DryRun bool `json:"dry_run,omitempty"`
@@ -104,8 +108,9 @@ type WireHostInfo struct {
 	HostKey string `json:"host_key"`
 	Jump    string `json:"jump,omitempty"`
 	// Capabilities: tells the broker (and the model) which operations are allowed.
-	AllowSudo bool `json:"allow_sudo,omitempty"`
-	AllowPTY  bool `json:"allow_pty,omitempty"`
+	AllowSudo         bool `json:"allow_sudo,omitempty"`
+	AllowPTY          bool `json:"allow_pty,omitempty"`
+	AllowFileTransfer bool `json:"allow_file_transfer,omitempty"`
 	// Groups are the RBAC groups the host belongs to, so the broker can filter
 	// the host list it shows to an end user by the user's OIDC groups —
 	// consistent with the per-user check the signer applies at signing time.
@@ -117,13 +122,14 @@ type WireHostInfo struct {
 // HostInfo is the broker's internal representation of connectivity and
 // capability data received from the signer.
 type HostInfo struct {
-	Addr      string
-	User      string
-	HostKey   string
-	Jump      string
-	AllowSudo bool
-	AllowPTY  bool
-	Groups    []string
+	Addr              string
+	User              string
+	HostKey           string
+	Jump              string
+	AllowSudo         bool
+	AllowPTY          bool
+	AllowFileTransfer bool
+	Groups            []string
 }
 
 // Remote delegates signing to the external service via HTTP+mTLS. It can talk
@@ -165,6 +171,7 @@ func (r *Remote) SignIntent(ctx context.Context, in Intent) (*Issued, error) {
 		Sudo:          in.Sudo,
 		SudoUser:      in.SudoUser,
 		PTY:           in.PTY,
+		FileTransfer:  in.FileTransfer,
 		DryRun:        in.DryRun,
 		Preflight:     in.Preflight,
 		OnBehalfOf:    in.OnBehalfOf,
@@ -318,13 +325,14 @@ func (r *Remote) FetchHosts(ctx context.Context, onBehalfOf string) (map[string]
 	hosts := make(map[string]HostInfo, len(wire))
 	for name, h := range wire {
 		hosts[name] = HostInfo{
-			Addr:      h.Addr,
-			User:      h.User,
-			HostKey:   h.HostKey,
-			Jump:      h.Jump,
-			AllowSudo: h.AllowSudo,
-			AllowPTY:  h.AllowPTY,
-			Groups:    h.Groups,
+			Addr:              h.Addr,
+			User:              h.User,
+			HostKey:           h.HostKey,
+			Jump:              h.Jump,
+			AllowSudo:         h.AllowSudo,
+			AllowPTY:          h.AllowPTY,
+			AllowFileTransfer: h.AllowFileTransfer,
+			Groups:            h.Groups,
 		}
 	}
 	return hosts, nil

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -63,6 +63,11 @@ type Intent struct {
 	// PTY: requests permit-pty in the certificate.
 	PTY bool
 
+	// FileTransfer marks the intent as a file transfer (ssh_put_file /
+	// ssh_get_file): the host policy must have allow_file_transfer=true or the
+	// request is rejected. The transfer command itself travels in Command.
+	FileTransfer bool
+
 	// DryRun: if true, the signer resolves the policy and returns the decision
 	// (DecisionInfo) WITHOUT issuing a usable certificate. Allows the model to
 	// preview whether a command would be allowed / require approval before running.
@@ -207,6 +212,12 @@ type HostPolicy struct {
 	// AllowPTY authorises the permit-pty extension in certificates for this host.
 	// If false, PTY requests are rejected.
 	AllowPTY bool `json:"allow_pty,omitempty"`
+
+	// AllowFileTransfer authorises the file-transfer tools (ssh_put_file /
+	// ssh_get_file) for this host. If false (the default — secure by default),
+	// signing requests flagged file_transfer are rejected. The generated
+	// transfer command is still subject to the host's command policy.
+	AllowFileTransfer bool `json:"allow_file_transfer,omitempty"`
 
 	// Groups lists the RBAC groups this host belongs to. A caller restricted by
 	// groups can only access hosts that share at least one of its allowed_groups.
@@ -357,6 +368,10 @@ func (p PolicyTable) resolve(in Intent, defaultMaxTTL time.Duration, grants Gran
 
 	if in.PTY && !hp.AllowPTY {
 		return Decision{}, fmt.Errorf("host %q does not allow PTY (allow_pty=false)", in.Host)
+	}
+
+	if in.FileTransfer && !hp.AllowFileTransfer {
+		return Decision{}, fmt.Errorf("host %q does not allow file transfer (allow_file_transfer=false)", in.Host)
 	}
 
 	cp, err := resolveCommandPolicy(hp, in, grants)

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -45,6 +45,40 @@ func TestResolveTargetOneshot(t *testing.T) {
 	}
 }
 
+func TestResolveFileTransferGate(t *testing.T) {
+	t.Parallel()
+	p := PolicyTable{
+		"ft":   {Principal: "host:ft", MaxTTL: 2 * time.Minute, AllowFileTransfer: true},
+		"noft": {Principal: "host:noft", MaxTTL: 2 * time.Minute},
+	}
+	// Denied by default: allow_file_transfer=false rejects the intent.
+	_, err := p.Resolve(Intent{
+		Caller: "x", Host: "noft", Role: RoleTarget, Purpose: PurposeOneshot,
+		Command: "cat > '/tmp/f'", FileTransfer: true, RequestedTTL: time.Minute,
+	}, 5*time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "allow_file_transfer=false") {
+		t.Fatalf("file transfer on a non-allowed host must be rejected, got err=%v", err)
+	}
+	// Allowed when the host opts in.
+	d, err := p.Resolve(Intent{
+		Caller: "x", Host: "ft", Role: RoleTarget, Purpose: PurposeOneshot,
+		Command: "cat > '/tmp/f'", FileTransfer: true, RequestedTTL: time.Minute,
+	}, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("file transfer on an allowed host must pass: %v", err)
+	}
+	if d.Constraints.ForceCommand != "cat > '/tmp/f'" {
+		t.Errorf("force-command = %q, want the transfer command", d.Constraints.ForceCommand)
+	}
+	// A plain exec on the same host is unaffected by the gate.
+	if _, err := p.Resolve(Intent{
+		Caller: "x", Host: "noft", Role: RoleTarget, Purpose: PurposeOneshot,
+		Command: "uptime", RequestedTTL: time.Minute,
+	}, 5*time.Minute); err != nil {
+		t.Errorf("non-transfer exec must not be gated: %v", err)
+	}
+}
+
 func TestResolveSessionNoForceCommand(t *testing.T) {
 	t.Parallel()
 	d, _ := testPolicy().Resolve(Intent{

--- a/internal/ssh/run.go
+++ b/internal/ssh/run.go
@@ -212,6 +212,9 @@ type ExecOptions struct {
 	Cols uint32
 	// Timeout caps the remote command wait (A3). 0 = defaultExecTimeout.
 	Timeout time.Duration
+	// Stdin, when non-empty, is streamed to the remote command's standard
+	// input (8-bit clean; used by file uploads). Ignored with PTY.
+	Stdin []byte
 }
 
 // defaultPTYTerm is the default terminal type.
@@ -289,6 +292,9 @@ func ExecOnce(ctx context.Context, client *ssh.Client, command string, opts ...E
 	stderr.max = maxOutputBytes
 	session.Stdout = &stdout
 	session.Stderr = &stderr
+	if len(o.Stdin) > 0 {
+		session.Stdin = bytes.NewReader(o.Stdin)
+	}
 
 	runErr, completed := runWithTimeout(ctx, session, command, execTimeout)
 	if !completed {

--- a/signer.example.json
+++ b/signer.example.json
@@ -85,7 +85,9 @@
       "groups": ["prod-web"],
       "_sudo_comment": "Enables sudo to root only (empty allowed_sudo_users implies root only).",
       "allow_sudo": true,
-      "allow_pty": true
+      "allow_pty": true,
+      "_file_transfer_comment": "Enables ssh_put_file / ssh_get_file on this host (default false — secure by default). Transfers run as the SSH user (no sudo) and the generated command (cat > path / bounded read) is still subject to command_policy.",
+      "allow_file_transfer": true
     },
     "web02": {
       "principal": "host:web02",


### PR DESCRIPTION
Closes #26 — the MCP tool surface was exec-only.

## What

Two new tools on the existing one-shot certificate machinery (no SFTP, no new dependency):

- **`ssh_put_file`** — force-command `cat > 'path'` (+ optional `chmod`), content streamed over stdin; binary via `content_base64`.
- **`ssh_get_file`** — bounded `head -c max+1 < 'path'`; oversize = error (not truncation); non-UTF-8 returned base64.

## Security posture

- Per-host gate **`allow_file_transfer`, default false** (signer HostPolicy + broker local HostConfig), enforced at signing time via the new `file_transfer` intent/wire flag — 403 like the sudo/PTY gates, `ft=1` in the signer audit token stream.
- Capability visible in `GET /v1/hosts`, `ssh_list_servers`, `broker-ctl host list` (FT column); set with `broker-ctl host add --file-transfer`.
- Transfer commands remain subject to `command_policy` (a `shell_parse` enforce policy rejects the redirects — deliberately conservative, documented).
- `file_transfer_max_bytes` caps size (default 512 KiB); transfers run as the SSH user, no sudo in v1.
- Audit: `file_put`/`file_get` entries with path, size, sha256, serial-correlated with the `executed` entry.

## Docs

USAGE §9 + list-servers table + quick reference + audit outcomes, API.md (tool specs, `/v1/sign` `file_transfer` field, `/v1/hosts` capability, 403 row), OPERATIONS flag table, examples, CHANGELOG v1.27.0, regenerated `docs/reference/{mcp-tools,config}.md`.

## Tests

Signer: `Resolve` file-transfer gate (deny default / allow opt-in / plain exec unaffected). Broker: path/mode/size validation, cap defaults. Full `gofmt`/`go vet`/`go test -race ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)