### PR TITLE
docs: audit low-severity documentation fixes (#47–#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Three frontends share the same engine (`internal/broker`) and tool surface
 
 - **MCP stdio (local, recommended for personal use)** — `cmd/mcp-broker`. Tools:
   `ssh_execute`, `ssh_session_open` / `ssh_session_exec` / `ssh_session_close`,
-  `ssh_list_servers`. No transport auth — isolation comes from the process being
-  launched by the user (as the MCP spec recommends for stdio).
+  `ssh_list_servers`, `ssh_put_file` / `ssh_get_file`. No transport auth —
+  isolation comes from the process being launched by the user (as the MCP spec
+  recommends for stdio).
 - **MCP HTTP + OAuth2/OIDC (remote, multi-user)** — `cmd/mcp-broker-http`,
   Streamable HTTP. Same tools, but each client authenticates with an **OIDC
   bearer token** validated locally against the issuer's JWKS; the user identity

--- a/config.example.json
+++ b/config.example.json
@@ -27,6 +27,9 @@
   "_recording_comment": "Optional session recording. When set, shell and pty sessions are recorded to ASCIIcast v2 files in this directory. One file per session: <session_id>.cast. Files are playable with 'asciinema play'. Correlate with audit log via session_id. Empty or absent = recording disabled.",
   "session_recording_dir": "",
 
+  "_file_transfer_comment": "Optional cap (bytes) on a single ssh_put_file / ssh_get_file transfer, per host that sets allow_file_transfer. A transfer larger than the cap is an error, not a truncation. 0 or absent = the built-in default (524288 = 512 KiB).",
+  "file_transfer_max_bytes": 524288,
+
   "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format), started by every frontend (broker, mcp-broker, mcp-broker-http). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: broker_events_total{outcome}, broker_sessions_active, audit_append_failures_total.",
   "monitor_listen": "127.0.0.1:9180",
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -785,6 +785,7 @@ model — only the logical name and capabilities.
 | `name` | string | Logical host name. |
 | `allow_sudo` | bool | Whether sudo elevation is available on this host. |
 | `allow_pty` | bool | Whether PTY allocation is available on this host. |
+| `allow_file_transfer` | bool | Whether the file-transfer tools (`ssh_put_file` / `ssh_get_file`) are available on this host. |
 | `jump` | string | Bastion host name. Empty if direct. |
 
 **Note:** always call `ssh_list_servers` first to discover available hosts and

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -547,6 +547,7 @@ it must be revoked before expiry.
 | `signer.json` | Active signer config (single source of truth for hosts) |
 | `signer.example.json` | Reference with per-host `allow_sudo`/`allowed_sudo_users`/`allow_pty`/`groups`/`command_policy` + `callers` + `trusted_forwarders` |
 | `control-plane.example.json` | Control plane reference: `signer` block, `sign_callers` (broker/approver role separation), `approval` (notifier/callers/timeout), `behavior`, `trusted_forwarders`, mTLS |
+| `broker-ctl.example.json` | Client parameters for the remote `broker-ctl` commands (`signer` / `control_plane` URL + mTLS cert/key/ca); see §4 |
 | `deploy/sshd_config.snippet` | `sshd_config` fragment + NOPASSWD sudoers for managed hosts |
 
 ### Common operational notes


### PR DESCRIPTION
Four independent documentation-drift fixes from the audit, one commit each:

- **#47** `docs/API.md` — add `allow_file_transfer` to the `ssh_list_servers` return table (it is emitted and gates the file-transfer tools).
- **#48** `README.md` — list `ssh_put_file`/`ssh_get_file` in the stdio tool bullet (5 → 7 tools).
- **#49** `docs/OPERATIONS.md` — add `broker-ctl.example.json` to the §6 reference-config table.
- **#50** `config.example.json` — add a commented `file_transfer_max_bytes` example (field name matches the struct; ExampleConfig test green).

**Verified:** ExampleConfig tests pass, `make docs-gen` shows no reference drift, strict mkdocs build passes.

Closes #47
Closes #48
Closes #49
Closes #50