### PR TITLE
feat: production deployment (systemd units, installer, make dist, agent deploy skill)

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: deploy
+description: Deploy ssh-broker to production (or upgrade an existing install) using make dist + deploy/install.sh, with preflight policy checks, operator choice of CA custody (Azure Key Vault vs local PEM), and post-deploy health verification. Use when the user asks to deploy, release, install as a service, or upgrade ssh-broker on a host.
+---
+
+# Deploy ssh-broker to production
+
+The deterministic mechanics live in the repo — `make dist`, `deploy/install.sh`,
+the systemd units in `deploy/systemd/` and the checklist in `deploy/README.md`.
+This skill adds the judgment layer: what to verify before, what to ask the
+operator, and how to confirm the deployment is healthy after.
+
+## 0. Scope the deployment
+
+Ask (or infer from the request) before doing anything:
+
+- **Which services on which host?** `signer` (CA custody — ideally its own
+  host), `control-plane` (approvals), `mcp-http` (remote MCP frontend). The
+  stdio `mcp-broker` is launched by the MCP client and is never deployed as a
+  service.
+- **Fresh install or upgrade?** An upgrade replaces binaries + units and keeps
+  `/etc/ssh-broker/*.json`; a fresh install seeds configs from the examples
+  that MUST be edited before starting.
+- **Local or remote target?** The installer runs as root ON the target host.
+  For a remote target: `make dist`, copy the tarball with scp, then run the
+  installer over ssh.
+
+## 1. CA custody — the operator chooses
+
+This is an explicit decision the user must make; never default silently.
+Set in `signer.json` → `ca_keys` (`"_default"` = global; per-group keys
+override). Backends supported by the code (`internal/ca/loader.go`):
+
+- **`akv` (Azure Key Vault) — recommended for production.** The private key
+  never leaves the vault. Needs `vault_url` + `key_name`. Auth via
+  `DefaultAzureCredential`: managed identity needs nothing; a service
+  principal needs `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`
+  in `/etc/ssh-broker/signer.env` (0600 root, loaded by the unit).
+  **Constraint:** AKV has no Ed25519 — the CA will be RSA or EC, and the
+  managed hosts' `TrustedUserCAKeys` must carry that public key
+  (`az keyvault key download` + `ssh-keygen -i -m PKCS8`).
+- **`pem` (local file) — lab/dev only.** The signer logs a warning at startup.
+  If the user picks this for production, warn once about the threat model
+  (key readable on disk) and respect their choice.
+
+If the user hasn't stated a preference, ask which backend to use, presenting
+exactly this trade-off.
+
+## 2. Preflight (before touching the target)
+
+Run from the repo:
+
+- `make test` and `make docs-check` pass (docs-check also validates the
+  example configs against the structs).
+- `make version` — confirm the tag you are about to ship; a `-dirty` suffix
+  means uncommitted changes: stop and ask.
+- Review the real config that will run (existing `/etc/ssh-broker/*.json` on
+  upgrade, or the edited seed on fresh install) for production posture:
+  - `callers` contains `"_default": {"allowed_groups": []}` — default-deny.
+    Its absence is the #1 fail-open misconfiguration; flag it.
+  - `sign_rate_limit_per_min` set (> 0).
+  - `monitor_listen` bound to localhost/private interface, never public.
+  - Cert/key paths are ABSOLUTE (`/etc/ssh-broker/pki/...`); a relative
+    `audit_log` is fine (lands in `/var/lib/ssh-broker/<svc>/`).
+  - Every host with `"jump"` shares a group with its bastion.
+
+## 3. Install
+
+```bash
+make dist                                   # dist/ssh-broker-<version>.tar.gz
+# remote target:
+scp dist/ssh-broker-<v>.tar.gz host:  &&  ssh host 'tar xzf ssh-broker-<v>.tar.gz'
+sudo ./deploy/install.sh [--services "..."]
+```
+
+Idempotent; never overwrites an existing real config. On a fresh install,
+edit `/etc/ssh-broker/*.json` and place the mTLS PKI before starting.
+
+## 4. Start / apply
+
+- **Order matters:** signer first, then control-plane / mcp-http
+  (`systemctl enable --now ssh-broker-signer`, then the rest).
+- **Upgrade of an already-running install:** decide reload vs restart.
+  Policy-only changes (hosts, callers, command policies, CA keys) →
+  `systemctl reload ssh-broker-signer` (SIGHUP), no downtime. New binaries,
+  `listen`, TLS material or `audit_log` → restart. Warn before restarting:
+  control-plane restart drops pending approvals and the behaviour baseline;
+  mcp-http restart drops live MCP sessions.
+
+## 5. Verify
+
+- `systemctl status` on each installed unit; `journalctl -u <unit> -n 20`
+  clean of errors. With `pem` custody a CA warning line is expected.
+- `curl -s http://127.0.0.1:9160/healthz` (signer monitor) and the
+  control-plane equivalent (`:9170` by default).
+- End-to-end: `broker-ctl host list` from a machine holding a valid broker
+  mTLS cert — proves TLS, RBAC and policy load in one shot.
+- `signer --version` matches the tag shipped in step 2.
+
+Report what was deployed (services, host, version, custody backend) and any
+checklist deviations the operator accepted.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ medium.txt
 # Sitio de documentación generado por MkDocs y entorno de la toolchain de docs
 /site/
 .venv/
+
+# Tarballs de release (make dist)
+/dist/
+
+# Configuración local de la sesión del agente (permisos por máquina, no versionar)
+.claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 #   make test          # go test -race ./...
 #   make fmt vet       # gofmt -l / go vet
 #   make version       # print the version that would be embedded
+#   make dist          # release tarball: binaries + deploy/ + example configs
 #   make docs-gen      # regenerate docs/reference/ from code
 #   make docs-check    # gen + drift checks + strict site build (CI gate, run before pushing)
 #   make docs-serve    # live-preview the site at 127.0.0.1:8000
@@ -19,7 +20,7 @@ CMDS    := signer broker broker-ctl mcp-broker mcp-broker-http control-plane
 # MkDocs runner: prefer a local mkdocs, else fall back to `python3 -m mkdocs`.
 MKDOCS  ?= $(shell command -v mkdocs 2>/dev/null || echo "python3 -m mkdocs")
 
-.PHONY: build install $(CMDS) test fmt vet version clean docs docs-gen docs-serve docs-check
+.PHONY: build install $(CMDS) test fmt vet version clean dist docs docs-gen docs-serve docs-check
 
 build: $(CMDS)
 install: build
@@ -41,6 +42,22 @@ version:
 
 clean:
 	rm -f $(addprefix $(BINDIR)/,$(CMDS))
+	rm -rf dist
+
+# Release tarball for deploy/install.sh: dist/ssh-broker-<version>/ with the
+# binaries under bin/, the deploy artifacts (systemd units + installer) and
+# the example configs the installer seeds /etc/ssh-broker from.
+DISTDIR := dist/ssh-broker-$(VERSION)
+
+dist:
+	rm -rf $(DISTDIR)
+	mkdir -p $(DISTDIR)/bin
+	$(MAKE) build BINDIR=$(abspath $(DISTDIR)/bin)
+	cp -r deploy $(DISTDIR)/
+	cp signer.example.json control-plane.example.json config.example.json \
+	   LICENSE README.md $(DISTDIR)/
+	tar -C dist -czf dist/ssh-broker-$(VERSION).tar.gz ssh-broker-$(VERSION)
+	@echo "dist/ssh-broker-$(VERSION).tar.gz"
 
 # ── Documentation (GitHub Pages, with anti-drift generation) ──────────────────
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,129 @@
+# Production deployment
+
+Artifacts to run ssh-broker as system services. For day-2 operations
+(adding hosts, hot reload, PKI, monitoring) see `docs/OPERATIONS.md`; for
+what to harden and why, `docs/THREAT_MODEL.md`.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `systemd/ssh-broker-signer.service` | Signing service — CA custody + issuance policy |
+| `systemd/ssh-broker-control-plane.service` | Approvals + behaviour guardrails |
+| `systemd/ssh-broker-mcp-http.service` | Remote MCP frontend (Streamable HTTP + OIDC) |
+| `install.sh` | Idempotent installer (run as root on the target host) |
+| `sshd_config.snippet` | Configuration for the *managed* hosts' sshd |
+
+The local stdio frontend (`cmd/mcp-broker`) needs no unit: the MCP client
+launches it on connect.
+
+## Quick start
+
+```bash
+# On a build machine
+make dist                                  # → dist/ssh-broker-<version>.tar.gz
+
+# On the target host
+tar xzf ssh-broker-<version>.tar.gz && cd ssh-broker-<version>
+sudo ./deploy/install.sh                   # everything; or --services "signer"
+```
+
+The installer creates the `ssh-broker` system user, installs binaries to
+`/usr/local/bin`, configs to `/etc/ssh-broker/` (never overwriting an
+existing one) and the units to `/etc/systemd/system`. It does **not** start
+anything: a fresh config still points at example values.
+
+## Reference layout
+
+```
+/usr/local/bin/{signer,control-plane,mcp-broker-http,broker-ctl}
+/etc/ssh-broker/{signer.json,control-plane.json,config.json}   root:ssh-broker 0640
+/etc/ssh-broker/pki/                                           mTLS certs/keys
+/etc/ssh-broker/signer.env                                     optional AZURE_* creds (0600 root)
+/var/lib/ssh-broker/<svc>/                                     audit logs (StateDirectory)
+```
+
+Configs must use **absolute** paths for certs/keys; a relative `audit_log`
+resolves under `/var/lib/ssh-broker/<svc>/` (the unit's WorkingDirectory),
+which is where audit logs belong.
+
+## Choosing CA custody
+
+The CA custody backend is **the operator's choice**, made in `signer.json`
+under `ca_keys` (globally with the reserved `_default` key, and optionally
+per group):
+
+| | `"akv"` — Azure Key Vault | `"pem"` — local file |
+|---|---|---|
+| Private key exposure | Never leaves the vault; broker/signer compromise cannot exfiltrate it | On disk; readable by the signer process |
+| Key types | RSA 2048/3072/4096, EC P-256/P-384/P-521 (no Ed25519) | Any OpenSSH type, incl. Ed25519 |
+| Credentials | `DefaultAzureCredential`: managed identity (recommended, zero config) or service principal via `/etc/ssh-broker/signer.env` | — |
+| Intended use | **Production** | Lab/dev (the signer logs a warning) |
+
+```jsonc
+// signer.json — production (AKV)
+"ca_keys": {
+  "_default": { "type": "akv", "vault_url": "https://my-vault.vault.azure.net", "key_name": "ssh-ca" }
+}
+
+// signer.json — lab (PEM)
+"ca_keys": {
+  "_default": { "type": "pem", "path": "/etc/ssh-broker/pki/ssh_ca" }
+}
+```
+
+With AKV, the managed hosts still need the CA **public** key in OpenSSH
+format for `TrustedUserCAKeys`:
+
+```bash
+az keyvault key download --vault-name my-vault -n ssh-ca -f ca.pem
+ssh-keygen -i -m PKCS8 -f ca.pem > /etc/ssh/ca_prod.pub
+```
+
+Service-principal credentials go in `/etc/ssh-broker/signer.env`
+(`0600 root:root`, loaded by the unit's `EnvironmentFile=`):
+
+```
+AZURE_TENANT_ID=...
+AZURE_CLIENT_ID=...
+AZURE_CLIENT_SECRET=...
+```
+
+## Production checklist
+
+- [ ] `signer.json` `callers` has `"_default": {"allowed_groups": []}` — default-deny for unknown broker CNs.
+- [ ] `sign_rate_limit_per_min` set (size to the busiest legitimate broker).
+- [ ] CA custody is `akv` (or another KMS); `pem` only in a lab.
+- [ ] mTLS PKI in `/etc/ssh-broker/pki`, keys `0640 root:ssh-broker`.
+- [ ] `monitor_listen` bound to localhost or a private scrape interface — never public.
+- [ ] Signer ideally on a separate host from the broker (see THREAT_MODEL.md).
+- [ ] Single instance per service: session/approval/behaviour state is in-memory.
+- [ ] Managed hosts configured per `sshd_config.snippet` (TrustedUserCAKeys, principals, sudoers).
+
+## Order and verification
+
+```bash
+sudo systemctl enable --now ssh-broker-signer        # always first
+sudo systemctl enable --now ssh-broker-control-plane # if installed
+sudo systemctl enable --now ssh-broker-mcp-http      # if installed
+
+curl -s http://127.0.0.1:9160/healthz                # signer liveness (monitor_listen)
+broker-ctl host list                                 # end-to-end: mTLS + policy load
+journalctl -u ssh-broker-signer -f                   # logs go to the journal
+```
+
+Policy changes (`hosts`, `callers`, `command_policies`, CA keys) do **not**
+need a restart: `sudo systemctl reload ssh-broker-signer` (SIGHUP), or
+`broker-ctl reload`, or `auto_reload_seconds`. Only `listen`, TLS material
+and `audit_log` require a restart.
+
+## Upgrades
+
+```bash
+sudo ./deploy/install.sh          # replaces binaries + units, keeps configs
+sudo systemctl restart ssh-broker-signer ssh-broker-control-plane ssh-broker-mcp-http
+signer --version                  # verify the embedded version
+```
+
+Restarting the control plane clears pending approvals and the behaviour
+baseline; restarting mcp-http drops live MCP sessions. Plan accordingly.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ssh-broker production installer (idempotent). Run as root ON THE TARGET HOST.
+#
+# Installs the selected services following the reference layout of the systemd
+# units in deploy/systemd/:
+#
+#   /usr/local/bin/{signer,control-plane,mcp-broker-http,broker-ctl}
+#   /etc/ssh-broker/            configs (0750 root:ssh-broker)
+#   /etc/ssh-broker/pki/        mTLS certs and keys (0750; keys 0640)
+#   /var/lib/ssh-broker/<svc>/  state and audit logs (created by systemd)
+#
+# Existing real configs are NEVER overwritten; *.example.json references are
+# refreshed on every run. Re-running after an upgrade replaces binaries and
+# units only.
+#
+# Usage:
+#   ./install.sh [--services "signer control-plane mcp-http"]
+#                [--src DIR]      # tree with bin/ and configs (default: auto)
+#                [--bindir DIR]   # default /usr/local/bin
+#                [--enable]       # systemctl enable the installed units
+#                [--start]        # implies --enable, also starts them
+#
+# The signer must be reachable before control-plane/mcp-http start, and the
+# choice of CA custody (pem vs akv) is made in signer.json — see
+# deploy/README.md before starting anything.
+
+set -euo pipefail
+
+SERVICES="signer control-plane mcp-http"
+BINDIR="/usr/local/bin"
+ETCDIR="/etc/ssh-broker"
+SRC=""
+ENABLE=0
+START=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --services) SERVICES="$2"; shift 2 ;;
+        --src)      SRC="$2";      shift 2 ;;
+        --bindir)   BINDIR="$2";   shift 2 ;;
+        --enable)   ENABLE=1;      shift ;;
+        --start)    ENABLE=1; START=1; shift ;;
+        -h|--help)  sed -n '2,/^set -euo/{/^#/s/^# \{0,1\}//p}' "$0"; exit 0 ;;
+        *) echo "unknown option: $1 (see --help)" >&2; exit 2 ;;
+    esac
+done
+
+[[ $(id -u) -eq 0 ]] || { echo "must run as root" >&2; exit 1; }
+
+# Locate the source tree: a dist tarball has deploy/install.sh with bin/ and
+# the example configs at its root; in a git checkout binaries come from
+# `make build BINDIR=<repo>/bin` (or pass --src).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SRC:-$(dirname "${SCRIPT_DIR}")}"
+[[ -d "${ROOT}/bin" ]] || {
+    echo "no bin/ under ${ROOT}. Build a dist tree first (make dist) or pass --src DIR" >&2
+    exit 1
+}
+
+# Map service name -> binary : config-basename : unit.
+svc_binary()  { case "$1" in signer) echo signer ;; control-plane) echo control-plane ;; mcp-http) echo mcp-broker-http ;; esac; }
+svc_config()  { case "$1" in signer) echo signer.json ;; control-plane) echo control-plane.json ;; mcp-http) echo config.json ;; esac; }
+svc_unit()    { case "$1" in signer) echo ssh-broker-signer.service ;; control-plane) echo ssh-broker-control-plane.service ;; mcp-http) echo ssh-broker-mcp-http.service ;; esac; }
+
+for svc in ${SERVICES}; do
+    [[ -n "$(svc_binary "${svc}")" ]] || { echo "unknown service '${svc}' (valid: signer control-plane mcp-http)" >&2; exit 2; }
+done
+
+# 1. System user (no shell, no home login).
+if ! getent group ssh-broker >/dev/null; then
+    groupadd --system ssh-broker
+    echo "created group ssh-broker"
+fi
+if ! getent passwd ssh-broker >/dev/null; then
+    useradd --system --gid ssh-broker --home-dir /var/lib/ssh-broker \
+            --no-create-home --shell /usr/sbin/nologin ssh-broker
+    echo "created user ssh-broker"
+fi
+
+# 2. Config directories. Configs stay root-owned; the group may read them.
+install -d -m 0750 -o root -g ssh-broker "${ETCDIR}" "${ETCDIR}/pki"
+
+# 3. Binaries (broker-ctl always: it is the admin CLI).
+install -d "${BINDIR}"
+for svc in ${SERVICES}; do
+    bin="$(svc_binary "${svc}")"
+    install -m 0755 "${ROOT}/bin/${bin}" "${BINDIR}/${bin}"
+    echo "installed ${BINDIR}/${bin}"
+done
+if [[ -f "${ROOT}/bin/broker-ctl" ]]; then
+    install -m 0755 "${ROOT}/bin/broker-ctl" "${BINDIR}/broker-ctl"
+    echo "installed ${BINDIR}/broker-ctl"
+fi
+
+# 4. Configs: refresh the .example reference, never touch a real config.
+for svc in ${SERVICES}; do
+    cfg="$(svc_config "${svc}")"
+    example="${ROOT}/${cfg%.json}.example.json"
+    if [[ -f "${example}" ]]; then
+        install -m 0640 -o root -g ssh-broker "${example}" "${ETCDIR}/${cfg}.example"
+        if [[ ! -f "${ETCDIR}/${cfg}" ]]; then
+            install -m 0640 -o root -g ssh-broker "${example}" "${ETCDIR}/${cfg}"
+            echo "installed ${ETCDIR}/${cfg} (from example — EDIT BEFORE STARTING)"
+        fi
+    fi
+done
+
+# 5. systemd units.
+for svc in ${SERVICES}; do
+    unit="$(svc_unit "${svc}")"
+    install -m 0644 "${SCRIPT_DIR}/systemd/${unit}" "/etc/systemd/system/${unit}"
+    echo "installed /etc/systemd/system/${unit}"
+done
+systemctl daemon-reload
+
+# 6. Enable/start only on request: a fresh install has configs that still
+# point at example values and an empty pki/.
+for svc in ${SERVICES}; do
+    unit="$(svc_unit "${svc}")"
+    [[ ${ENABLE} -eq 1 ]] && systemctl enable "${unit}"
+    [[ ${START}  -eq 1 ]] && systemctl restart "${unit}"
+done
+
+cat <<EOF
+
+Done. Before starting (see deploy/README.md for the full checklist):
+
+ 1. Edit ${ETCDIR}/*.json — use ABSOLUTE paths (${ETCDIR}/pki/...) for
+    certs/keys; relative audit_log paths land in /var/lib/ssh-broker/<svc>/.
+ 2. Choose CA custody in signer.json (ca_keys._default.type):
+      "akv"  Azure Key Vault (production; credentials via managed identity or
+             ${ETCDIR}/signer.env with AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET)
+      "pem"  local key file (lab/dev only)
+ 3. Place the mTLS PKI under ${ETCDIR}/pki (keys 0640 root:ssh-broker).
+ 4. Production hardening: callers should contain "_default": {"allowed_groups": []}
+    (default-deny) and sign_rate_limit_per_min should be set.
+ 5. systemctl enable --now ssh-broker-signer   # signer first, then the rest
+EOF

--- a/deploy/systemd/ssh-broker-control-plane.service
+++ b/deploy/systemd/ssh-broker-control-plane.service
@@ -1,0 +1,63 @@
+# ssh-broker control plane (cmd/control-plane).
+#
+# Sits between brokers and the signer: forwards signing requests propagating
+# the broker identity (on_behalf_of), orchestrates human approval, and applies
+# per-agent behaviour guardrails. Does NOT hold the CA key. Reference layout:
+#
+#   binary   /usr/local/bin/control-plane
+#   config   /etc/ssh-broker/control-plane.json (root:ssh-broker 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/               (root:ssh-broker 0750, keys 0640)
+#   state    /var/lib/ssh-broker/control-plane/ (audit log; created via StateDirectory)
+#
+# Use ABSOLUTE paths in control-plane.json for certs/keys. Relative paths (the
+# default audit_log) resolve under WorkingDirectory. Approval/behaviour state
+# is in-memory: a restart clears pending approvals and the behaviour baseline.
+
+[Unit]
+Description=ssh-broker control plane (approvals and behaviour guardrails)
+Documentation=https://github.com/luisgf/ssh-broker
+After=network-online.target
+Wants=network-online.target
+# Same-host deployments: start after the signer. Harmless if the signer is remote.
+After=ssh-broker-signer.service
+
+[Service]
+Type=simple
+User=ssh-broker
+Group=ssh-broker
+ExecStart=/usr/local/bin/control-plane -config /etc/ssh-broker/control-plane.json
+WorkingDirectory=/var/lib/ssh-broker/control-plane
+StateDirectory=ssh-broker/control-plane
+StateDirectoryMode=0750
+EnvironmentFile=-/etc/ssh-broker/control-plane.env
+Restart=on-failure
+RestartSec=2
+
+# Sandboxing: read /etc/ssh-broker, write its state dir, listen on its mTLS
+# port, outbound HTTPS to the signer and (optionally) webhook/Teams notifiers.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/ssh-broker-mcp-http.service
+++ b/deploy/systemd/ssh-broker-mcp-http.service
@@ -1,0 +1,65 @@
+# ssh-broker remote MCP frontend (cmd/mcp-broker-http).
+#
+# Exposes the broker as a remote MCP server over Streamable HTTP protected
+# with OAuth2/OIDC. For multi-user network deployments; the local stdio
+# frontend (cmd/mcp-broker) is launched by the MCP client instead and needs
+# no unit. Reference layout:
+#
+#   binary   /usr/local/bin/mcp-broker-http
+#   config   /etc/ssh-broker/config.json       (root:ssh-broker 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/               (root:ssh-broker 0750, keys 0640)
+#   state    /var/lib/ssh-broker/mcp-http/      (audit log; created via StateDirectory)
+#
+# Use ABSOLUTE paths in config.json for certs/keys. Relative paths (the
+# default audit_log) resolve under WorkingDirectory. Session state is
+# in-memory per process: run a single instance (see THREAT_MODEL.md).
+
+[Unit]
+Description=ssh-broker remote MCP server (Streamable HTTP + OIDC)
+Documentation=https://github.com/luisgf/ssh-broker
+After=network-online.target
+Wants=network-online.target
+# Same-host deployments: the broker requires the signer at startup (GET /v1/hosts).
+After=ssh-broker-signer.service
+
+[Service]
+Type=simple
+User=ssh-broker
+Group=ssh-broker
+ExecStart=/usr/local/bin/mcp-broker-http -config /etc/ssh-broker/config.json
+WorkingDirectory=/var/lib/ssh-broker/mcp-http
+StateDirectory=ssh-broker/mcp-http
+StateDirectoryMode=0750
+EnvironmentFile=-/etc/ssh-broker/mcp-http.env
+Restart=on-failure
+RestartSec=2
+
+# Sandboxing: read /etc/ssh-broker, write its state dir, listen on its HTTP
+# port, outbound to signer/control-plane, the OIDC issuer (JWKS) and SSH
+# target hosts (port 22).
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/ssh-broker-signer.service
+++ b/deploy/systemd/ssh-broker-signer.service
@@ -1,0 +1,70 @@
+# ssh-broker signing service (cmd/signer).
+#
+# Holds the CA key (or the AKV client when ca_keys uses type "akv") and the
+# issuance policy. In the reference layout:
+#
+#   binary   /usr/local/bin/signer
+#   config   /etc/ssh-broker/signer.json        (root:ssh-broker 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/               (root:ssh-broker 0750, keys 0640)
+#   state    /var/lib/ssh-broker/signer/        (audit log; created via StateDirectory)
+#
+# Use ABSOLUTE paths in signer.json for certs/keys under /etc/ssh-broker/pki.
+# Relative paths (e.g. the default audit_log "signer_audit.log") resolve under
+# WorkingDirectory, i.e. /var/lib/ssh-broker/signer — that is intentional.
+#
+# CA custody is chosen in signer.json (ca_keys._default.type):
+#   "pem"  local key file — lab/dev only, the signer logs a warning.
+#   "akv"  Azure Key Vault — private key never leaves the vault. Credentials
+#          come from DefaultAzureCredential: managed identity needs nothing
+#          extra; a service principal takes AZURE_TENANT_ID / AZURE_CLIENT_ID /
+#          AZURE_CLIENT_SECRET from the optional environment file below.
+
+[Unit]
+Description=ssh-broker signing service (CA custody and issuance policy)
+Documentation=https://github.com/luisgf/ssh-broker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ssh-broker
+Group=ssh-broker
+ExecStart=/usr/local/bin/signer -config /etc/ssh-broker/signer.json
+# Hot-reload of policy/CA (same validated path as POST /v1/reload).
+ExecReload=/bin/kill -HUP $MAINPID
+WorkingDirectory=/var/lib/ssh-broker/signer
+StateDirectory=ssh-broker/signer
+StateDirectoryMode=0750
+# Optional: AZURE_* credentials for the "akv" CA backend (0600, root-owned).
+EnvironmentFile=-/etc/ssh-broker/signer.env
+Restart=on-failure
+RestartSec=2
+
+# Sandboxing. The service needs: read /etc/ssh-broker, write its state dir,
+# listen on its mTLS port, and (akv only) outbound HTTPS to the vault / IMDS.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [v1.29.0] - 2026-07-02
+
+### Added
+- Production deployment artifacts under `deploy/`: hardened systemd units for
+  the three daemons (`ssh-broker-signer`, `ssh-broker-control-plane`,
+  `ssh-broker-mcp-http`) with full sandboxing (`ProtectSystem=strict`, empty
+  capability bounding set, syscall filtering), `StateDirectory`-managed audit
+  log directories under `/var/lib/ssh-broker/<svc>/`, `systemctl reload`
+  (SIGHUP) wired to the signer's hot-reload, and an optional
+  `EnvironmentFile=/etc/ssh-broker/<svc>.env` for `AZURE_*` credentials when
+  CA custody is Azure Key Vault.
+- `deploy/install.sh`: idempotent root installer — creates the `ssh-broker`
+  system user, the `/etc/ssh-broker` + `/etc/ssh-broker/pki` layout, installs
+  binaries and units, and seeds configs from the examples without ever
+  overwriting an existing real config (safe for upgrades).
+- `make dist`: release tarball (`dist/ssh-broker-<version>.tar.gz`) bundling
+  the binaries, `deploy/`, and the example configs the installer seeds from.
+- `deploy/README.md`: production checklist presenting **CA custody as an
+  explicit operator choice** — `akv` (Azure Key Vault; the private key never
+  leaves the vault; RSA/EC only) vs `pem` (local file; lab/dev) — plus
+  default-deny `callers`, rate limiting, monitor binding, and upgrade caveats
+  (in-memory approvals/sessions).
+- Vendor-agnostic agent skill `.agents/skills/deploy/SKILL.md` (symlinked from
+  `.claude/skills`): the judgment layer over the deterministic tooling —
+  preflight policy checks, the custody question, reload-vs-restart decision,
+  and post-deploy health verification.
+- New § 8 "Production deployment" in OPERATIONS.md.
+
 ## [v1.28.0] - 2026-07-02
 
 ### Added

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -15,6 +15,7 @@ for the security posture see [THREAT_MODEL.md](THREAT_MODEL.md).
 5. [Local PKI](#5-local-pki)
 6. [Reference config files](#6-reference-config-files)
 7. [Monitoring](#7-monitoring)
+8. [Production deployment](#8-production-deployment)
 
 ---
 
@@ -585,3 +586,35 @@ Example scrape check:
 curl -s http://127.0.0.1:9160/healthz
 curl -s http://127.0.0.1:9160/metrics | grep signer_sign_requests_total
 ```
+
+---
+
+## 8. Production deployment
+
+The manual flow above (signer.sh + `make install` to `~/bin`) is the lab
+setup. For production, `deploy/` in the repository ships hardened systemd
+units for the three daemons (`signer`, `control-plane`, `mcp-broker-http`),
+an idempotent installer and a release target:
+
+```bash
+make dist                        # dist/ssh-broker-<version>.tar.gz
+# on the target host, as root:
+./deploy/install.sh              # user, dirs, binaries, units, seed configs
+systemctl enable --now ssh-broker-signer   # always the signer first
+```
+
+Reference layout: binaries in `/usr/local/bin`, configs in
+`/etc/ssh-broker/` (never overwritten on upgrade), mTLS PKI in
+`/etc/ssh-broker/pki/`, audit logs in `/var/lib/ssh-broker/<svc>/`.
+Policy hot-reload maps to `systemctl reload ssh-broker-signer` (SIGHUP).
+
+**CA custody is the operator's choice**, made in `signer.json` → `ca_keys`:
+`"akv"` (Azure Key Vault — the private key never leaves the vault;
+recommended for production; RSA/EC only) or `"pem"` (local file — lab/dev,
+the signer logs a warning). Credentials for AKV come from
+`DefaultAzureCredential` (managed identity, or a service principal via the
+unit's optional `EnvironmentFile=/etc/ssh-broker/signer.env`).
+
+The full checklist — custody trade-offs, default-deny `callers`, rate
+limits, upgrade caveats (in-memory approvals/sessions) — lives in
+`deploy/README.md` in the repository.


### PR DESCRIPTION
Closes #30

Turns production deployment into a repeatable step and makes **CA custody an explicit operator choice** (the `akv` backend was already implemented in `internal/ca/loader.go`; now the deploy flow surfaces it instead of defaulting silently).

## What's included

- **`deploy/systemd/`** — hardened units for `signer`, `control-plane` and `mcp-broker-http`: `ProtectSystem=strict`, empty capability bounding set, `@system-service` syscall filter, `StateDirectory` for audit logs under `/var/lib/ssh-broker/<svc>/`, `systemctl reload` → SIGHUP hot-reload on the signer, optional `EnvironmentFile` for `AZURE_*` credentials (AKV custody with a service principal; managed identity needs nothing).
- **`deploy/install.sh`** — idempotent root installer: `ssh-broker` system user, `/etc/ssh-broker` + `pki/` layout, binaries to `/usr/local/bin`, units, seed configs from the examples **never overwriting an existing real config** (upgrade-safe). Does not start anything on a fresh install.
- **`make dist`** — release tarball with `bin/`, `deploy/` and the example configs; `dist/` gitignored.
- **`deploy/README.md`** — production checklist: `akv` vs `pem` trade-off table (AKV: key never leaves the vault, RSA/EC only, no Ed25519; PEM: lab/dev with startup warning), default-deny `callers._default`, `sign_rate_limit_per_min`, private `monitor_listen`, upgrade caveats (in-memory approvals/sessions), and how to extract the CA public key from AKV for `TrustedUserCAKeys`.
- **`.agents/skills/deploy/SKILL.md`** — vendor-agnostic agent skill (`.claude/skills` is a symlink to `.agents/skills`): preflight checks, the custody question, reload-vs-restart, post-deploy verification (`healthz`, `broker-ctl host list`, version match).
- **Docs** — OPERATIONS.md § 8 + CHANGELOG entry for v1.29.0. `.claude/settings.local.json` gitignored.

## Validation

- `make test` (full `-race` suite) ✅
- `make docs-check` (example-config validation + strict site build) ✅
- `systemd-analyze verify` on the three units: no syntax errors (only expected missing-binary notices on the dev machine) ✅
- `make dist` produces a tarball whose layout `install.sh` auto-detects; installer smoke-tested (`--help`, root guard) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)