### PR TITLE
fix: allow the signer unit to persist policy changes (ReadWritePaths)

### DIFF
--- a/deploy/systemd/ssh-broker-signer.service
+++ b/deploy/systemd/ssh-broker-signer.service
@@ -44,6 +44,12 @@ RestartSec=2
 # listen on its mTLS port, and (akv only) outbound HTTPS to the vault / IMDS.
 NoNewPrivileges=yes
 ProtectSystem=strict
+# The durable policy-mutation API (POST/DELETE /v1/policy/hosts/{host}/allow)
+# and `broker-ctl policy add/remove` rewrite signer.json in place via a
+# temp-file+rename in /etc/ssh-broker, so that directory must be writable
+# despite ProtectSystem=strict. A compromised signer already holds the CA key
+# in memory, so write access to the config dir does not widen the blast radius.
+ReadWritePaths=/etc/ssh-broker
 ProtectHome=yes
 PrivateTmp=yes
 PrivateDevices=yes


### PR DESCRIPTION
Closes #38

`ProtectSystem=strict` mounts `/etc` read-only, but the durable policy-mutation API (`POST/DELETE /v1/policy/hosts/{host}/allow`, `broker-ctl policy add/remove`) rewrites `/etc/ssh-broker/signer.json` via temp-file+rename. Without `ReadWritePaths` that write fails EROFS → HTTP 500 and the change never persists, while in-memory grants and SIGHUP reload keep working and hide the breakage.

Add `ReadWritePaths=/etc/ssh-broker` to the **signer** unit only (control-plane and mcp-http write solely to their StateDirectory). A compromised signer already holds the CA key in memory, so a writable config dir does not widen the blast radius.

**Verified:** `systemd-analyze verify` parses the unit clean; `go build`/`go test -race ./...` still green.