### PR TITLE
fix: reject empty one-shot command at the signer (force-command bypass)

### DIFF
--- a/internal/signer/security_test.go
+++ b/internal/signer/security_test.go
@@ -41,6 +41,51 @@ func TestResolveBastionRoleRejectedOnCommandPolicyHost(t *testing.T) {
 	}
 }
 
+// TestResolveRejectsEmptyOneShotCommand is the regression test for the
+// force-command bypass: an empty (or whitespace-only) one-shot target command
+// bakes no force-command into the certificate (ca.BuildAndSign omits the
+// critical option when empty), producing an unrestricted host credential that
+// also evades denylist and require_approval evaluation. The authoritative
+// signer must reject it, mirroring the broker's "command is required" guard.
+func TestResolveRejectsEmptyOneShotCommand(t *testing.T) {
+	t.Parallel()
+	pt := PolicyTable{
+		// Denylist host: an empty command matches no deny rule (default-allow),
+		// so without the guard it would be issued with no force-command.
+		"deny01": {
+			Principal:     "host:deny01",
+			MaxTTL:        2 * time.Minute,
+			CommandPolicy: CommandPolicy{Mode: CmdPolicyDenylist, Deny: []string{"^rm "}},
+		},
+		// Require-approval-only host: an empty command matches no approval
+		// pattern, so RequireApproval would be false and the approval gate would
+		// never fire.
+		"appr01": {
+			Principal:     "host:appr01",
+			MaxTTL:        2 * time.Minute,
+			CommandPolicy: CommandPolicy{Mode: CmdPolicyOff, RequireApproval: []string{"^systemctl "}},
+		},
+	}
+	for _, host := range []string{"deny01", "appr01"} {
+		for _, cmd := range []string{"", "   ", "\t"} {
+			if _, err := pt.Resolve(Intent{
+				Caller: "broker-1", Host: host, Role: RoleTarget, Purpose: PurposeOneshot,
+				Command: cmd, RequestedTTL: time.Minute,
+			}, time.Minute); err == nil {
+				t.Errorf("host %q: empty/whitespace one-shot command %q must be rejected (force-command bypass)", host, cmd)
+			}
+		}
+	}
+	// A non-empty command on the same denylist host is still allowed — the guard
+	// must not over-reject.
+	if _, err := pt.Resolve(Intent{
+		Caller: "broker-1", Host: "deny01", Role: RoleTarget, Purpose: PurposeOneshot,
+		Command: "uptime", RequestedTTL: time.Minute,
+	}, time.Minute); err != nil {
+		t.Errorf("non-empty command must still be allowed on the denylist host: %v", err)
+	}
+}
+
 // TestValidateRejectsBastionPlusCommandPolicy ensures the unsafe combination is
 // caught at config load/reload, not only at request time.
 func TestValidateRejectsBastionPlusCommandPolicy(t *testing.T) {

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -458,6 +458,17 @@ func authorizeIntent(hp HostPolicy, in Intent) error {
 	if strings.ContainsAny(in.Command, "\n\r") && (in.Purpose == PurposeOneshot || hp.effectivePolicies().Restricts()) {
 		return fmt.Errorf("command must not contain newline characters (\\n or \\r)")
 	}
+	// A one-shot target's only command restriction is the force-command baked
+	// into the certificate. An empty (or whitespace-only) command bakes no
+	// force-command at all — ca.BuildAndSign emits the critical option only when
+	// non-empty — yielding an unrestricted host credential that also slips past
+	// denylist and require_approval evaluation, since an empty string matches no
+	// rule (allowlist hosts still deny it). The broker already requires a
+	// command; enforce the same invariant at the authoritative signer so a
+	// malicious or buggy client cannot obtain an unconstrained certificate.
+	if in.Purpose == PurposeOneshot && in.Role == RoleTarget && strings.TrimSpace(in.Command) == "" {
+		return fmt.Errorf("one-shot command must not be empty")
+	}
 	if !callerAllowed(hp.AllowedCallers, in.Caller) {
 		return fmt.Errorf("caller %q not authorised for %q", in.Caller, in.Host)
 	}

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -108,7 +108,7 @@ func TestResolveTTLCap(t *testing.T) {
 	t.Parallel()
 	d, _ := testPolicy().Resolve(Intent{
 		Caller: "x", Host: "web01", Role: RoleTarget, Purpose: PurposeOneshot,
-		RequestedTTL: time.Hour, // greater than MaxTTL=2m
+		Command: "uptime", RequestedTTL: time.Hour, // greater than MaxTTL=2m
 	}, 5*time.Minute)
 	if d.Constraints.TTL != 2*time.Minute {
 		t.Errorf("TTL = %s, want capped at 2m", d.Constraints.TTL)
@@ -118,10 +118,10 @@ func TestResolveTTLCap(t *testing.T) {
 func TestResolveAuthz(t *testing.T) {
 	t.Parallel()
 	p := testPolicy()
-	if _, err := p.Resolve(Intent{Caller: "broker-b", Host: "locked", Role: RoleTarget, Purpose: PurposeOneshot, RequestedTTL: time.Minute}, time.Minute); err == nil {
+	if _, err := p.Resolve(Intent{Caller: "broker-b", Host: "locked", Role: RoleTarget, Purpose: PurposeOneshot, Command: "uptime", RequestedTTL: time.Minute}, time.Minute); err == nil {
 		t.Error("expected denial for unauthorised caller")
 	}
-	if _, err := p.Resolve(Intent{Caller: "broker-a", Host: "locked", Role: RoleTarget, Purpose: PurposeOneshot, RequestedTTL: time.Minute}, time.Minute); err != nil {
+	if _, err := p.Resolve(Intent{Caller: "broker-a", Host: "locked", Role: RoleTarget, Purpose: PurposeOneshot, Command: "uptime", RequestedTTL: time.Minute}, time.Minute); err != nil {
 		t.Errorf("authorised caller must not fail: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #37

## Vulnerability
For a one-shot target, the signer sets the cert's force-command to the requested command. An **empty** command bakes **no** force-command critical option at all (`ca.BuildAndSign` emits it only when non-empty), so the issued certificate is an unrestricted credential for the host principal. The empty string also evades the command firewall: on a **denylist** host it matches no deny rule (default-allow), and `require_approval` patterns never match, so the human-approval gate never fires. The broker self-guards (`engine.go`), but the signer is the authoritative network boundary reachable by any authorized mTLS CN and must self-defend.

## Fix
Reject a whitespace-only command for `Purpose=oneshot && Role=target` in `authorizeIntent` — the same place that already rejects unknown role/purpose and newline injection — mirroring the broker's "command is required" invariant. Allowlist hosts were already safe (empty → no allow match → denied).

## Tests
- New `TestResolveRejectsEmptyOneShotCommand`: a denylist host and an approval-only host both reject `""`, `"   "`, `"\t"`; a non-empty command on the denylist host is still allowed (guard does not over-reject).
- Updated two existing tests (`TestResolveTTLCap`, `TestResolveAuthz`) that used an empty command as a don't-care fixture on the one-shot path.

## Verification
`gofmt -l .` clean · `go vet ./...` · `go build ./...` · `go test -race ./...` all pass.