### PR TITLE
docs(deploy): fix end-to-end verification — broker-ctl host list is local

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -93,8 +93,16 @@ edit `/etc/ssh-broker/*.json` and place the mTLS PKI before starting.
   clean of errors. With `pem` custody a CA warning line is expected.
 - `curl -s http://127.0.0.1:9160/healthz` (signer monitor) and the
   control-plane equivalent (`:9170` by default).
-- End-to-end: `broker-ctl host list` from a machine holding a valid broker
-  mTLS cert — proves TLS, RBAC and policy load in one shot.
+- End-to-end (proves TLS, RBAC and policy load in one shot — note that
+  `broker-ctl host list` reads the local config file and proves nothing):
+
+  ```bash
+  curl -s --cert broker.crt --key broker.key --cacert mtls_ca.crt \
+    https://<signer>:9443/v1/hosts
+  ```
+
+  Expect the hosts of the caller's groups; an unknown CN must get `{}` when
+  `callers._default` is default-deny.
 - `signer --version` matches the tag shipped in step 2.
 
 Report what was deployed (services, host, version, custody backend) and any

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -108,7 +108,8 @@ sudo systemctl enable --now ssh-broker-control-plane # if installed
 sudo systemctl enable --now ssh-broker-mcp-http      # if installed
 
 curl -s http://127.0.0.1:9160/healthz                # signer liveness (monitor_listen)
-broker-ctl host list                                 # end-to-end: mTLS + policy load
+curl -s --cert broker.crt --key broker.key \
+     --cacert mtls_ca.crt https://<signer>:9443/v1/hosts   # end-to-end: mTLS + RBAC + policy
 journalctl -u ssh-broker-signer -f                   # logs go to the journal
 ```
 


### PR DESCRIPTION
Found while exercising the deploy skill end-to-end on a real host (issue #30 follow-up): `broker-ctl host list` reads the **local** `signer.json` (`cmd/broker-ctl/main.go` → `loadRaw(configPath)`), so using it as the post-deploy end-to-end check proves nothing about the running service. The skill and `deploy/README.md` now use the mTLS `curl` to `/v1/hosts`, which actually exercises TLS, caller RBAC and policy load, and document that an unknown CN must get `{}` under a default-deny `callers._default`.

Verified live on a fresh install from the v1.29.0 tarball: healthz, mTLS `/v1/hosts` with `CN=broker-1`, default-deny with an unlisted CN, and `systemctl reload` hot-reload all behave as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)