### PR TITLE
feat: broker-ctl host list --remote (GET /v1/policy/hosts) + client parameters file

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -93,16 +93,27 @@ edit `/etc/ssh-broker/*.json` and place the mTLS PKI before starting.
   clean of errors. With `pem` custody a CA warning line is expected.
 - `curl -s http://127.0.0.1:9160/healthz` (signer monitor) and the
   control-plane equivalent (`:9170` by default).
-- End-to-end (proves TLS, RBAC and policy load in one shot — note that
-  `broker-ctl host list` reads the local config file and proves nothing):
+- End-to-end — proves mTLS, `reload_callers` authorization and full policy
+  load in one shot (plain `broker-ctl host list` reads the local file and
+  proves nothing):
 
   ```bash
-  curl -s --cert broker.crt --key broker.key --cacert mtls_ca.crt \
+  broker-ctl host list --remote
+  ```
+
+  URL and certs come from `/etc/ssh-broker/broker-ctl.json` (seeded by the
+  installer; flags/`BROKER_CTL_SIGNER_*` override). The client cert CN must
+  be in the signer's `reload_callers`. Expect the full table (principal, TTL,
+  groups, policy) reflecting the live in-memory state.
+- RBAC default-deny check, separately — the admin read above bypasses group
+  filtering, so it cannot prove it. With a cert whose CN is NOT in `callers`:
+
+  ```bash
+  curl -s --cert other.crt --key other.key --cacert mtls_ca.crt \
     https://<signer>:9443/v1/hosts
   ```
 
-  Expect the hosts of the caller's groups; an unknown CN must get `{}` when
-  `callers._default` is default-deny.
+  Expect `{}` when `callers._default` is default-deny.
 - `signer --version` matches the tag shipped in step 2.
 
 Report what was deployed (services, host, version, custody backend) and any

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pki/
 # Usar config.example.json y signer.example.json como referencia
 config.json
 signer.json
+broker-ctl.json
 
 # Logs de auditoría (datos operativos)
 *.log

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dist:
 	$(MAKE) build BINDIR=$(abspath $(DISTDIR)/bin)
 	cp -r deploy $(DISTDIR)/
 	cp signer.example.json control-plane.example.json config.example.json \
-	   LICENSE README.md $(DISTDIR)/
+	   broker-ctl.example.json LICENSE README.md $(DISTDIR)/
 	tar -C dist -czf dist/ssh-broker-$(VERSION).tar.gz ssh-broker-$(VERSION)
 	@echo "dist/ssh-broker-$(VERSION).tar.gz"
 
@@ -76,7 +76,7 @@ docs: docs-gen
 docs-check: docs-gen
 	@git diff --exit-code docs/reference \
 	  || { echo "docs/reference is stale — commit the regenerated files (make docs-gen)"; exit 1; }
-	go test ./cmd/signer/ ./cmd/control-plane/ ./internal/broker/ -run ExampleConfig
+	go test ./cmd/signer/ ./cmd/control-plane/ ./cmd/broker-ctl/ ./internal/broker/ -run ExampleConfig
 	$(MKDOCS) build --strict
 
 # Live preview at http://127.0.0.1:8000 (regenerates first).

--- a/broker-ctl.example.json
+++ b/broker-ctl.example.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "broker-ctl CLIENT parameters (optional). Where to reach the services and which mTLS identity to present, so the remote commands (reload, policy add/remove/grant/grants/revoke, approval, host list --remote) do not need --url/--cert/--key/--ca on every call. This is client-side config — the service policy lives in signer.json. Per-parameter precedence: explicit flag > BROKER_CTL_* env var > this file > built-in default. Search order: --client-config, $BROKER_CTL_CONFIG, ./broker-ctl.json, ~/.config/broker-ctl/config.json, /etc/ssh-broker/broker-ctl.json. Env vars: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and BROKER_CTL_CP_{URL,CERT,KEY,CA}.",
+
+  "_signer_comment": "Signer-facing commands (reload, policy *, host list --remote). The cert CN must be in the signer's reload_callers for the policy/read APIs. If url is empty everywhere, it is derived from the listen field of --config.",
+  "signer": {
+    "url": "127.0.0.1:9443",
+    "cert": "/etc/ssh-broker/pki/broker.crt",
+    "key": "/etc/ssh-broker/pki/broker.key",
+    "ca": "/etc/ssh-broker/pki/mtls_ca.crt"
+  },
+
+  "_control_plane_comment": "Control-plane-facing commands (approval list/allow/deny). The cert CN must be in the control plane's approval.callers.",
+  "control_plane": {
+    "url": "127.0.0.1:7443",
+    "cert": "/etc/ssh-broker/pki/broker-admin.crt",
+    "key": "/etc/ssh-broker/pki/broker-admin.key",
+    "ca": "/etc/ssh-broker/pki/mtls_ca.crt"
+  }
+}

--- a/cmd/broker-ctl/clientconfig.go
+++ b/cmd/broker-ctl/clientconfig.go
@@ -1,0 +1,168 @@
+// clientconfig.go implements the optional broker-ctl client parameters file
+// and its environment-variable overrides, so remote commands (reload, policy,
+// approval, host list --remote) do not need --url/--cert/--key/--ca on every
+// invocation.
+//
+// This is CLIENT configuration (where to reach the services, which mTLS
+// identity to present) — deliberately separate from signer.json, which is the
+// service's policy. Precedence, per parameter:
+//
+//	explicit flag  >  BROKER_CTL_* env var  >  client config file  >  built-in default
+//
+// The file is JSON with one section per target service:
+//
+//	{
+//	  "signer":        { "url": "127.0.0.1:9443", "cert": "...", "key": "...", "ca": "..." },
+//	  "control_plane": { "url": "127.0.0.1:7443", "cert": "...", "key": "...", "ca": "..." }
+//	}
+//
+// Search order: --client-config (global flag) → $BROKER_CTL_CONFIG →
+// ./broker-ctl.json → <user config dir>/broker-ctl/config.json →
+// /etc/ssh-broker/broker-ctl.json. The first two are explicit choices and must
+// exist; the rest are skipped when absent. A file that exists but does not
+// parse is always a hard error — never silently ignored.
+//
+// Environment variables: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and
+// BROKER_CTL_CP_{URL,CERT,KEY,CA}.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// clientTarget holds the connection parameters for one remote service.
+type clientTarget struct {
+	URL  string `json:"url,omitempty"`
+	Cert string `json:"cert,omitempty"`
+	Key  string `json:"key,omitempty"`
+	CA   string `json:"ca,omitempty"`
+}
+
+// clientConfig is the parsed broker-ctl client parameters file.
+type clientConfig struct {
+	Signer       clientTarget `json:"signer"`
+	ControlPlane clientTarget `json:"control_plane"`
+}
+
+// clientConfigPath is the value of the global --client-config flag (set by
+// parseGlobalFlags; empty = use env/search order).
+var clientConfigPath string
+
+// ccCandidate is one entry of the client-config search order. A required
+// candidate was named explicitly (flag or env) and must exist.
+type ccCandidate struct {
+	path     string
+	required bool
+}
+
+// clientConfigCandidates returns the search order for the client config file.
+func clientConfigCandidates() []ccCandidate {
+	var cands []ccCandidate
+	if clientConfigPath != "" {
+		cands = append(cands, ccCandidate{clientConfigPath, true})
+	}
+	if p := os.Getenv("BROKER_CTL_CONFIG"); p != "" {
+		cands = append(cands, ccCandidate{p, true})
+	}
+	cands = append(cands, ccCandidate{"./broker-ctl.json", false})
+	if dir, err := os.UserConfigDir(); err == nil {
+		cands = append(cands, ccCandidate{filepath.Join(dir, "broker-ctl", "config.json"), false})
+	}
+	cands = append(cands, ccCandidate{"/etc/ssh-broker/broker-ctl.json", false})
+	return cands
+}
+
+// loadClientConfigFrom resolves the first usable candidate. It returns the
+// parsed config and the path it came from ("" when no file was found, which
+// is not an error: flags/env/defaults still apply).
+func loadClientConfigFrom(cands []ccCandidate) (clientConfig, string, error) {
+	for _, c := range cands {
+		b, err := os.ReadFile(c.path)
+		if err != nil {
+			if os.IsNotExist(err) && !c.required {
+				continue
+			}
+			return clientConfig{}, "", fmt.Errorf("client config %s: %w", c.path, err)
+		}
+		var cfg clientConfig
+		if err := json.Unmarshal(b, &cfg); err != nil {
+			return clientConfig{}, "", fmt.Errorf("client config %s: %w", c.path, err)
+		}
+		return cfg, c.path, nil
+	}
+	return clientConfig{}, "", nil
+}
+
+// cachedClientConfig memoizes the result of the first load for the process.
+var cachedClientConfig *clientConfig
+
+// loadClientConfig loads the client config once, fatally on a malformed or
+// explicitly-named-but-missing file.
+func loadClientConfig() clientConfig {
+	if cachedClientConfig != nil {
+		return *cachedClientConfig
+	}
+	cfg, _, err := loadClientConfigFrom(clientConfigCandidates())
+	if err != nil {
+		fatalf("%v", err)
+	}
+	cachedClientConfig = &cfg
+	return cfg
+}
+
+// resolveTarget applies the client-parameter precedence to the url/cert/key/ca
+// flags of an already-parsed FlagSet: a flag the user set explicitly wins; an
+// unset flag takes the BROKER_CTL_<env>_{URL,CERT,KEY,CA} variable, then the
+// client config file value, and otherwise keeps its built-in default. Flags
+// the FlagSet does not define are skipped.
+func resolveTarget(fs *flag.FlagSet, env string, file clientTarget) {
+	set := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+	apply := func(name, envSuffix, fileVal string) {
+		if set[name] {
+			return
+		}
+		f := fs.Lookup(name)
+		if f == nil {
+			return
+		}
+		if v := os.Getenv(env + envSuffix); v != "" {
+			f.Value.Set(v)
+			return
+		}
+		if fileVal != "" {
+			f.Value.Set(fileVal)
+		}
+	}
+	apply("url", "_URL", file.URL)
+	apply("cert", "_CERT", file.Cert)
+	apply("key", "_KEY", file.Key)
+	apply("ca", "_CA", file.CA)
+}
+
+// resolveSignerTarget resolves the signer-facing flags of fs (env prefix
+// BROKER_CTL_SIGNER, file section "signer").
+func resolveSignerTarget(fs *flag.FlagSet) {
+	resolveTarget(fs, "BROKER_CTL_SIGNER", loadClientConfig().Signer)
+}
+
+// resolveControlPlaneTarget resolves the control-plane-facing flags of fs
+// (env prefix BROKER_CTL_CP, file section "control_plane").
+func resolveControlPlaneTarget(fs *flag.FlagSet) {
+	resolveTarget(fs, "BROKER_CTL_CP", loadClientConfig().ControlPlane)
+}
+
+// signerFlags registers the shared flags of the signer-facing remote commands.
+// The empty --url default means "resolve via env/file, else the listen field
+// of the signer config" (see policyHTTP).
+func signerFlags(fs *flag.FlagSet) (url, cert, key, ca *string) {
+	url = fs.String("url", "", "signer host:port (default: broker-ctl.json / BROKER_CTL_SIGNER_URL, else the config file's listen)")
+	cert = fs.String("cert", "./pki/broker.crt", "mTLS client cert")
+	key = fs.String("key", "./pki/broker.key", "mTLS client key")
+	ca = fs.String("ca", "./pki/mtls_ca.crt", "mTLS CA")
+	return
+}

--- a/cmd/broker-ctl/clientconfig_test.go
+++ b/cmd/broker-ctl/clientconfig_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeClientConfig(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const ccFixture = `{
+  "signer":        {"url": "signer.example:9443", "cert": "/etc/pki/s.crt", "key": "/etc/pki/s.key", "ca": "/etc/pki/ca.crt"},
+  "control_plane": {"url": "cp.example:7443", "cert": "/etc/pki/a.crt", "key": "/etc/pki/a.key", "ca": "/etc/pki/ca.crt"}
+}`
+
+func TestLoadClientConfigFrom(t *testing.T) {
+	dir := t.TempDir()
+	good := writeClientConfig(t, dir, "good.json", ccFixture)
+	bad := writeClientConfig(t, dir, "bad.json", "{not json")
+	missing := filepath.Join(dir, "absent.json")
+
+	// First usable candidate wins; optional missing candidates are skipped.
+	cfg, src, err := loadClientConfigFrom([]ccCandidate{{missing, false}, {good, false}})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if src != good || cfg.Signer.URL != "signer.example:9443" || cfg.ControlPlane.Cert != "/etc/pki/a.crt" {
+		t.Errorf("unexpected result: src=%q cfg=%+v", src, cfg)
+	}
+
+	// No candidate found: not an error, empty config.
+	cfg, src, err = loadClientConfigFrom([]ccCandidate{{missing, false}})
+	if err != nil || src != "" || cfg.Signer.URL != "" {
+		t.Errorf("absent optional: cfg=%+v src=%q err=%v", cfg, src, err)
+	}
+
+	// An explicitly-named file must exist.
+	if _, _, err = loadClientConfigFrom([]ccCandidate{{missing, true}}); err == nil {
+		t.Error("required missing file: expected error")
+	}
+
+	// A file that exists but does not parse is a hard error, never skipped.
+	if _, _, err = loadClientConfigFrom([]ccCandidate{{bad, false}, {good, false}}); err == nil {
+		t.Error("malformed file: expected error, got silent skip")
+	} else if !strings.Contains(err.Error(), "bad.json") {
+		t.Errorf("error should name the offending file: %v", err)
+	}
+}
+
+// TestResolveTargetPrecedence: explicit flag > env var > file > built-in
+// default, independently per parameter.
+func TestResolveTargetPrecedence(t *testing.T) {
+	t.Setenv("BROKER_CTL_SIGNER_URL", "env.example:9443")
+	t.Setenv("BROKER_CTL_SIGNER_CERT", "")
+	t.Setenv("BROKER_CTL_SIGNER_KEY", "")
+	t.Setenv("BROKER_CTL_SIGNER_CA", "")
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	url, cert, key, ca := signerFlags(fs)
+	// --cert passed explicitly; --url/--key/--ca left unset.
+	if err := fs.Parse([]string{"--cert", "/flag/cert.crt"}); err != nil {
+		t.Fatal(err)
+	}
+	file := clientTarget{URL: "file.example:9443", Cert: "/file/cert.crt", Key: "/file/key.pem"}
+	resolveTarget(fs, "BROKER_CTL_SIGNER", file)
+
+	if *cert != "/flag/cert.crt" {
+		t.Errorf("flag must win: cert = %q", *cert)
+	}
+	if *url != "env.example:9443" {
+		t.Errorf("env must beat file: url = %q", *url)
+	}
+	if *key != "/file/key.pem" {
+		t.Errorf("file must beat default: key = %q", *key)
+	}
+	if *ca != "./pki/mtls_ca.crt" {
+		t.Errorf("built-in default must survive when nothing overrides: ca = %q", *ca)
+	}
+}
+
+// TestClientConfigCandidatesOrder: --client-config and $BROKER_CTL_CONFIG are
+// explicit (required) and come first, in that order.
+func TestClientConfigCandidatesOrder(t *testing.T) {
+	t.Setenv("BROKER_CTL_CONFIG", "/env/cc.json")
+	old := clientConfigPath
+	clientConfigPath = "/flag/cc.json"
+	defer func() { clientConfigPath = old }()
+
+	cands := clientConfigCandidates()
+	if len(cands) < 3 {
+		t.Fatalf("too few candidates: %+v", cands)
+	}
+	if cands[0].path != "/flag/cc.json" || !cands[0].required {
+		t.Errorf("first candidate must be the --client-config flag: %+v", cands[0])
+	}
+	if cands[1].path != "/env/cc.json" || !cands[1].required {
+		t.Errorf("second candidate must be $BROKER_CTL_CONFIG: %+v", cands[1])
+	}
+	last := cands[len(cands)-1]
+	if last.path != "/etc/ssh-broker/broker-ctl.json" || last.required {
+		t.Errorf("last candidate must be the system path, optional: %+v", last)
+	}
+}

--- a/cmd/broker-ctl/config_example_test.go
+++ b/cmd/broker-ctl/config_example_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/luisgf/ssh-broker/internal/confcheck"
+)
+
+// TestClientExampleConfigMatchesStruct fails if broker-ctl.example.json uses a
+// key that no longer exists on the clientConfig struct — i.e. the example
+// drifted from the code. Comment keys ("_*") are stripped first.
+func TestClientExampleConfigMatchesStruct(t *testing.T) {
+	raw, err := os.ReadFile("../../broker-ctl.example.json")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	clean, err := confcheck.StripUnderscoreKeys(raw)
+	if err != nil {
+		t.Fatalf("strip comments: %v", err)
+	}
+	var cfg clientConfig
+	if err := confcheck.DecodeStrict(clean, &cfg); err != nil {
+		t.Fatalf("broker-ctl.example.json has a key not in clientConfig (doc/code drift?): %v", err)
+	}
+	if cfg.Signer.URL == "" || cfg.ControlPlane.Cert == "" {
+		t.Errorf("example should populate both sections: %+v", cfg)
+	}
+}

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -109,11 +109,13 @@ func parseGlobalFlags(args []string) (cfg string, rest []string, showVersion, ve
 	fs := flag.NewFlagSet("broker-ctl", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	c := fs.String("config", "./signer.json", "path to signer.json")
+	cc := fs.String("client-config", "", "path to the broker-ctl client parameters file (default: $BROKER_CTL_CONFIG, ./broker-ctl.json, ~/.config/broker-ctl/config.json, /etc/ssh-broker/broker-ctl.json)")
 	sv := fs.Bool("version", false, "print version and exit")
 	vb := fs.Bool("verbose", false, "with --version, print detailed build info")
 	if perr := fs.Parse(args); perr != nil {
 		return "", nil, false, false, perr
 	}
+	clientConfigPath = *cc
 	return *c, fs.Args(), *sv, *vb, nil
 }
 
@@ -130,11 +132,11 @@ func usageTop() {
 	fmt.Fprintln(os.Stderr, `broker-ctl — SSH broker configuration management
 
 Usage:
-  broker-ctl [--config f] <command> [args]
+  broker-ctl [--config f] [--client-config f] <command> [args]
 
 Commands:
   broker-ctl host add      [flags]                          Add or update a host
-  broker-ctl host list                                      List configured hosts
+  broker-ctl host list     [--remote]                       List configured hosts (--remote: live from the signer, mTLS)
   broker-ctl host remove   <name>                           Remove a host
   broker-ctl ca-keys add   --name <n> [flags]               Add or update a CA key entry
   broker-ctl ca-keys list                                   List configured CA keys
@@ -159,8 +161,17 @@ Commands:
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:
-  --config   Path to signer.json (default: ./signer.json), before the subcommand
-  --version  Print the build version and exit (--verbose for details)`)
+  --config         Path to signer.json (default: ./signer.json), before the subcommand
+  --client-config  Path to the client parameters file for the remote commands
+  --version        Print the build version and exit (--verbose for details)
+
+Client parameters (remote commands: reload, policy add/remove/grant/grants/revoke,
+approval, host list --remote):
+  Per-parameter precedence: flag > env var > client config file > default.
+  File search order: --client-config, $BROKER_CTL_CONFIG, ./broker-ctl.json,
+  ~/.config/broker-ctl/config.json, /etc/ssh-broker/broker-ctl.json. Sections
+  "signer" and "control_plane", each with url/cert/key/ca (see broker-ctl.example.json).
+  Env vars: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA}, BROKER_CTL_CP_{URL,CERT,KEY,CA}.`)
 }
 
 // ── host ──────────────────────────────────────────────────────────────────────
@@ -499,19 +510,61 @@ func commandPolicyLabel(raw json.RawMessage) string {
 
 func cmdHostList(args []string) {
 	fs := flag.NewFlagSet("host list", flag.ExitOnError)
+	remote := fs.Bool("remote", false, "read the live policy from the signer over mTLS instead of the local config file")
+	urlFlag, cert, key, ca := signerFlags(fs)
 	must(fs.Parse(args))
 
-	raw, err := loadRaw(configPath)
-	if err != nil {
-		fatalf("reading config: %v", err)
+	var hosts map[string]hostEntry
+	if *remote {
+		resolveSignerTarget(fs)
+		client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+		var err error
+		hosts, err = fetchRemoteHosts(client, base)
+		if err != nil {
+			fatalf("%v", err)
+		}
+	} else {
+		raw, err := loadRaw(configPath)
+		if err != nil {
+			fatalf("reading config: %v", err)
+		}
+		hosts, err = extractHosts(raw)
+		if err != nil {
+			fatalf("parsing hosts: %v", err)
+		}
 	}
-	hosts, err := extractHosts(raw)
-	if err != nil {
-		fatalf("parsing hosts: %v", err)
-	}
+	renderHostTable(os.Stdout, hosts)
+}
 
+// fetchRemoteHosts retrieves the full host-policy table from the signer's
+// GET /v1/policy/hosts. The response uses the same schema as the signer.json
+// "hosts" table, so it decodes straight into hostEntry and both modes render
+// identically. A non-200 is a hard failure — deliberately no fallback to the
+// reduced GET /v1/hosts view, whose blank PRINCIPAL/TTL/CALLERS/POLICY columns
+// would read as "no policy configured".
+func fetchRemoteHosts(client *http.Client, base string) (map[string]hostEntry, error) {
+	resp, err := client.Get(base + "/v1/policy/hosts")
+	if err != nil {
+		return nil, fmt.Errorf("GET %s/v1/policy/hosts: %w", base, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("signer rejected the request (HTTP %d): %s\nhint: the client cert CN must be in the signer's reload_callers (GET /v1/hosts is the caller-scoped connectivity view)",
+			resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	var hosts map[string]hostEntry
+	if err := json.Unmarshal(rb, &hosts); err != nil {
+		return nil, fmt.Errorf("decoding host policy: %w", err)
+	}
+	return hosts, nil
+}
+
+// renderHostTable prints the host-policy table; shared by the local and
+// remote modes of `host list` so both render the exact same columns.
+func renderHostTable(out io.Writer, hosts map[string]hostEntry) {
 	if len(hosts) == 0 {
-		fmt.Println("(no hosts configured)")
+		fmt.Fprintln(out, "(no hosts configured)")
 		return
 	}
 
@@ -521,7 +574,7 @@ func cmdHostList(args []string) {
 	}
 	sort.Strings(names)
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tADDR\tUSER\tPRINCIPAL\tTTL\tJUMP\tSRC_ADDR\tSUDO\tSUDO_USERS\tPTY\tFT\tBASTION\tGROUPS\tCALLERS\tPOLICY")
 	for _, n := range names {
 		h := hosts[n]
@@ -946,9 +999,7 @@ func writeCallers(path string, raw map[string]json.RawMessage, callers map[strin
 func cmdReload(args []string) {
 	fs := flag.NewFlagSet("reload", flag.ExitOnError)
 	pidFile := fs.String("pid-file", "./signer.pid", "path to signer PID file")
-	cert := fs.String("cert", "./pki/broker.crt", "mTLS client cert for /v1/reload")
-	key := fs.String("key", "./pki/broker.key", "mTLS client key")
-	ca := fs.String("ca", "./pki/mtls_ca.crt", "mTLS CA")
+	urlFlag, cert, key, ca := signerFlags(fs)
 	must(fs.Parse(args))
 
 	// Try local SIGHUP first, but only when we can confirm the PID really is the
@@ -968,20 +1019,9 @@ func cmdReload(args []string) {
 	}
 
 	// Fallback: POST /v1/reload via mTLS.
-	signerURL, err := readSignerURL(configPath)
-	if err != nil {
-		fatalf("reading signer URL from config: %v", err)
-	}
-	url := "https://" + signerURL + "/v1/reload"
-
-	tlsCfg, err := buildTLSConfig(*cert, *key, *ca)
-	if err != nil {
-		fatalf("TLS: %v", err)
-	}
-	client := &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
-	}
+	resolveSignerTarget(fs)
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+	url := base + "/v1/reload"
 	resp, err := client.Post(url, "application/json", nil)
 	if err != nil {
 		fatalf("POST %s: %v", url, err)
@@ -1042,6 +1082,7 @@ func cmdApprovalList(args []string) {
 	url, cert, key, ca := approvalFlags(fs)
 	asJSON := fs.Bool("json", false, "raw JSON output")
 	must(fs.Parse(args))
+	resolveControlPlaneTarget(fs)
 
 	client := approvalClient(*cert, *key, *ca)
 	resp, err := client.Get("https://" + *url + "/v1/approvals")
@@ -1112,6 +1153,7 @@ func cmdApprovalDecide(args []string, approve bool) {
 		fatalf("missing request id")
 	}
 	id := fs.Arg(0)
+	resolveControlPlaneTarget(fs)
 
 	body := map[string]any{"approve": approve}
 	if approve && *learn {

--- a/cmd/broker-ctl/policy.go
+++ b/cmd/broker-ctl/policy.go
@@ -64,19 +64,24 @@ func policyUsage() {
 		"  broker-ctl [--config f] policy revoke    <grant-id>                     (mTLS)")
 }
 
-// policyHTTP builds an mTLS client and the signer base URL ("https://host:port")
-// from the global --config, shared by the grant commands.
-func policyHTTP(cert, key, ca string) (*http.Client, string) {
-	signerURL, err := readSignerURL(configPath)
-	if err != nil {
-		fatalf("reading signer URL from config: %v", err)
+// policyHTTP builds an mTLS client and the signer base URL ("https://host:port"),
+// shared by the signer-facing remote commands. An empty url falls back to the
+// listen field of the signer config (--config): with --url (or the client
+// config file / BROKER_CTL_SIGNER_URL) no local signer.json is needed at all.
+func policyHTTP(url, cert, key, ca string) (*http.Client, string) {
+	if url == "" {
+		s, err := readSignerURL(configPath)
+		if err != nil {
+			fatalf("no signer URL: %v (pass --url, set BROKER_CTL_SIGNER_URL, or add it to broker-ctl.json)", err)
+		}
+		url = s
 	}
 	tlsCfg, err := buildTLSConfig(cert, key, ca)
 	if err != nil {
 		fatalf("TLS: %v", err)
 	}
 	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsCfg}}
-	return client, "https://" + signerURL
+	return client, "https://" + url
 }
 
 // cmdPolicyGrant creates a runtime, widen-only grant on the signer over mTLS: a
@@ -90,9 +95,7 @@ func cmdPolicyGrant(args []string) {
 	ttl := fs.Duration("ttl", time.Hour, "grant lifetime, e.g. 2h, 30m, 90s")
 	scopeCaller := fs.String("caller", "", "optional: limit the grant to this broker CN")
 	scopeUser := fs.String("end-user", "", "optional: limit the grant to this end user")
-	cert := fs.String("cert", "./pki/broker.crt", "mTLS client cert")
-	key := fs.String("key", "./pki/broker.key", "mTLS client key")
-	ca := fs.String("ca", "./pki/mtls_ca.crt", "mTLS CA")
+	urlFlag, cert, key, ca := signerFlags(fs)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] policy grant --host <name> --allow <regex> [--ttl 2h] [--caller cn] [--end-user u]")
 		fs.PrintDefaults()
@@ -102,8 +105,9 @@ func cmdPolicyGrant(args []string) {
 		fs.Usage()
 		os.Exit(1)
 	}
+	resolveSignerTarget(fs)
 
-	client, base := policyHTTP(*cert, *key, *ca)
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
 	endpoint := base + "/v1/policy/hosts/" + url.PathEscape(*host) + "/grants"
 	body, _ := json.Marshal(map[string]any{
 		"allow": []string{*allow}, "ttl_seconds": int(ttl.Seconds()),
@@ -136,16 +140,15 @@ func cmdPolicyGrant(args []string) {
 func cmdPolicyGrants(args []string) {
 	fs := flag.NewFlagSet("policy grants", flag.ExitOnError)
 	asJSON := fs.Bool("json", false, "output as JSON")
-	cert := fs.String("cert", "./pki/broker.crt", "mTLS client cert")
-	key := fs.String("key", "./pki/broker.key", "mTLS client key")
-	ca := fs.String("ca", "./pki/mtls_ca.crt", "mTLS CA")
+	urlFlag, cert, key, ca := signerFlags(fs)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] policy grants [--json]")
 		fs.PrintDefaults()
 	}
 	must(fs.Parse(args))
+	resolveSignerTarget(fs)
 
-	client, base := policyHTTP(*cert, *key, *ca)
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
 	resp, err := client.Get(base + "/v1/policy/grants")
 	if err != nil {
 		fatalf("GET %s/v1/policy/grants: %v", base, err)
@@ -208,9 +211,7 @@ func grantScope(g signer.Grant) string {
 // cmdPolicyRevoke revokes a grant by id over mTLS.
 func cmdPolicyRevoke(args []string) {
 	fs := flag.NewFlagSet("policy revoke", flag.ExitOnError)
-	cert := fs.String("cert", "./pki/broker.crt", "mTLS client cert")
-	key := fs.String("key", "./pki/broker.key", "mTLS client key")
-	ca := fs.String("ca", "./pki/mtls_ca.crt", "mTLS CA")
+	urlFlag, cert, key, ca := signerFlags(fs)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] policy revoke <grant-id>")
 		fs.PrintDefaults()
@@ -221,8 +222,9 @@ func cmdPolicyRevoke(args []string) {
 		os.Exit(1)
 	}
 	id := fs.Arg(0)
+	resolveSignerTarget(fs)
 
-	client, base := policyHTTP(*cert, *key, *ca)
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
 	endpoint := base + "/v1/policy/grants/" + url.PathEscape(id)
 	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
 	if err != nil {
@@ -252,9 +254,7 @@ func cmdPolicyMutate(args []string, add bool) {
 	fs := flag.NewFlagSet("policy "+op, flag.ExitOnError)
 	host := fs.String("host", "", "target host (required)")
 	allow := fs.String("allow", "", "allow regex to "+op+" (required)")
-	cert := fs.String("cert", "./pki/broker.crt", "mTLS client cert")
-	key := fs.String("key", "./pki/broker.key", "mTLS client key")
-	ca := fs.String("ca", "./pki/mtls_ca.crt", "mTLS CA")
+	urlFlag, cert, key, ca := signerFlags(fs)
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: broker-ctl [--config f] policy %s --host <name> --allow <regex>\n", op)
 		fs.PrintDefaults()
@@ -264,17 +264,10 @@ func cmdPolicyMutate(args []string, add bool) {
 		fs.Usage()
 		os.Exit(1)
 	}
+	resolveSignerTarget(fs)
 
-	signerURL, err := readSignerURL(configPath)
-	if err != nil {
-		fatalf("reading signer URL from config: %v", err)
-	}
-	endpoint := "https://" + signerURL + "/v1/policy/hosts/" + url.PathEscape(*host) + "/allow"
-	tlsCfg, err := buildTLSConfig(*cert, *key, *ca)
-	if err != nil {
-		fatalf("TLS: %v", err)
-	}
-	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+	endpoint := base + "/v1/policy/hosts/" + url.PathEscape(*host) + "/allow"
 
 	method := http.MethodPost
 	if !add {

--- a/cmd/broker-ctl/remote_list_test.go
+++ b/cmd/broker-ctl/remote_list_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// remoteHostsFixture mirrors what GET /v1/policy/hosts serves: the signer.json
+// "hosts" schema, full policy fields included.
+const remoteHostsFixture = `{
+  "web01": {
+    "addr": "10.0.0.1:22",
+    "user": "deploy",
+    "host_key": "ssh-ed25519 AAAA...",
+    "principal": "host:web01",
+    "source_address": "203.0.113.10",
+    "max_ttl_seconds": 120,
+    "allowed_callers": ["broker-1"],
+    "allow_sudo": true,
+    "allowed_sudo_users": ["root", "deploy"],
+    "allow_pty": true,
+    "groups": ["prod-web"],
+    "command_policy": {"mode": "allowlist", "shell_parse": true, "allow": ["^uptime$"]}
+  },
+  "bastion": {
+    "addr": "203.0.113.10:22",
+    "user": "jump",
+    "host_key": "ssh-ed25519 BBBB...",
+    "principal": "host:bastion",
+    "max_ttl_seconds": 60,
+    "allow_as_bastion": true,
+    "groups": ["prod-web"]
+  }
+}`
+
+func TestFetchRemoteHosts(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/policy/hosts" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(remoteHostsFixture))
+	}))
+	defer ts.Close()
+
+	hosts, err := fetchRemoteHosts(&http.Client{Timeout: 5 * time.Second}, ts.URL)
+	if err != nil {
+		t.Fatalf("fetchRemoteHosts: %v", err)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("got %d hosts, want 2", len(hosts))
+	}
+	web := hosts["web01"]
+	if web.Principal != "host:web01" || web.MaxTTLSeconds != 120 || !web.AllowSudo {
+		t.Errorf("web01 policy fields lost in decode: %+v", web)
+	}
+	if len(web.AllowedCallers) != 1 || web.AllowedCallers[0] != "broker-1" {
+		t.Errorf("allowed_callers lost: %+v", web.AllowedCallers)
+	}
+	if got := commandPolicyLabel(web.CommandPolicy); got != "allowlist(1)" {
+		t.Errorf("command_policy label = %q, want allowlist(1)", got)
+	}
+	if !hosts["bastion"].AllowAsBastion {
+		t.Errorf("bastion allow_as_bastion lost")
+	}
+}
+
+// TestFetchRemoteHostsRejected: a non-200 must surface the status, the
+// signer's message, and the reload_callers hint — and never fall back to a
+// partial view.
+func TestFetchRemoteHostsRejected(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not authorised to read policy", http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	_, err := fetchRemoteHosts(&http.Client{Timeout: 5 * time.Second}, ts.URL)
+	if err == nil {
+		t.Fatal("expected an error on 403")
+	}
+	for _, want := range []string{"HTTP 403", "not authorised to read policy", "reload_callers"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestRenderHostTable(t *testing.T) {
+	t.Parallel()
+	hosts := map[string]hostEntry{
+		"web01": {
+			Addr: "10.0.0.1:22", User: "deploy", Principal: "host:web01",
+			MaxTTLSeconds: 120, SourceAddress: "203.0.113.10",
+			AllowSudo: true, AllowedSudoUsers: []string{"root"},
+			Groups: []string{"prod-web"}, AllowedCallers: []string{"broker-1"},
+		},
+	}
+	var sb strings.Builder
+	renderHostTable(&sb, hosts)
+	out := sb.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want header + 1 row:\n%s", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "NAME") || !strings.Contains(lines[0], "PRINCIPAL") || !strings.Contains(lines[0], "POLICY") {
+		t.Errorf("unexpected header: %q", lines[0])
+	}
+	for _, want := range []string{"web01", "10.0.0.1:22", "deploy", "host:web01", "120s", "203.0.113.10", "prod-web", "broker-1"} {
+		if !strings.Contains(lines[1], want) {
+			t.Errorf("row missing %q: %q", want, lines[1])
+		}
+	}
+
+	sb.Reset()
+	renderHostTable(&sb, nil)
+	if got := strings.TrimSpace(sb.String()); got != "(no hosts configured)" {
+		t.Errorf("empty table output = %q", got)
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -180,6 +180,11 @@ func main() {
 	mux.HandleFunc("POST /v1/policy/hosts/{host}/grants", srv.handleGrantCreate)
 	mux.HandleFunc("GET /v1/policy/grants", srv.handleGrantList)
 	mux.HandleFunc("DELETE /v1/policy/grants/{id}", srv.handleGrantRevoke)
+	// Full host-policy read for operators (auth: reload_callers): the current
+	// in-memory table, same schema as signer.json "hosts". Unlike GET /v1/hosts
+	// (caller-scoped connectivity view) it exposes every internal policy field,
+	// so it shares the mutation trust tier. Used by `broker-ctl host list --remote`.
+	mux.HandleFunc("GET /v1/policy/hosts", srv.handlePolicyHostsRead)
 
 	// Hot-reload via SIGHUP (in addition to the HTTP endpoint). Local to the
 	// host, so it bypasses the reload_callers allowlist.

--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -222,3 +222,46 @@ func (s *server) auditPolicy(caller, host, pattern string, add bool, outcome str
 		log.Printf("warning: error writing signer audit log: %v", aerr)
 	}
 }
+
+// handlePolicyHostsRead serves the full host-policy table (GET /v1/policy/hosts).
+// Auth is mTLS + reload_callers — the same "may change policy" tier as the
+// mutation APIs above, because the response carries every internal policy field
+// (principal, source_address, TTLs, allowed_callers, command_policy) that
+// GET /v1/hosts deliberately withholds from brokers. It serves the current
+// in-memory table, so it reflects hot-reloads and runtime mutations without a
+// restart. Successful reads and denied attempts are both recorded in the audit
+// log: a full policy dump is security-sensitive. No X-On-Behalf-Of handling —
+// the admin tier is direct-CN only, exactly like /v1/reload.
+func (s *server) handlePolicyHostsRead(w http.ResponseWriter, r *http.Request) {
+	caller, authd, authz := s.policyAdmin(r)
+	if !authd {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	if !authz {
+		s.auditPolicyRead(caller, 0, "policy-read-denied", errors.New("caller not authorised"))
+		http.Error(w, "not authorised to read policy", http.StatusForbidden)
+		return
+	}
+	_, hosts, _, _ := s.snapshot()
+	if hosts == nil {
+		hosts = signer.PolicyTable{}
+	}
+	s.auditPolicyRead(caller, len(hosts), "policy-read", nil)
+	writeJSON(w, http.StatusOK, hosts)
+}
+
+// auditPolicyRead records a full host-policy read attempt in the signed audit log.
+func (s *server) auditPolicyRead(caller string, hosts int, outcome string, err error) {
+	e := audit.Entry{
+		Caller:  caller,
+		Command: fmt.Sprintf("policy-hosts-read hosts=%d", hosts),
+		Outcome: outcome,
+	}
+	if err != nil {
+		e.Err = err.Error()
+	}
+	if aerr := s.audit.Append(e); aerr != nil {
+		log.Printf("warning: error writing signer audit log: %v", aerr)
+	}
+}

--- a/cmd/signer/policy_read_test.go
+++ b/cmd/signer/policy_read_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/luisgf/ssh-broker/internal/audit"
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+// policyReadHosts is a raw (uncompiled) table exercising every JSON-visible
+// HostPolicy field, so the round-trip assertion proves the endpoint leaks
+// nothing and loses nothing.
+func policyReadHosts() signer.PolicyTable {
+	return signer.PolicyTable{
+		"web01": {
+			Addr:             "10.0.0.1:22",
+			User:             "deploy",
+			HostKey:          "ssh-ed25519 AAAAC3Nza...",
+			Jump:             "bastion",
+			Principal:        "host:web01",
+			SourceAddress:    "203.0.113.10",
+			MaxTTLSeconds:    120,
+			AllowAsBastion:   false,
+			AllowedCallers:   []string{"broker-1"},
+			AllowSudo:        true,
+			AllowedSudoUsers: []string{"root", "deploy"},
+			AllowPTY:         true,
+			Groups:           []string{"prod-web"},
+			CommandPolicy: signer.CommandPolicy{
+				Mode:            signer.CmdPolicyAllowlist,
+				ShellParse:      true,
+				Allow:           []string{"^uptime$", "^systemctl restart [a-z0-9_.-]+$"},
+				RequireApproval: []string{"^systemctl restart "},
+			},
+		},
+		"bastion": {
+			Addr:           "203.0.113.10:22",
+			User:           "jump",
+			HostKey:        "ssh-ed25519 AAAAC3Nzb...",
+			Principal:      "host:bastion",
+			MaxTTLSeconds:  60,
+			AllowAsBastion: true,
+			Groups:         []string{"prod-web"},
+		},
+	}
+}
+
+func policyReadTestServer(t *testing.T, reloadCN map[string]struct{}) *server {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize) // deterministic test signing key
+	auditLog, err := audit.Open(filepath.Join(t.TempDir(), "audit.log"), ed25519.NewKeyFromSeed(seed))
+	if err != nil {
+		t.Fatalf("audit open: %v", err)
+	}
+	t.Cleanup(func() { auditLog.Close() })
+
+	return &server{
+		hosts:    policyReadHosts(),
+		audit:    auditLog,
+		reloadCN: reloadCN,
+	}
+}
+
+func policyReadMux(s *server) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/policy/hosts", s.handlePolicyHostsRead)
+	return mux
+}
+
+// TestPolicyHostsReadRoundTrip: an authorised CN gets the full table back,
+// field for field — including the internal policy fields that GET /v1/hosts
+// deliberately withholds (principal, source_address, max_ttl_seconds,
+// allowed_callers, command_policy).
+func TestPolicyHostsReadRoundTrip(t *testing.T) {
+	t.Parallel()
+	srv := policyReadTestServer(t, map[string]struct{}{"admin": {}})
+	mux := policyReadMux(srv)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodGet, "/v1/policy/hosts", "admin", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var got signer.PolicyTable
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if want := policyReadHosts(); !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestPolicyHostsReadAuth: the endpoint shares the reload_callers tier —
+// unknown CN → 403, no client cert → 401, empty reload_callers → 403 for
+// everyone (endpoint effectively disabled), non-GET → 405 from the mux.
+func TestPolicyHostsReadAuth(t *testing.T) {
+	t.Parallel()
+	srv := policyReadTestServer(t, map[string]struct{}{"admin": {}})
+	mux := policyReadMux(srv)
+
+	cases := []struct {
+		name   string
+		method string
+		cn     string
+		want   int
+	}{
+		{"authorised", http.MethodGet, "admin", http.StatusOK},
+		{"not-authorised", http.MethodGet, "broker-1", http.StatusForbidden},
+		{"unauthenticated", http.MethodGet, "", http.StatusUnauthorized},
+		{"post", http.MethodPost, "admin", http.StatusMethodNotAllowed},
+	}
+	for _, tc := range cases {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, grantRequest(tc.method, "/v1/policy/hosts", tc.cn, nil))
+		if rec.Code != tc.want {
+			t.Errorf("%s: status = %d, want %d", tc.name, rec.Code, tc.want)
+		}
+	}
+
+	// Empty reload_callers: nobody is authorised, matching the mutation APIs.
+	empty := policyReadTestServer(t, map[string]struct{}{})
+	rec := httptest.NewRecorder()
+	policyReadMux(empty).ServeHTTP(rec, grantRequest(http.MethodGet, "/v1/policy/hosts", "admin", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("empty reload_callers: status = %d, want 403", rec.Code)
+	}
+}
+
+// TestPolicyHostsReadFreshness: the endpoint serves the in-memory table, so a
+// hot-reload (simulated by swapping s.hosts under the lock) is visible on the
+// next request without a restart.
+func TestPolicyHostsReadFreshness(t *testing.T) {
+	t.Parallel()
+	srv := policyReadTestServer(t, map[string]struct{}{"admin": {}})
+	mux := policyReadMux(srv)
+
+	srv.mu.Lock()
+	srv.hosts = signer.PolicyTable{"onlyone": {Principal: "host:onlyone", MaxTTLSeconds: 30}}
+	srv.mu.Unlock()
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodGet, "/v1/policy/hosts", "admin", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got signer.PolicyTable
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(got) != 1 || got["onlyone"].Principal != "host:onlyone" {
+		t.Errorf("response does not reflect the reloaded table: %+v", got)
+	}
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -108,8 +108,17 @@ sudo systemctl enable --now ssh-broker-control-plane # if installed
 sudo systemctl enable --now ssh-broker-mcp-http      # if installed
 
 curl -s http://127.0.0.1:9160/healthz                # signer liveness (monitor_listen)
-curl -s --cert broker.crt --key broker.key \
-     --cacert mtls_ca.crt https://<signer>:9443/v1/hosts   # end-to-end: mTLS + RBAC + policy
+
+# End-to-end: mTLS + reload_callers authz + full policy load in one shot.
+# Uses /etc/ssh-broker/broker-ctl.json (seeded by the installer) for URL and
+# certs; the client cert CN must be in the signer's reload_callers.
+broker-ctl host list --remote
+
+# RBAC default-deny check (separate: the admin read above bypasses group
+# filtering). An unknown CN must get {} when callers._default is default-deny:
+curl -s --cert other.crt --key other.key --cacert mtls_ca.crt \
+     https://<signer>:9443/v1/hosts
+
 journalctl -u ssh-broker-signer -f                   # logs go to the journal
 ```
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -105,6 +105,17 @@ for svc in ${SERVICES}; do
     fi
 done
 
+# 4b. broker-ctl client parameters: /etc/ssh-broker/broker-ctl.json is the
+# last entry of broker-ctl's search order, so the admin CLI works without
+# --url/--cert/--key/--ca flags once it points at the real PKI.
+if [[ -f "${ROOT}/broker-ctl.example.json" ]]; then
+    install -m 0640 -o root -g ssh-broker "${ROOT}/broker-ctl.example.json" "${ETCDIR}/broker-ctl.json.example"
+    if [[ ! -f "${ETCDIR}/broker-ctl.json" ]]; then
+        install -m 0640 -o root -g ssh-broker "${ROOT}/broker-ctl.example.json" "${ETCDIR}/broker-ctl.json"
+        echo "installed ${ETCDIR}/broker-ctl.json (from example — EDIT BEFORE USING)"
+    fi
+fi
+
 # 5. systemd units.
 for svc in ${SERVICES}; do
     unit="$(svc_unit "${svc}")"

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,7 @@ request/response schema changes.
   - [POST /v1/reload](#post-v1reload)
   - [POST·DELETE /v1/policy/hosts/{host}/allow](#post-v1policyhostshostallow--delete-v1policyhostshostallow)
   - [Runtime grants: POST /v1/policy/hosts/{host}/grants · GET /v1/policy/grants · DELETE /v1/policy/grants/{id}](#runtime-grants)
+  - [GET /v1/policy/hosts](#get-v1policyhosts)
 - [Control Plane API](#control-plane-api) — `cmd/control-plane` · HTTPS + mTLS · default `:7443`
   - [POST /v1/sign](#post-v1sign-control-plane)
   - [GET /v1/sign/result/{id}](#get-v1signresultid)
@@ -382,6 +383,35 @@ store, so they appear in `GET /v1/policy/grants` (with a `waive_approval` field)
 are revoked by `DELETE /v1/policy/grants/{id}` like any grant. Audit outcomes:
 `approval-waiver-created` / `approval-waiver-failed`, carrying the originating
 `approval_id` and approver.
+
+---
+
+### GET /v1/policy/hosts
+
+Return the **full host-policy table** — the current in-memory state, so it
+reflects hot-reloads and policy mutations without a restart. The response uses
+exactly the schema of the `hosts` object in `signer.json`, including the
+internal issuance-policy fields that [`GET /v1/hosts`](#get-v1hosts)
+deliberately withholds from brokers: `principal`, `source_address`,
+`max_ttl_seconds`, `allow_as_bastion`, `allowed_callers`, `allowed_sudo_users`
+and `command_policy`. This is the read counterpart of the policy mutation
+APIs, and what `broker-ctl host list --remote` consumes.
+
+**Auth:** mTLS client certificate whose CN is in `reload_callers` — the same
+"may change policy" trust tier as [`POST /v1/reload`](#post-v1reload) and the
+mutation APIs, because reading the complete policy is as sensitive as changing
+it. No `X-On-Behalf-Of` handling (admin tier is direct-CN only). An empty
+`reload_callers` disables the endpoint (403 for everyone).
+**No request body.**
+
+**Response body (200 OK):** JSON object mapping host name → the full host
+policy object (see [`signer.json` reference](reference/config.md)).
+
+**Errors:** `401` no client certificate · `403` CN not in `reload_callers`.
+
+**Audit:** every read attempt is recorded — outcome `policy-read` (with the
+host count) on success, `policy-read-denied` on 403. A full policy dump is
+security-sensitive, so unlike `GET /v1/hosts` this endpoint is audited.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [v1.30.0] - 2026-07-02
+
+### Added
+- `GET /v1/policy/hosts` on the signer: full host-policy read (the current
+  in-memory table, same schema as the signer.json `hosts` object, including
+  the fields `GET /v1/hosts` withholds from brokers — principal, TTLs,
+  `allowed_callers`, `command_policy`). Auth is the `reload_callers` tier,
+  like the policy mutation APIs; every read attempt is audited
+  (`policy-read` / `policy-read-denied`).
+- `broker-ctl host list --remote`: renders the live policy from a running
+  signer over mTLS with the same columns as the local view — the recommended
+  post-deploy end-to-end check. A non-200 is a hard failure (no silent
+  fallback to the reduced `/v1/hosts` view).
+- broker-ctl client parameters file: the remote commands (`reload`,
+  `policy add/remove/grant/grants/revoke`, `approval list/allow/deny`,
+  `host list --remote`) resolve `--url/--cert/--key/--ca` with per-parameter
+  precedence **flag > env > file > default**. File search order:
+  `--client-config`, `$BROKER_CTL_CONFIG`, `./broker-ctl.json`,
+  `~/.config/broker-ctl/config.json`, `/etc/ssh-broker/broker-ctl.json`
+  (seeded by `deploy/install.sh`). Env vars:
+  `BROKER_CTL_SIGNER_{URL,CERT,KEY,CA}`, `BROKER_CTL_CP_{URL,CERT,KEY,CA}`.
+  New `broker-ctl.example.json`, validated against the struct in CI.
+- The signer-facing remote commands accept `--url`, so none of them need a
+  local `signer.json` anymore (its `listen` field remains the last-resort
+  URL fallback).
+
 ## [v1.29.0] - 2026-07-02
 
 ### Added

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -163,7 +163,7 @@ go build -o ~/bin/broker-ctl ./cmd/broker-ctl
 **Global options (before the subcommand):**
 
 ```bash
-broker-ctl [--config <signer.json>] <command> [args]
+broker-ctl [--config <signer.json>] [--client-config <broker-ctl.json>] <command> [args]
 broker-ctl --version [--verbose]     # print the build version
 ```
 
@@ -174,6 +174,29 @@ binaries. It defaults to `./signer.json`.
 > **Breaking change (v1.15.0):** `--config` no longer works *after* the
 > subcommand. Replace `broker-ctl host list --config f` with
 > `broker-ctl --config f host list`.
+
+### Client configuration (remote commands)
+
+The remote commands (`reload`, `policy add/remove/grant/grants/revoke`,
+`approval list/allow/deny`, `host list --remote`) need a URL and an mTLS
+identity. Instead of repeating `--url/--cert/--key/--ca` on every call, put
+them in a **client parameters file** (this is client-side config — the service
+policy stays in `signer.json`):
+
+```json
+{
+  "signer":        { "url": "127.0.0.1:9443", "cert": "pki/broker.crt", "key": "pki/broker.key", "ca": "pki/mtls_ca.crt" },
+  "control_plane": { "url": "127.0.0.1:7443", "cert": "pki/broker-admin.crt", "key": "pki/broker-admin.key", "ca": "pki/mtls_ca.crt" }
+}
+```
+
+Search order: `--client-config` → `$BROKER_CTL_CONFIG` → `./broker-ctl.json` →
+`~/.config/broker-ctl/config.json` → `/etc/ssh-broker/broker-ctl.json`
+(the production installer seeds the last one). Per-parameter precedence:
+**explicit flag > env var > file > built-in default**. Environment variables:
+`BROKER_CTL_SIGNER_{URL,CERT,KEY,CA}` for the signer section,
+`BROKER_CTL_CP_{URL,CERT,KEY,CA}` for the control plane. See
+`broker-ctl.example.json`.
 
 ### Hosts
 
@@ -205,6 +228,12 @@ broker-ctl host add --name web01 --addr 10.0.0.1:22 --user deploy --scan --force
 
 # List hosts (columns: JUMP, SRC_ADDR, SUDO_USERS, CALLERS, POLICY)
 broker-ctl host list
+
+# List the LIVE policy from a running signer over mTLS (GET /v1/policy/hosts;
+# the client cert CN must be in reload_callers). Same columns as the local
+# view, but reflecting the in-memory state after hot-reloads and grants —
+# also the recommended post-deploy end-to-end check.
+broker-ctl host list --remote
 
 # Remove host
 broker-ctl host remove web01
@@ -607,6 +636,9 @@ Reference layout: binaries in `/usr/local/bin`, configs in
 `/etc/ssh-broker/` (never overwritten on upgrade), mTLS PKI in
 `/etc/ssh-broker/pki/`, audit logs in `/var/lib/ssh-broker/<svc>/`.
 Policy hot-reload maps to `systemctl reload ssh-broker-signer` (SIGHUP).
+The installer also seeds `/etc/ssh-broker/broker-ctl.json` (client parameters,
+see §4) so `broker-ctl host list --remote` works flag-less as the post-deploy
+end-to-end check.
 
 **CA custody is the operator's choice**, made in `signer.json` → `ca_keys`:
 `"akv"` (Azure Key Vault — the private key never leaves the vault;

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,11 +8,11 @@ Top-level command reference, captured from `broker-ctl` itself. Run any subcomma
 broker-ctl — SSH broker configuration management
 
 Usage:
-  broker-ctl [--config f] <command> [args]
+  broker-ctl [--config f] [--client-config f] <command> [args]
 
 Commands:
   broker-ctl host add      [flags]                          Add or update a host
-  broker-ctl host list                                      List configured hosts
+  broker-ctl host list     [--remote]                       List configured hosts (--remote: live from the signer, mTLS)
   broker-ctl host remove   <name>                           Remove a host
   broker-ctl ca-keys add   --name <n> [flags]               Add or update a CA key entry
   broker-ctl ca-keys list                                   List configured CA keys
@@ -37,7 +37,16 @@ Commands:
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:
-  --config   Path to signer.json (default: ./signer.json), before the subcommand
-  --version  Print the build version and exit (--verbose for details)
+  --config         Path to signer.json (default: ./signer.json), before the subcommand
+  --client-config  Path to the client parameters file for the remote commands
+  --version        Print the build version and exit (--verbose for details)
+
+Client parameters (remote commands: reload, policy add/remove/grant/grants/revoke,
+approval, host list --remote):
+  Per-parameter precedence: flag > env var > client config file > default.
+  File search order: --client-config, $BROKER_CTL_CONFIG, ./broker-ctl.json,
+  ~/.config/broker-ctl/config.json, /etc/ssh-broker/broker-ctl.json. Sections
+  "signer" and "control_plane", each with url/cert/key/ca (see broker-ctl.example.json).
+  Env vars: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA}, BROKER_CTL_CP_{URL,CERT,KEY,CA}.
 exit status 1
 ```

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -16,6 +16,7 @@ Every route registered across the services, extracted from the `mux.HandleFunc` 
 | `DELETE /v1/policy/grants/{id}` | `srv.handleGrantRevoke` |
 | `DELETE /v1/policy/hosts/{host}/allow` | `srv.handlePolicyAllow` |
 | `GET /v1/policy/grants` | `srv.handleGrantList` |
+| `GET /v1/policy/hosts` | `srv.handlePolicyHostsRead` |
 | `POST /v1/policy/hosts/{host}/allow` | `srv.handlePolicyAllow` |
 | `POST /v1/policy/hosts/{host}/grants` | `srv.handleGrantCreate` |
 


### PR DESCRIPTION
Closes #33

Replaces the hand-written mTLS `curl` from the deploy verification with first-class tooling, as discussed after the v1.29.0 deployment test.

## Signer: `GET /v1/policy/hosts`

Full host-policy read — the current **in-memory** table (reflects hot-reloads and runtime mutations), serialized with the exact `signer.json` `hosts` schema, including everything `GET /v1/hosts` deliberately withholds from brokers (principal, `source_address`, TTLs, `allowed_callers`, `command_policy`). Auth is the `reload_callers` tier, same as the mutation APIs (reading the whole policy is as sensitive as changing it); empty `reload_callers` disables it; no `X-On-Behalf-Of`. Every read attempt is audited: `policy-read` (with host count) / `policy-read-denied`.

## broker-ctl: `host list --remote`

Same 15 columns as the local view (shared `renderHostTable`, so they can never drift). Non-200 → hard failure with a `reload_callers` hint; deliberately **no fallback** to the reduced `/v1/hosts` view, whose blank PRINCIPAL/TTL/CALLERS/POLICY columns would read as "no policy configured".

## broker-ctl: client parameters file

All remote commands (`reload`, `policy add/remove/grant/grants/revoke`, `approval list/allow/deny`, `host list --remote`) resolve `--url/--cert/--key/--ca` with per-parameter precedence **flag > env > file > built-in default** (`fs.Visit` detects explicitly-set flags). Search order: `--client-config` → `$BROKER_CTL_CONFIG` → `./broker-ctl.json` → `~/.config/broker-ctl/config.json` → `/etc/ssh-broker/broker-ctl.json` (seeded by `deploy/install.sh`). Env vars: `BROKER_CTL_SIGNER_{URL,CERT,KEY,CA}` / `BROKER_CTL_CP_{URL,CERT,KEY,CA}`. A malformed file is a hard error, never silently skipped. The signer-facing commands gain `--url`, so no local `signer.json` is needed anymore (its `listen` stays as last-resort fallback). Fully backward compatible: with no file/env present, behavior and defaults are unchanged.

## Tests

- Signer: full-schema round-trip (proves no `json:"-"` leakage/loss), 401/403/405, empty `reload_callers`, freshness after a simulated reload.
- broker-ctl: `fetchRemoteHosts` (httptest, incl. 403 error surface), `renderHostTable`, client-config precedence/search-order/malformed-file, and `broker-ctl.example.json` validated against the struct in `make docs-check` like the other example configs.

## Verified live on this machine

Against the systemd install from the v1.29.0 test: flag-less `broker-ctl host list --remote` using `/etc/ssh-broker/broker-ctl.json`; env-override precedence (cert swapped via `BROKER_CTL_SIGNER_CERT` → 403 for the non-admin CN, with hint); `systemctl reload` freshness (new host visible without restart); audit log shows `policy-read` ×2 and `policy-read-denied` ×1. Service stopped/disabled afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)