### PR TITLE
fix: build the release from make dist (ships control-plane + deploy/)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # fetch-depth: 0 fetches the full history and tags so `git describe --tags`
+      # in `make dist` resolves the release version to inject into the binaries.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -24,24 +28,21 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Build binaries (linux/amd64)
-        env:
-          GOOS: linux
-          GOARCH: amd64
-          CGO_ENABLED: 0
-        run: |
-          mkdir -p dist
-          for cmd in mcp-broker mcp-broker-http signer broker-ctl; do
-            go build -trimpath -ldflags="-s -w" -o "dist/$cmd" "./cmd/$cmd"
-          done
+      # Build the SAME artifact as the documented install path (OPERATIONS §8):
+      # `make dist` produces dist/ssh-broker-<version>.tar.gz with all six
+      # binaries (incl. control-plane, which the shipped systemd unit execs),
+      # version-injected, plus deploy/ and the example configs. Building a subset
+      # here would ship a release whose control-plane unit has nothing to run.
+      - name: Build release tarball
+        run: make dist
 
-      - name: Package and checksum
+      - name: Checksum
         run: |
-          TAG="${{ github.ref_name }}"
-          ARCHIVE="ssh-broker_${TAG}_linux_amd64.tar.gz"
-          tar -czf "$ARCHIVE" -C dist .
+          cd dist
+          ARCHIVE=$(ls ssh-broker-*.tar.gz)
           sha256sum "$ARCHIVE" > checksums.txt
-          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+          echo "ARCHIVE=dist/$ARCHIVE" >> "$GITHUB_ENV"
+          echo "CHECKSUMS=dist/checksums.txt" >> "$GITHUB_ENV"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -49,4 +50,4 @@ jobs:
           generate_release_notes: true
           files: |
             ${{ env.ARCHIVE }}
-            checksums.txt
+            ${{ env.CHECKSUMS }}


### PR DESCRIPTION
Closes #41

The release job built only 4 binaries and packaged a bare tarball, so the published artifact had **no control-plane** binary (the shipped `ssh-broker-control-plane.service` had nothing to exec) and none of `deploy/` or the example configs — diverging from `make dist` and the install path in OPERATIONS §8. It also dropped the version ldflags (binaries reported `dev-<commit>`).

**Fix:** run `make dist`, which builds all six binaries version-injected plus `deploy/` and the examples as `ssh-broker-<version>.tar.gz` — the exact artifact the docs tell operators to install. `fetch-depth: 0` so `git describe --tags` resolves the version.

**Verified:** YAML parses; `make dist` bundles `bin/control-plane` + `deploy/` + `broker-ctl.example.json` and matches the upload glob; `go build`/`go test` green.