### PR TITLE
fix: gate broker-supplied end_user in the approval flow on trusted_forwarders

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -401,6 +401,16 @@ func (s *server) forwardSignResult(w http.ResponseWriter, _ *http.Request, broke
 // rule documents the reason (command policy rule or "behavior"); anomaly lists
 // behaviour anomalies when the escalation came from the guardrails.
 func (s *server) requireApproval(w http.ResponseWriter, brokerCN string, req signer.WireRequest, rule, anomaly string) {
+	// end_user is an unauthenticated, broker-supplied JSON field. Trust it — for
+	// the approver's display, the notifier payload, and the forward to the
+	// signer — only when the broker CN is a trusted forwarder, mirroring
+	// guardrailSubject and the signer's own trusted_forwarders semantics.
+	// Otherwise a malicious broker could label a dangerous command as coming
+	// from a trusted admin (e.g. end_user=ciso@corp) to bias the human decision.
+	// req is a local copy, so clearing it here does not affect the caller.
+	if _, trusted := s.forwarders[brokerCN]; !trusted {
+		req.EndUser = ""
+	}
 	a, err := s.registry.Create(req, brokerCN, &signer.DecisionInfo{RequireApproval: true, MatchedRule: rule})
 	if err != nil {
 		http.Error(w, "could not create approval request", http.StatusInternalServerError)

--- a/cmd/control-plane/main_test.go
+++ b/cmd/control-plane/main_test.go
@@ -592,6 +592,46 @@ func TestControlPlaneSelfApprovalRejected(t *testing.T) {
 	}
 }
 
+// TestRequireApprovalGatesUntrustedEndUser verifies that the unauthenticated,
+// broker-supplied end_user claim only reaches the approval (its display, the
+// notifier, and the forward to the signer) when the broker CN is a trusted
+// forwarder. Otherwise a malicious broker could label a dangerous command as
+// originating from a trusted admin to bias the human approver.
+func TestRequireApprovalGatesUntrustedEndUser(t *testing.T) {
+	s := testServer(t, "")
+
+	// Untrusted broker: end_user must be dropped from both the stored approval
+	// (display/notifier) and the retained request (forward to the signer).
+	w := httptest.NewRecorder()
+	s.requireApproval(w, "rogue-broker",
+		signer.WireRequest{Host: "web01", Command: "reboot now", EndUser: "ciso@corp"}, "rule", "")
+	var acc struct {
+		ApprovalID string `json:"approval_id"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &acc)
+	a, ok := s.registry.Get(acc.ApprovalID)
+	if !ok {
+		t.Fatal("approval not created")
+	}
+	if a.EndUser != "" {
+		t.Errorf("untrusted broker end_user must be dropped from the approval, got %q", a.EndUser)
+	}
+	if fwd, _ := s.registry.Request(acc.ApprovalID); fwd.EndUser != "" {
+		t.Errorf("untrusted broker end_user must not be forwarded to the signer, got %q", fwd.EndUser)
+	}
+
+	// Trusted forwarder: end_user is authoritative and preserved.
+	s.forwarders["trusted-cp"] = struct{}{}
+	w = httptest.NewRecorder()
+	s.requireApproval(w, "trusted-cp",
+		signer.WireRequest{Host: "web01", Command: "reboot now", EndUser: "alice@corp"}, "rule", "")
+	json.Unmarshal(w.Body.Bytes(), &acc)
+	a, _ = s.registry.Get(acc.ApprovalID)
+	if a.EndUser != "alice@corp" {
+		t.Errorf("trusted forwarder end_user must be preserved, got %q", a.EndUser)
+	}
+}
+
 func TestGuardrailSubject(t *testing.T) {
 	t.Parallel()
 	s := &server{forwarders: map[string]struct{}{"trusted-broker": {}}}


### PR DESCRIPTION
Closes #40

`end_user` is an unauthenticated JSON field. `guardrailSubject` already ignores it for non-forwarder broker CNs, but `requireApproval` copied it verbatim into the Approval, so the approver UI, the notifier, and the forward to the signer presented it as an authoritative **End user**. A malicious broker could label a dangerous command as coming from a trusted admin (`end_user=ciso@corp`) to bias the human's approve/deny decision — attacking the very control the approval flow provides.

**Fix:** clear `req.EndUser` in `requireApproval` when the broker CN is not a trusted forwarder (`req` is a local copy, so display, notifier, and the signer forward are all gated consistently). Trusted forwarders are unaffected.

**Verified:** `gofmt -l` clean · `go vet`/`go build`/`go test -race ./...` pass, incl. new `TestRequireApprovalGatesUntrustedEndUser`.