### PR TITLE
fix: resolve broker-ctl default cert/key/ca relative to the config file dir (#42)

### DIFF
--- a/cmd/broker-ctl/clientconfig.go
+++ b/cmd/broker-ctl/clientconfig.go
@@ -25,6 +25,12 @@
 // A file that exists but does not parse is always a hard error — never silently
 // ignored.
 //
+// When a config file is loaded but omits a cert/key/ca, the built-in default
+// (./pki/*) is resolved relative to that file's directory rather than the
+// current working directory, so a partial file cannot pull the mTLS trust
+// material from wherever the CLI happens to run. With no config file the default
+// stays CWD-relative (the lab fallback).
+//
 // Environment variables: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and
 // BROKER_CTL_CP_{URL,CERT,KEY,CA}.
 package main
@@ -105,20 +111,29 @@ func loadClientConfigFrom(cands []ccCandidate) (clientConfig, string, error) {
 }
 
 // cachedClientConfig memoizes the result of the first load for the process.
-var cachedClientConfig *clientConfig
+// cachedClientConfigDir is the directory of the loaded file ("" when no file
+// was found), used to resolve relative default paths against.
+var (
+	cachedClientConfig    *clientConfig
+	cachedClientConfigDir string
+)
 
 // loadClientConfig loads the client config once, fatally on a malformed or
-// explicitly-named-but-missing file.
-func loadClientConfig() clientConfig {
+// explicitly-named-but-missing file. It returns the parsed config and the
+// directory of the file it came from ("" when no file was loaded).
+func loadClientConfig() (clientConfig, string) {
 	if cachedClientConfig != nil {
-		return *cachedClientConfig
+		return *cachedClientConfig, cachedClientConfigDir
 	}
-	cfg, _, err := loadClientConfigFrom(clientConfigCandidates())
+	cfg, path, err := loadClientConfigFrom(clientConfigCandidates())
 	if err != nil {
 		fatalf("%v", err)
 	}
 	cachedClientConfig = &cfg
-	return cfg
+	if path != "" {
+		cachedClientConfigDir = filepath.Dir(path)
+	}
+	return cfg, cachedClientConfigDir
 }
 
 // resolveTarget applies the client-parameter precedence to the url/cert/key/ca
@@ -126,10 +141,18 @@ func loadClientConfig() clientConfig {
 // unset flag takes the BROKER_CTL_<env>_{URL,CERT,KEY,CA} variable, then the
 // client config file value, and otherwise keeps its built-in default. Flags
 // the FlagSet does not define are skipped.
-func resolveTarget(fs *flag.FlagSet, env string, file clientTarget) {
+//
+// fileDir is the directory of the loaded config file ("" when none was loaded).
+// When a file was loaded but does NOT set a cert/key/ca, the built-in default
+// (a relative ./pki/* path) is resolved against fileDir instead of the current
+// working directory — so a partial config file cannot silently pull the mTLS
+// cert/key/CA from whatever directory the CLI happens to run in. With no config
+// file, the relative default is kept as-is (the lab/dev fallback, run from the
+// repo where ./pki lives).
+func resolveTarget(fs *flag.FlagSet, env string, file clientTarget, fileDir string) {
 	set := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
-	apply := func(name, envSuffix, fileVal string) {
+	apply := func(name, envSuffix, fileVal string, isPath bool) {
 		if set[name] {
 			return
 		}
@@ -143,24 +166,34 @@ func resolveTarget(fs *flag.FlagSet, env string, file clientTarget) {
 		}
 		if fileVal != "" {
 			f.Value.Set(fileVal)
+			return
+		}
+		// Built-in default stands. If it came alongside a config file and is a
+		// relative path, rebase it onto the file's directory.
+		if isPath && fileDir != "" {
+			if cur := f.Value.String(); cur != "" && !filepath.IsAbs(cur) {
+				f.Value.Set(filepath.Join(fileDir, cur))
+			}
 		}
 	}
-	apply("url", "_URL", file.URL)
-	apply("cert", "_CERT", file.Cert)
-	apply("key", "_KEY", file.Key)
-	apply("ca", "_CA", file.CA)
+	apply("url", "_URL", file.URL, false)
+	apply("cert", "_CERT", file.Cert, true)
+	apply("key", "_KEY", file.Key, true)
+	apply("ca", "_CA", file.CA, true)
 }
 
 // resolveSignerTarget resolves the signer-facing flags of fs (env prefix
 // BROKER_CTL_SIGNER, file section "signer").
 func resolveSignerTarget(fs *flag.FlagSet) {
-	resolveTarget(fs, "BROKER_CTL_SIGNER", loadClientConfig().Signer)
+	cfg, dir := loadClientConfig()
+	resolveTarget(fs, "BROKER_CTL_SIGNER", cfg.Signer, dir)
 }
 
 // resolveControlPlaneTarget resolves the control-plane-facing flags of fs
 // (env prefix BROKER_CTL_CP, file section "control_plane").
 func resolveControlPlaneTarget(fs *flag.FlagSet) {
-	resolveTarget(fs, "BROKER_CTL_CP", loadClientConfig().ControlPlane)
+	cfg, dir := loadClientConfig()
+	resolveTarget(fs, "BROKER_CTL_CP", cfg.ControlPlane, dir)
 }
 
 // signerFlags registers the shared flags of the signer-facing remote commands.

--- a/cmd/broker-ctl/clientconfig_test.go
+++ b/cmd/broker-ctl/clientconfig_test.go
@@ -71,7 +71,7 @@ func TestResolveTargetPrecedence(t *testing.T) {
 		t.Fatal(err)
 	}
 	file := clientTarget{URL: "file.example:9443", Cert: "/file/cert.crt", Key: "/file/key.pem"}
-	resolveTarget(fs, "BROKER_CTL_SIGNER", file)
+	resolveTarget(fs, "BROKER_CTL_SIGNER", file, "") // no file dir → default stays CWD-relative
 
 	if *cert != "/flag/cert.crt" {
 		t.Errorf("flag must win: cert = %q", *cert)
@@ -84,6 +84,56 @@ func TestResolveTargetPrecedence(t *testing.T) {
 	}
 	if *ca != "./pki/mtls_ca.crt" {
 		t.Errorf("built-in default must survive when nothing overrides: ca = %q", *ca)
+	}
+}
+
+// TestResolveTargetRebasesDefaultToFileDir: when a config file was loaded but
+// omits cert/key/ca, the relative ./pki/* default resolves against the file's
+// directory (not the CWD), so a partial file cannot pull mTLS trust material
+// from wherever the CLI runs. With no file dir the default stays CWD-relative.
+func TestResolveTargetRebasesDefaultToFileDir(t *testing.T) {
+	for _, e := range []string{"URL", "CERT", "KEY", "CA"} {
+		t.Setenv("BROKER_CTL_SIGNER_"+e, "")
+	}
+
+	// File provides only the URL; cert/key/ca fall to the default and must
+	// rebase onto the config file's directory.
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	_, cert, key, ca := signerFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	resolveTarget(fs, "BROKER_CTL_SIGNER", clientTarget{URL: "s:9443"}, "/etc/ssh-broker")
+	if *cert != "/etc/ssh-broker/pki/broker.crt" {
+		t.Errorf("cert default must rebase onto the file dir, got %q", *cert)
+	}
+	if *key != "/etc/ssh-broker/pki/broker.key" {
+		t.Errorf("key default must rebase onto the file dir, got %q", *key)
+	}
+	if *ca != "/etc/ssh-broker/pki/mtls_ca.crt" {
+		t.Errorf("ca default must rebase onto the file dir, got %q", *ca)
+	}
+
+	// No file dir: the default stays CWD-relative (lab fallback).
+	fs2 := flag.NewFlagSet("t2", flag.ContinueOnError)
+	_, cert2, _, _ := signerFlags(fs2)
+	if err := fs2.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	resolveTarget(fs2, "BROKER_CTL_SIGNER", clientTarget{}, "")
+	if *cert2 != "./pki/broker.crt" {
+		t.Errorf("with no config file the default must stay CWD-relative, got %q", *cert2)
+	}
+
+	// A file that DOES set cert (absolute) is used verbatim, not rebased.
+	fs3 := flag.NewFlagSet("t3", flag.ContinueOnError)
+	_, cert3, _, _ := signerFlags(fs3)
+	if err := fs3.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	resolveTarget(fs3, "BROKER_CTL_SIGNER", clientTarget{Cert: "/abs/cert.crt"}, "/etc/ssh-broker")
+	if *cert3 != "/abs/cert.crt" {
+		t.Errorf("file-provided cert must be used verbatim, got %q", *cert3)
 	}
 }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -199,7 +199,10 @@ must be named explicitly with `--client-config`. Per-parameter precedence:
 **explicit flag > env var > file > built-in default**. Environment variables:
 `BROKER_CTL_SIGNER_{URL,CERT,KEY,CA}` for the signer section,
 `BROKER_CTL_CP_{URL,CERT,KEY,CA}` for the control plane. See
-`broker-ctl.example.json`.
+`broker-ctl.example.json`. When a config file omits `cert`/`key`/`ca`, the
+built-in `./pki/*` default is resolved relative to that file's directory (not
+the current working directory), so a partial file cannot pull the mTLS trust
+material from wherever `broker-ctl` happens to run.
 
 ### Hosts
 


### PR DESCRIPTION
Closes #42

Implements **Option B** from the issue triage. When a client config file is loaded but omits `cert`/`key`/`ca`, the built-in `./pki/*` defaults resolved against the **current working directory**, so a partial file could pull the mTLS trust material from wherever `broker-ctl` runs (an attacker-writable CWD could plant `./pki/mtls_ca.crt`).

**Fix:** rebase a relative cert/key/ca default onto the loaded config file's directory. With no config file the default stays CWD-relative (lab fallback); a file that sets the value explicitly, or an absolute default, is used verbatim.

**Verified:** gofmt clean · go vet/build · go test -race ./... incl. new `TestResolveTargetRebasesDefaultToFileDir` (rebase when file loaded; CWD-relative when no file; file-provided value verbatim) · make docs-gen + strict mkdocs build.