### PR TITLE
fix: move the signer config to the service-owned state directory (v1.31.1)

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -54,8 +54,10 @@ Run from the repo:
   example configs against the structs).
 - `make version` — confirm the tag you are about to ship; a `-dirty` suffix
   means uncommitted changes: stop and ask.
-- Review the real config that will run (existing `/etc/ssh-broker/*.json` on
-  upgrade, or the edited seed on fresh install) for production posture:
+- Review the real config that will run for production posture (the signer
+  config is `/var/lib/ssh-broker/signer/signer.json` — service-owned so the
+  durable policy API can rewrite it; control-plane/mcp-http configs are under
+  `/etc/ssh-broker/`):
   - `callers` contains `"_default": {"allowed_groups": []}` — default-deny.
     Its absence is the #1 fail-open misconfiguration; flag it.
   - `reload_callers` lists the admin CN. Without it there is no HTTP reload,
@@ -85,8 +87,9 @@ scp dist/ssh-broker-<v>.tar.gz host:  &&  ssh host 'tar xzf ssh-broker-<v>.tar.g
 sudo ./deploy/install.sh [--services "..."]
 ```
 
-Idempotent; never overwrites an existing real config. On a fresh install,
-edit `/etc/ssh-broker/*.json` and place the mTLS PKI before starting. That
+Idempotent; never overwrites an existing real config. On a fresh install, edit
+the seeded configs (`/var/lib/ssh-broker/signer/signer.json` for the signer,
+`/etc/ssh-broker/*.json` for the rest) and place the mTLS PKI before starting. That
 includes the seeded `/etc/ssh-broker/broker-ctl.json`: point its `signer` /
 `control_plane` sections at the installed PKI so the admin CLI needs no
 flags (precedence: flag > `BROKER_CTL_*` env > file > default).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -37,11 +37,18 @@ anything: a fresh config still points at example values.
 
 ```
 /usr/local/bin/{signer,control-plane,mcp-broker-http,broker-ctl}
-/etc/ssh-broker/{signer.json,control-plane.json,config.json}   root:ssh-broker 0640
-/etc/ssh-broker/pki/                                           mTLS certs/keys
-/etc/ssh-broker/signer.env                                     optional AZURE_* creds (0600 root)
-/var/lib/ssh-broker/<svc>/                                     audit logs (StateDirectory)
+/etc/ssh-broker/{control-plane.json,config.json,broker-ctl.json}  root:ssh-broker 0640
+/etc/ssh-broker/pki/                                              mTLS certs/keys
+/etc/ssh-broker/signer.env                                        optional AZURE_* creds (0600 root)
+/var/lib/ssh-broker/signer/signer.json                           ssh-broker:ssh-broker 0640
+/var/lib/ssh-broker/<svc>/                                        audit logs (StateDirectory)
 ```
+
+The **signer config lives under `/var/lib/ssh-broker/signer/`**, owned by the
+service, not under `/etc` — the durable policy-mutation API (`broker-ctl policy
+add/remove`) rewrites it in place, which the read-only `/etc` tree would block.
+The PKI and the other services' configs stay root-owned in `/etc`; the services
+only read them.
 
 Configs must use **absolute** paths for certs/keys; a relative `audit_log`
 resolves under `/var/lib/ssh-broker/<svc>/` (the unit's WorkingDirectory),

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -77,8 +77,17 @@ if ! getent passwd ssh-broker >/dev/null; then
     echo "created user ssh-broker"
 fi
 
-# 2. Config directories. Configs stay root-owned; the group may read them.
+# 2. Directories.
+# /etc/ssh-broker holds the read-only material the services never rewrite: the
+# mTLS PKI and the control-plane / mcp-http configs (root-owned, group-readable).
 install -d -m 0750 -o root -g ssh-broker "${ETCDIR}" "${ETCDIR}/pki"
+# The signer REWRITES its own config on a durable policy mutation
+# (broker-ctl policy add/remove -> temp-file+rename), so its config lives in the
+# service-owned state directory it can write, not under the read-only /etc tree.
+STATEDIR="/var/lib/ssh-broker"
+if [[ " ${SERVICES} " == *" signer "* ]]; then
+    install -d -m 0750 -o ssh-broker -g ssh-broker "${STATEDIR}" "${STATEDIR}/signer"
+fi
 
 # 3. Binaries (broker-ctl always: it is the admin CLI).
 install -d "${BINDIR}"
@@ -92,16 +101,22 @@ if [[ -f "${ROOT}/bin/broker-ctl" ]]; then
     echo "installed ${BINDIR}/broker-ctl"
 fi
 
-# 4. Configs: refresh the .example reference, never touch a real config.
+# 4. Configs: refresh the .example reference, never touch a real config. The
+# signer config goes to its writable state dir (step 2), owned by the service so
+# the durable policy-mutation API can rewrite it; the others stay root-owned
+# under /etc, read-only for their services.
 for svc in ${SERVICES}; do
     cfg="$(svc_config "${svc}")"
     example="${ROOT}/${cfg%.json}.example.json"
-    if [[ -f "${example}" ]]; then
-        install -m 0640 -o root -g ssh-broker "${example}" "${ETCDIR}/${cfg}.example"
-        if [[ ! -f "${ETCDIR}/${cfg}" ]]; then
-            install -m 0640 -o root -g ssh-broker "${example}" "${ETCDIR}/${cfg}"
-            echo "installed ${ETCDIR}/${cfg} (from example — EDIT BEFORE STARTING)"
-        fi
+    [[ -f "${example}" ]] || continue
+    case "${svc}" in
+        signer) confdir="${STATEDIR}/signer"; cowner="ssh-broker" ;;
+        *)      confdir="${ETCDIR}";          cowner="root" ;;
+    esac
+    install -m 0640 -o "${cowner}" -g ssh-broker "${example}" "${confdir}/${cfg}.example"
+    if [[ ! -f "${confdir}/${cfg}" ]]; then
+        install -m 0640 -o "${cowner}" -g ssh-broker "${example}" "${confdir}/${cfg}"
+        echo "installed ${confdir}/${cfg} (from example — EDIT BEFORE STARTING)"
     fi
 done
 
@@ -136,8 +151,11 @@ cat <<EOF
 
 Done. Before starting (see deploy/README.md for the full checklist):
 
- 1. Edit ${ETCDIR}/*.json — use ABSOLUTE paths (${ETCDIR}/pki/...) for
-    certs/keys; relative audit_log paths land in /var/lib/ssh-broker/<svc>/.
+ 1. Edit the configs — use ABSOLUTE paths (${ETCDIR}/pki/...) for certs/keys;
+    relative audit_log paths land in /var/lib/ssh-broker/<svc>/. Note the
+    SIGNER config lives in ${STATEDIR}/signer/signer.json (service-owned, so
+    the durable policy-mutation API can rewrite it); control-plane / mcp-http
+    configs are in ${ETCDIR}.
  2. Choose CA custody in signer.json (ca_keys._default.type):
       "akv"  Azure Key Vault (production; credentials via managed identity or
              ${ETCDIR}/signer.env with AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET)

--- a/deploy/systemd/ssh-broker-signer.service
+++ b/deploy/systemd/ssh-broker-signer.service
@@ -4,9 +4,13 @@
 # issuance policy. In the reference layout:
 #
 #   binary   /usr/local/bin/signer
-#   config   /etc/ssh-broker/signer.json        (root:ssh-broker 0640)
-#   mTLS/PKI /etc/ssh-broker/pki/               (root:ssh-broker 0750, keys 0640)
-#   state    /var/lib/ssh-broker/signer/        (audit log; created via StateDirectory)
+#   config   /var/lib/ssh-broker/signer/signer.json   (ssh-broker:ssh-broker 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/                      (root:ssh-broker 0750, keys 0640)
+#   state    /var/lib/ssh-broker/signer/               (config + audit log; StateDirectory)
+#
+# The signer config lives in the service-owned state directory, NOT under the
+# read-only /etc tree, because the durable policy-mutation API rewrites it in
+# place (see below). The PKI stays root-owned in /etc; the service only reads it.
 #
 # Use ABSOLUTE paths in signer.json for certs/keys under /etc/ssh-broker/pki.
 # Relative paths (e.g. the default audit_log "signer_audit.log") resolve under
@@ -29,7 +33,7 @@ Wants=network-online.target
 Type=simple
 User=ssh-broker
 Group=ssh-broker
-ExecStart=/usr/local/bin/signer -config /etc/ssh-broker/signer.json
+ExecStart=/usr/local/bin/signer -config /var/lib/ssh-broker/signer/signer.json
 # Hot-reload of policy/CA (same validated path as POST /v1/reload).
 ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory=/var/lib/ssh-broker/signer
@@ -40,16 +44,13 @@ EnvironmentFile=-/etc/ssh-broker/signer.env
 Restart=on-failure
 RestartSec=2
 
-# Sandboxing. The service needs: read /etc/ssh-broker, write its state dir,
-# listen on its mTLS port, and (akv only) outbound HTTPS to the vault / IMDS.
+# Sandboxing. The service needs: read /etc/ssh-broker (PKI), read+write its own
+# state dir (config + audit log; the durable policy-mutation API rewrites the
+# config there via temp-file+rename, which the service-owned StateDirectory
+# permits), listen on its mTLS port, and (akv only) outbound HTTPS to the vault
+# / IMDS. /etc stays fully read-only for the service — no ReadWritePaths needed.
 NoNewPrivileges=yes
 ProtectSystem=strict
-# The durable policy-mutation API (POST/DELETE /v1/policy/hosts/{host}/allow)
-# and `broker-ctl policy add/remove` rewrite signer.json in place via a
-# temp-file+rename in /etc/ssh-broker, so that directory must be writable
-# despite ProtectSystem=strict. A compromised signer already holds the CA key
-# in memory, so write access to the config dir does not widen the blast radius.
-ReadWritePaths=/etc/ssh-broker
 ProtectHome=yes
 PrivateTmp=yes
 PrivateDevices=yes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v1.31.1] - 2026-07-02
+
+### Fixed
+- Deployment: the signer config moves to the service-owned state directory
+  `/var/lib/ssh-broker/signer/signer.json`. v1.31.0's `ReadWritePaths` fix (#38)
+  removed the systemd barrier to the durable policy-mutation API
+  (`broker-ctl policy add/remove`), but the POSIX permission barrier remained —
+  `/etc/ssh-broker` is `root:ssh-broker 0750`, so the `ssh-broker` service user
+  could not create `signer.json.tmp` for the temp-file+rename and every durable
+  mutation still failed `EACCES`. Placing the signer config where the service
+  owns it (and reverting the now-unnecessary `ReadWritePaths`, keeping `/etc`
+  read-only for the service) lets durable mutations persist while the PKI and
+  the other services' configs stay root-owned in `/etc`. Binaries are unchanged
+  from v1.31.0; this is a deploy-artifact + docs fix. The installer seeds the
+  signer config to the new location; the systemd unit points `-config` there.
+
 ## [v1.31.0] - 2026-07-02
 
 Security & correctness audit pass. Fourteen findings across the signer, control

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -639,10 +639,13 @@ make dist                        # dist/ssh-broker-<version>.tar.gz
 systemctl enable --now ssh-broker-signer   # always the signer first
 ```
 
-Reference layout: binaries in `/usr/local/bin`, configs in
-`/etc/ssh-broker/` (never overwritten on upgrade), mTLS PKI in
-`/etc/ssh-broker/pki/`, audit logs in `/var/lib/ssh-broker/<svc>/`.
-Policy hot-reload maps to `systemctl reload ssh-broker-signer` (SIGHUP).
+Reference layout: binaries in `/usr/local/bin`, the control-plane / mcp-http
+configs and the mTLS PKI in `/etc/ssh-broker/` (root-owned, never overwritten
+on upgrade), audit logs in `/var/lib/ssh-broker/<svc>/`. The **signer config
+lives in `/var/lib/ssh-broker/signer/signer.json`** (service-owned): the durable
+policy-mutation API rewrites it in place, so it cannot sit in the read-only
+`/etc` tree. Policy hot-reload maps to `systemctl reload ssh-broker-signer`
+(SIGHUP).
 The installer also seeds `/etc/ssh-broker/broker-ctl.json` (client parameters,
 see §4) so `broker-ctl host list --remote` works flag-less as the post-deploy
 end-to-end check.


### PR DESCRIPTION
Follow-up to #38, found during v1.31.0 release verification. The `ReadWritePaths` fix removed the systemd barrier, but `/etc/ssh-broker` is `root:ssh-broker 0750`, so the `ssh-broker` service user still couldn't create `signer.json.tmp` for the temp-file+rename — every `broker-ctl policy add/remove` failed `EACCES`. (My #38 close-out only checked the unit parsed, not the end-to-end write.)

**Fix (Option 2):** the signer config moves to `/var/lib/ssh-broker/signer/signer.json` (service-owned, inside the existing StateDirectory), and the now-unnecessary `ReadWritePaths` is reverted so `/etc` stays fully read-only for the service. PKI + other configs stay root-owned in `/etc`.

**No Go changes** — deploy artifacts (unit, installer) + docs only.

**Verified end-to-end on a live install:**
- `broker-ctl policy add --host testhost --allow '^uptime$'` → succeeds and **persists** to the on-disk config.
- The file stays `ssh-broker:ssh-broker` (0600 after `UMask=0077`) across the rewrite, so future mutations keep working.
- The change is live via `host list --remote` (`allowlist(2)`).
- `systemd-analyze verify` clean; `go build`/`go test`/strict mkdocs build green.