### PR TITLE
ci(docs): serialize Pages deploys and cover broker-ctl example config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Validate example configs against structs
-        run: go test ./cmd/signer/ ./cmd/control-plane/ ./internal/broker/ -run ExampleConfig
+        run: go test ./cmd/signer/ ./cmd/control-plane/ ./cmd/broker-ctl/ ./internal/broker/ -run ExampleConfig
 
       - name: Build site (strict — broken links/anchors fail)
         run: mkdocs build --strict
@@ -66,9 +66,15 @@ jobs:
           path: site
 
   # Publish to GitHub Pages. Only on push to main, after the gate passes.
+  # GitHub Pages allows a single active deployment: serialize deploys from
+  # back-to-back merges (queue, don't cancel — cancelling mid-deploy leaves a
+  # server-side "in progress deployment" lock that 400s the next attempt).
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: check
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
The Docs runs for the #34 and #35 merges both failed to deploy: GitHub Pages allows one active deployment, the first hung until `deploy-pages`' 10-minute timeout, and the second was rejected with `Deployment request failed ... due to in progress deployment` (run 28603768473). Neither merge got published.

- Job-level `concurrency: {group: github-pages, cancel-in-progress: false}` on the deploy job — back-to-back merges now queue instead of clashing. Queue rather than cancel: cancelling a Pages deploy mid-flight leaves the server-side "in progress" lock that produces exactly this 400.
- The example-config validation step now includes `./cmd/broker-ctl/`, matching `make docs-check` (drift introduced in #34 when `broker-ctl.example.json` gained its own struct test).

After merge I'll confirm the Docs run deploys the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)