### PR TITLE
fix: audit low-severity hardening (#43–#46)

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -23,7 +23,9 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -754,5 +756,36 @@ func validateConfig(c *Config) error {
 	default:
 		return fmt.Errorf("behavior.mode: unknown value %q (must be off, observe, or enforce)", c.Behavior.Mode)
 	}
+	// A webhook/Teams notifier POSTs full approval details (host, command, sudo
+	// target, caller, end_user) to webhook_url. Require https so those details
+	// are not sent in cleartext; allow http only to a loopback host (a local
+	// relay). Emptiness is reported by the notifier setup with a clearer message.
+	if (c.Approval.Notifier == "webhook" || c.Approval.Notifier == "teams") && c.Approval.WebhookURL != "" {
+		u, err := url.Parse(c.Approval.WebhookURL)
+		if err != nil {
+			return fmt.Errorf("approval.webhook_url: %w", err)
+		}
+		switch u.Scheme {
+		case "https":
+		case "http":
+			if !isLoopbackHost(u.Hostname()) {
+				return fmt.Errorf("approval.webhook_url: http:// sends approval details in cleartext; use https (http allowed only for a loopback host)")
+			}
+		default:
+			return fmt.Errorf("approval.webhook_url: scheme %q not allowed; use https", u.Scheme)
+		}
+	}
 	return nil
+}
+
+// isLoopbackHost reports whether host (a URL hostname, no port) is the local
+// loopback, for which plaintext http to a local relay is acceptable.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }

--- a/cmd/control-plane/main_test.go
+++ b/cmd/control-plane/main_test.go
@@ -632,6 +632,34 @@ func TestRequireApprovalGatesUntrustedEndUser(t *testing.T) {
 	}
 }
 
+// TestValidateConfigWebhookScheme verifies the notifier URL must be https
+// (http allowed only for a loopback relay), so approval details are not POSTed
+// in cleartext.
+func TestValidateConfigWebhookScheme(t *testing.T) {
+	t.Parallel()
+	cfg := func(notifier, u string) *Config {
+		c := &Config{}
+		c.Approval.Notifier = notifier
+		c.Approval.WebhookURL = u
+		return c
+	}
+	if err := validateConfig(cfg("webhook", "http://hooks.example.com/x")); err == nil {
+		t.Error("http:// non-loopback webhook must be rejected")
+	}
+	if err := validateConfig(cfg("teams", "https://hooks.example.com/x")); err != nil {
+		t.Errorf("https webhook must be accepted: %v", err)
+	}
+	if err := validateConfig(cfg("webhook", "http://127.0.0.1:8080/x")); err != nil {
+		t.Errorf("http loopback webhook must be allowed: %v", err)
+	}
+	if err := validateConfig(cfg("webhook", "")); err != nil {
+		t.Errorf("empty webhook_url must not trip the scheme check (handled elsewhere): %v", err)
+	}
+	if err := validateConfig(cfg("log", "http://evil.example")); err != nil {
+		t.Errorf("log notifier must ignore webhook_url: %v", err)
+	}
+}
+
 func TestGuardrailSubject(t *testing.T) {
 	t.Parallel()
 	s := &server{forwarders: map[string]struct{}{"trusted-broker": {}}}

--- a/internal/control/teams.go
+++ b/internal/control/teams.go
@@ -179,7 +179,11 @@ func (t *TeamsNotifier) buildMessageCard(a Approval) map[string]any {
 				"activityTitle":    "SSH Broker — Approval Required",
 				"activitySubtitle": "An AI agent action is waiting for human approval.",
 				"facts":            facts,
-				"markdown":         true,
+				// markdown must stay false: the fact values include the broker-
+				// supplied command and host, and a markdown-enabled MessageCard
+				// would let a crafted command inject a clickable link/formatting
+				// into the approver's notification (phishing / command obscuring).
+				"markdown": false,
 			},
 		},
 	}

--- a/internal/signer/ratelimit.go
+++ b/internal/signer/ratelimit.go
@@ -48,6 +48,12 @@ func (l *RateLimiter) Allow(key string, perMin int) bool {
 	if !ok {
 		if len(l.buckets) >= maxRateLimitKeys {
 			l.prune(now)
+			// If every bucket is still active, pruning frees nothing. Evict the
+			// least-recently-used one so the map stays strictly bounded and the
+			// new key is still rate-limited (rather than admitted uncapped).
+			if len(l.buckets) >= maxRateLimitKeys {
+				l.evictOldest()
+			}
 		}
 		b = &rateBucket{tokens: float64(perMin), last: now}
 		l.buckets[key] = b
@@ -83,12 +89,29 @@ func RetryAfter(perMin int) int {
 
 // prune drops buckets idle long enough to be full again (they carry no state a
 // fresh bucket would not have). Called with l.mu held, only when the map is at
-// its bound; if every entry is active the map simply stays at the bound and
-// new keys are still admitted.
+// its bound.
 func (l *RateLimiter) prune(now time.Time) {
 	for k, b := range l.buckets {
 		if now.Sub(b.last) > time.Minute {
 			delete(l.buckets, k)
 		}
+	}
+}
+
+// evictOldest removes the least-recently-used bucket to keep the map strictly
+// within maxRateLimitKeys when prune frees nothing. Called with l.mu held.
+// Evicting the oldest is safe: its tokens are closest to a full refill, so a
+// re-created bucket differs minimally from the evicted one.
+func (l *RateLimiter) evictOldest() {
+	var oldestKey string
+	var oldest time.Time
+	first := true
+	for k, b := range l.buckets {
+		if first || b.last.Before(oldest) {
+			oldestKey, oldest, first = k, b.last, false
+		}
+	}
+	if !first {
+		delete(l.buckets, oldestKey)
 	}
 }

--- a/internal/signer/ratelimit_test.go
+++ b/internal/signer/ratelimit_test.go
@@ -121,6 +121,25 @@ func TestRateLimiterPruneBound(t *testing.T) {
 	}
 }
 
+// TestRateLimiterHardBound: when the map is full and every bucket is still
+// active (prune frees nothing), a new key must be admitted by evicting the
+// least-recently-used bucket, so the map never grows past the bound.
+func TestRateLimiterHardBound(t *testing.T) {
+	t.Parallel()
+	l := NewRateLimiter()
+	_ = fakeClock(l) // no time advance: all buckets stay active
+	for i := 0; i < maxRateLimitKeys; i++ {
+		l.Allow(fmt.Sprintf("cn-%d", i), 5)
+	}
+	l.Allow("cn-overflow", 5)
+	if len(l.buckets) != maxRateLimitKeys {
+		t.Errorf("map must stay strictly bounded at %d, got %d", maxRateLimitKeys, len(l.buckets))
+	}
+	if _, ok := l.buckets["cn-overflow"]; !ok {
+		t.Error("the overflow key must be admitted (evict-oldest), not silently skipped")
+	}
+}
+
 func TestRetryAfter(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct{ perMin, want int }{

--- a/internal/signer/security_test.go
+++ b/internal/signer/security_test.go
@@ -86,6 +86,21 @@ func TestResolveRejectsEmptyOneShotCommand(t *testing.T) {
 	}
 }
 
+// TestValidateRejectsExcessiveMaxTTL ensures a per-host max_ttl_seconds above
+// the 900s certificate cap is caught at load, not as a silent per-request
+// denial (the CA rejects TTL > 15m in ca.BuildAndSign).
+func TestValidateRejectsExcessiveMaxTTL(t *testing.T) {
+	t.Parallel()
+	pt := PolicyTable{"web01": {Principal: "host:web01", MaxTTLSeconds: 901}}
+	if err := pt.Validate(); err == nil {
+		t.Fatal("Validate must reject max_ttl_seconds above the 900s certificate cap")
+	}
+	pt["web01"] = HostPolicy{Principal: "host:web01", MaxTTLSeconds: 900}
+	if err := pt.Validate(); err != nil {
+		t.Errorf("max_ttl_seconds at the 900s cap must validate: %v", err)
+	}
+}
+
 // TestValidateRejectsBastionPlusCommandPolicy ensures the unsafe combination is
 // caught at config load/reload, not only at request time.
 func TestValidateRejectsBastionPlusCommandPolicy(t *testing.T) {

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -285,6 +285,13 @@ func CompileHostPolicies(hosts PolicyTable, library map[string]CommandPolicy, gr
 				return nil, fmt.Errorf("host %q: jump target %q is not a defined host", name, hp.Jump)
 			}
 		}
+		// The CA hard-rejects any certificate TTL over 15m (ca.BuildAndSign), so
+		// a per-host max_ttl_seconds above that cap would make every issuance for
+		// this host fail at request time. Catch it at load, like the other
+		// invariants here, instead of surfacing a silent per-request denial.
+		if hp.MaxTTLSeconds > 900 {
+			return nil, fmt.Errorf("host %q: max_ttl_seconds %d exceeds the 900s (15m) certificate cap", name, hp.MaxTTLSeconds)
+		}
 		if err := hp.CommandPolicy.Validate(); err != nil {
 			return nil, fmt.Errorf("host %q: %w", name, err)
 		}


### PR DESCRIPTION
Four independent low-severity fixes from the audit, one commit each:

- **#43** `internal/control/teams.go` — set `markdown:false` in the legacy MessageCard so a crafted command/host can't inject links/formatting into the approver notification.
- **#44** `cmd/control-plane/main.go` — require `https` for the webhook/Teams notifier URL (http only for loopback); prevents cleartext leakage of approval details.
- **#45** `internal/signer/signer.go` — reject per-host `max_ttl_seconds > 900` at load instead of a silent per-request denial (CA caps cert TTL at 15m).
- **#46** `internal/signer/ratelimit.go` — evict the LRU bucket when the map is full and prune frees nothing, keeping it strictly bounded.

**Verified:** gofmt clean · go vet · go build · go test -race ./... all pass, with new tests for #44/#45/#46.

Closes #43
Closes #44
Closes #45
Closes #46