### PR TITLE
feat: versioned /audit skill with a deterministic issue-formatting helper

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: audit
+description: Recurring security & correctness audit of the ssh-broker repo. Iteratively find, fix, and CLOSE issues across security / logic / documentation, tracking each as a GitHub issue and linking every fix back to it. Use when the user asks to audit the repo, run a security/correctness pass, hunt for bugs across the codebase, or continue the audit loop.
+---
+
+# ssh-broker security & correctness audit
+
+You are a security & correctness auditor for `ssh-broker`, a security-sensitive
+SSH certificate broker/signer in Go. You iteratively find, fix, and CLOSE issues
+across THREE categories, each tracked as a GitHub issue with the fix linked back.
+
+**The deterministic mechanics — audit-id, issue format, dedupe, ledger,
+close-out, report, labels — are a script; do NOT hand-roll `gh` commands.** Use
+the helper next to this skill so every issue comes out identically formatted:
+
+```
+AI=.agents/skills/audit/audit-issue.sh      # run from the repo root
+$AI labels-init                             # once, idempotent
+$AI id <category> <path> <signature>        # the audit-id fingerprint
+$AI create --category C --severity S --title T --location L --description D [--repro R] --fix F [--dry-run]
+$AI closeout <issue> --commit SHA --files "a,b" --verified "gofmt/vet/build/test..."
+$AI needs-human <issue> --rationale "why a human must decide"
+$AI ledger        # audit-id -> #issue -> state -> severity -> title, live from GitHub
+$AI report        # final summary: counts by category/severity, closed, needs-human
+```
+
+The script derives the ledger and report from GitHub (the `audit-bot` label +
+`audit-id` in the body), so there is no local state to drift.
+
+## Categories
+
+1. **SECURITY** — auth/authz bypass, key/secret handling, cert/CA signing, input
+   validation, injection, TLS/mTLS, audit-log integrity, approval/policy bypass,
+   races, privilege scope. Also: deployment/installer/systemd hardening, on-disk
+   key/secret file permissions (PKI, `*.env` with `AZURE_*` creds), and
+   shell-script robustness (quoting, `set -euo pipefail`, filename injection) —
+   the `deploy/` artifacts are in scope.
+2. **LOGIC** — wrong behavior, edge cases, error handling, concurrency bugs,
+   broken invariants, dead paths. Includes drift between `.github/workflows/*`
+   and the `make` targets they mirror (e.g. a CI job validating fewer packages
+   than `make docs-check`).
+3. **DOCUMENTATION** — README/docs/mkdocs drift, wrong/missing config docs, stale
+   reference pages, undocumented flags/routes/tools. Includes the generated
+   `docs/reference/{endpoints,cli,config,mcp-tools}.md`, the deploy docs
+   (`deploy/README.md`), and the agent skills under `.agents/skills/`.
+
+## Prerequisites (verify once; abort with a clear message if missing)
+
+- `gh` authenticated (`gh auth status`), `origin` = `luisgf/ssh-broker`.
+- Docs toolchain for STEP 5 (`make docs-check`): a venv with
+  `pip install -r requirements-docs.txt`. A missing `mkdocs` is an ENVIRONMENT
+  error, not a content finding — install it, do not file an issue.
+- Labels exist: run `$AI labels-init` (idempotent).
+
+## High-risk zones (audit first, extra scrutiny)
+
+`internal/signer`, `internal/ca` (incl. `akv.go` / Azure Key Vault),
+`internal/auth` (mtls), `internal/audit`, `internal/control` (approval, behavior,
+notifier, `teams.go` — outbound webhook URL validation / SSRF / payload
+injection), `internal/policyrec`, `internal/oauth`, `cmd/signer` (grants, policy,
+handlers). Also, with the same scrutiny:
+
+- `cmd/signer` `GET /v1/policy/hosts` (`handlePolicyHostsRead`): full internal
+  policy exposure (principals, allowed_callers, command_policy) gated by
+  `reload_callers` — verify the authz gate and the audit trail.
+- `cmd/broker-ctl` (`clientconfig.go`): client parameters file. Precedence
+  flag > `BROKER_CTL_*` env > file > default selects the mTLS cert/key/CA and
+  URL; a relative default resolves against the config file's dir; the CWD is
+  deliberately NOT searched. Re-verify these invariants hold — a precedence or
+  path-resolution bug presents the wrong mTLS identity (treat as an auth surface).
+- `cmd/control-plane` approval UI (`ui.go`, `/ui/approvals`): server-rendered
+  HTML — CSRF (Content-Type gate), XSS via `html/template`, and broker/approver
+  mTLS role separation. The `end_user` shown to the approver must be gated on
+  `trusted_forwarders`.
+- `internal/monitor` (`/healthz`, `/metrics` on every service): unauthenticated
+  listener; must bind localhost / a private interface and must not leak
+  sensitive data via metrics.
+- `deploy/` (systemd units + `install.sh` + example configs): unit sandboxing
+  regressions, `EnvironmentFile` secret handling, installer file modes/ownership
+  on keys and configs. Note the signer config lives service-owned under
+  `/var/lib/ssh-broker/signer/` so the durable policy API can rewrite it.
+
+## Operating loop (repeat until TERMINATION)
+
+- **STEP 1 — AUDIT (read-only):** fresh, systematic pass over the WHOLE repo
+  (code, docs, example configs, CI, scripts). Re-derive findings from the CURRENT
+  tree; do not rely on memory. Print `$AI ledger` first so you know what already
+  exists.
+
+- **STEP 2 — RECORD each finding:** for every real finding, call
+  `$AI create --category … --severity … --title … --location file:line
+  --description … [--repro …] --fix …`. The script computes the audit-id,
+  dedupes (skips if an issue with that audit-id already exists), applies the
+  labels, and writes the canonical body. Preview with `--dry-run` if unsure.
+  If a finding is real but stale in an existing issue, `gh issue comment` it.
+
+- **STEP 3 — TRIAGE:** pick the single highest-severity OPEN issue
+  (security > logic > documentation on ties). Work on exactly ONE.
+
+- **STEP 4 — FIX:** minimal, correct fix. NEVER weaken a security control or
+  delete/skip a test to make checks pass. If the fix needs a product/security
+  decision you cannot safely make, `$AI needs-human <issue> --rationale …` and
+  SKIP (do not commit).
+
+- **STEP 5 — VERIFY (all must pass before committing):**
+  ```
+  gofmt -l .        # must print nothing
+  go vet ./...
+  go build ./...
+  go test -race ./...
+  make docs-gen     # FIRST when routes/tools/config/CLI changed — docs-check only DETECTS drift
+  make docs-check   # only when docs/config/routes/tools changed
+  ```
+  On failure, fix forward; never commit a red tree.
+
+- **STEP 6 — COMMIT (linked):** one logical fix per commit. Conventional Commits
+  matching repo history: `fix:` (security/logic), `docs:` (documentation).
+  The commit BODY must contain `Fixes #<issue>` so it auto-closes on merge to the
+  default branch, plus what was verified. Follow the repo's branch → PR → merge
+  convention.
+
+- **STEP 7 — CLOSE-OUT:** after the merge, `$AI closeout <issue> --commit SHA
+  --files … --verified …`. Confirm the issue is CLOSED (the `Fixes` link closes
+  it on merge; otherwise `gh issue close`).
+
+- **STEP 8 — re-audit:** return to STEP 1.
+
+## Termination (stop when ANY holds)
+
+- A full fresh audit yields ZERO new findings AND every audit-bot issue is CLOSED
+  or labeled `needs-human`.
+- Iteration cap reached (default 15).
+- Only `needs-human` issues remain open.
+
+On termination, print `$AI report` and relay it to the user.
+
+## Guardrails (HARD RULES)
+
+- Read-only during AUDIT; modify files only during FIX.
+- One issue per commit; no drive-by changes.
+- **NEVER add `Co-Authored-By`, "Generated with", or any assistant-attribution
+  trailer to commits.**
+- Never commit secrets, keys, real configs (`signer.json`, `config.json`,
+  `broker-ctl.json`), `*.env`, `dist/` tarballs, `.claude/settings.local.json`,
+  or `*.log` / `*.pid` / audit data.
+- Prefer adding/strengthening tests that lock in security & logic fixes.
+- Idempotency: the tool dedupes by audit-id — never create a second issue for one,
+  and never reopen an issue you just closed in the same run.

--- a/.agents/skills/audit/audit-issue.sh
+++ b/.agents/skills/audit/audit-issue.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# audit-issue — deterministic mechanics for the /audit skill.
+#
+# Encapsulates the parts of the audit loop that must be identical every run:
+# the audit-id fingerprint, the fixed issue-body format, dedupe, the close-out
+# comment, and the ledger/report — all derived from GitHub so there is no local
+# state to drift. The judgment (what to audit, triage, fix) lives in SKILL.md.
+#
+# Requires: gh (authenticated), git, sha1sum. Repo is taken from the gh context
+# of the current directory (origin), matching how the maintainer runs it.
+#
+# Usage:
+#   audit-issue labels-init
+#   audit-issue id <category> <normalized-path> <signature>
+#   audit-issue create --category C --severity S --title T --location L \
+#                      --description D [--repro R] --fix F [--dry-run]
+#   audit-issue closeout <issue> --commit SHA --files "a,b" --verified "gofmt/vet/..."
+#   audit-issue needs-human <issue> --rationale "why a human must decide"
+#   audit-issue ledger
+#   audit-issue report
+
+set -euo pipefail
+
+die() { echo "audit-issue: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"; }
+need gh; need git; need sha1sum
+
+CATEGORIES="security logic documentation"
+SEVERITIES="critical high medium low"
+
+# audit_id computes the stable dedupe fingerprint: sha1(category|path|signature)
+# truncated to 12 hex chars. The path is normalized (leading ./ stripped, no
+# trailing spaces) so the same finding hashes identically across runs.
+audit_id() {
+    local cat="$1" path="$2" sig="$3"
+    path="${path#./}"
+    printf '%s|%s|%s' "$cat" "$path" "$sig" | sha1sum | cut -c1-12
+}
+
+require_enum() {
+    local val="$1" set="$2" name="$3"
+    for x in $set; do [[ "$val" == "$x" ]] && return 0; done
+    die "invalid $name '$val' (must be one of: $set)"
+}
+
+# format_body emits the canonical issue body. Every issue created by this tool
+# has the same section order, so a reviewer (and the dedupe search) can rely on
+# it. audit-id is first and verbatim — it is the machine-readable dedupe key.
+format_body() {
+    local aid="$1" cat="$2" sev="$3" justification="$4" location="$5" desc="$6" repro="$7" fix="$8"
+    printf 'audit-id: %s\n\n' "$aid"
+    printf '**Category:** %s · **Severity:** %s — %s\n\n' "$cat" "$sev" "$justification"
+    printf '**Location:** %s\n\n' "$location"
+    printf '**Description:** %s\n\n' "$desc"
+    if [[ -n "$repro" ]]; then
+        printf '**Reproduction / evidence:** %s\n\n' "$repro"
+    fi
+    printf '**Proposed fix & verification:** %s\n' "$fix"
+}
+
+cmd_id() {
+    [[ $# -eq 3 ]] || die "usage: audit-issue id <category> <normalized-path> <signature>"
+    require_enum "$1" "$CATEGORIES" category
+    audit_id "$1" "$2" "$3"
+}
+
+# find_by_aid prints the issue number whose body carries the given audit-id, or
+# nothing. Searches all states, restricted to the audit-bot label.
+find_by_aid() {
+    local aid="$1"
+    gh issue list --state all --label audit-bot --search "$aid" \
+        --json number,body \
+        --jq "map(select(.body | contains(\"audit-id: $aid\"))) | .[0].number // empty"
+}
+
+cmd_create() {
+    local category="" severity="" title="" location="" description="" repro="" fix="" justification="" dry=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --category) category="$2"; shift 2 ;;
+            --severity) severity="$2"; shift 2 ;;
+            --title) title="$2"; shift 2 ;;
+            --location) location="$2"; shift 2 ;;
+            --description) description="$2"; shift 2 ;;
+            --repro) repro="$2"; shift 2 ;;
+            --fix) fix="$2"; shift 2 ;;
+            --justification) justification="$2"; shift 2 ;;
+            --dry-run) dry=1; shift ;;
+            *) die "create: unknown flag $1" ;;
+        esac
+    done
+    [[ -n "$category" && -n "$severity" && -n "$title" && -n "$location" && -n "$description" && -n "$fix" ]] \
+        || die "create: --category --severity --title --location --description --fix are required"
+    require_enum "$category" "$CATEGORIES" category
+    require_enum "$severity" "$SEVERITIES" severity
+    : "${justification:=see description}"
+
+    local aid; aid="$(audit_id "$category" "$location" "$title")"
+    local body; body="$(format_body "$aid" "$category" "$severity" "$justification" "$location" "$description" "$repro" "$fix")"
+
+    if [[ $dry -eq 1 ]]; then
+        echo "# labels: audit-bot,$category,severity:$severity"
+        echo "# title:  $title"
+        echo "# --- body ---"
+        printf '%s\n' "$body"
+        return 0
+    fi
+
+    # Dedupe: never create a second issue for an existing audit-id.
+    local existing; existing="$(find_by_aid "$aid")"
+    if [[ -n "$existing" ]]; then
+        echo "$existing (existing — audit-id $aid, not creating a duplicate)"
+        return 0
+    fi
+
+    local url; url="$(gh issue create \
+        --label audit-bot --label "$category" --label "severity:$severity" \
+        --title "$title" --body "$body")"
+    echo "${url##*/}"
+}
+
+cmd_closeout() {
+    local issue="$1"; shift
+    [[ -n "$issue" ]] || die "usage: audit-issue closeout <issue> --commit SHA --files F --verified V"
+    local commit="" files="" verified=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --commit) commit="$2"; shift 2 ;;
+            --files) files="$2"; shift 2 ;;
+            --verified) verified="$2"; shift 2 ;;
+            *) die "closeout: unknown flag $1" ;;
+        esac
+    done
+    [[ -n "$commit" && -n "$verified" ]] || die "closeout: --commit and --verified are required"
+    local body
+    body="$(printf 'Fixed in %s.\n\n**Files touched:** %s\n\n**Verification:** %s' "$commit" "${files:-—}" "$verified")"
+    gh issue comment "$issue" --body "$body" >/dev/null
+    echo "closeout posted on #$issue"
+}
+
+cmd_needs_human() {
+    local issue="$1"; shift
+    [[ -n "$issue" ]] || die "usage: audit-issue needs-human <issue> --rationale R"
+    local rationale=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --rationale) rationale="$2"; shift 2 ;;
+            *) die "needs-human: unknown flag $1" ;;
+        esac
+    done
+    [[ -n "$rationale" ]] || die "needs-human: --rationale is required"
+    gh issue edit "$issue" --add-label needs-human >/dev/null
+    gh issue comment "$issue" --body "$(printf '**Triaged as needs-human (product/security decision).**\n\n%s' "$rationale")" >/dev/null
+    echo "labeled needs-human and commented on #$issue"
+}
+
+# ledger prints one row per audit-bot issue, derived live from GitHub: the
+# audit-id (parsed from the body), issue number, state, severity, and title.
+cmd_ledger() {
+    gh issue list --state all --label audit-bot --limit 200 \
+        --json number,title,state,labels,body \
+        --jq '
+          sort_by(.number) | .[] |
+          ( .body | capture("audit-id: (?<a>[0-9a-f]+)").a ) as $aid |
+          ( [.labels[].name | select(startswith("severity:"))] | .[0] // "severity:?" ) as $sev |
+          "\($aid // "?")\t#\(.number)\t\(.state)\t\($sev | ltrimstr("severity:"))\t\(.title)"
+        '
+}
+
+# report prints the final summary: counts by category/severity plus the closed
+# and needs-human lists. All from GitHub, so it is correct regardless of which
+# machine or run produced the issues.
+cmd_report() {
+    local json; json="$(gh issue list --state all --label audit-bot --limit 200 \
+        --json number,title,state,labels)"
+    echo "=== Audit report (from GitHub, label=audit-bot) ==="
+    echo
+    echo "Total findings: $(jq 'length' <<<"$json")"
+    echo
+    echo "By category:"
+    for c in $CATEGORIES; do
+        printf '  %-14s %s\n' "$c" "$(jq --arg c "$c" '[.[] | select(.labels[].name==$c)] | length' <<<"$json")"
+    done
+    echo "By severity:"
+    for s in $SEVERITIES; do
+        printf '  %-14s %s\n' "$s" "$(jq --arg s "severity:$s" '[.[] | select(.labels[].name==$s)] | length' <<<"$json")"
+    done
+    echo
+    echo "Closed: $(jq '[.[] | select(.state=="CLOSED")] | length' <<<"$json")   Open: $(jq '[.[] | select(.state=="OPEN")] | length' <<<"$json")   needs-human: $(jq '[.[] | select(.labels[].name=="needs-human")] | length' <<<"$json")"
+    echo
+    echo "Open needs-human (require a decision):"
+    jq -r '.[] | select(.labels[].name=="needs-human") | select(.state=="OPEN") | "  #\(.number) \(.title)"' <<<"$json" | { grep . || echo "  (none)"; }
+}
+
+cmd_labels_init() {
+    # (name, color, description) — created idempotently.
+    local specs=(
+        "security|b60205|Audit category: security"
+        "logic|d93f0b|Audit category: logic"
+        "documentation|0075ca|Improvements or additions to documentation"
+        "severity:critical|b60205|Severity: critical"
+        "severity:high|d93f0b|Severity: high"
+        "severity:medium|fbca04|Severity: medium"
+        "severity:low|0e8a16|Severity: low"
+        "audit-bot|5319e7|Created/managed by the audit loop"
+        "needs-human|e99695|Requires a human product/security decision"
+    )
+    for spec in "${specs[@]}"; do
+        IFS='|' read -r name color desc <<<"$spec"
+        gh label create "$name" --color "$color" --description "$desc" --force >/dev/null 2>&1 \
+            && echo "label ok: $name" || echo "label ok: $name (exists)"
+    done
+}
+
+case "${1:-}" in
+    id)          shift; cmd_id "$@" ;;
+    create)      shift; cmd_create "$@" ;;
+    closeout)    shift; cmd_closeout "$@" ;;
+    needs-human) shift; cmd_needs_human "$@" ;;
+    ledger)      shift; cmd_ledger "$@" ;;
+    report)      shift; cmd_report "$@" ;;
+    labels-init) shift; cmd_labels_init "$@" ;;
+    ""|-h|--help)
+        sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+        ;;
+    *) die "unknown subcommand '$1' (see --help)" ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,3 @@ medium.txt
 
 # Configuración local de la sesión del agente (permisos por máquina, no versionar)
 .claude/settings.local.json
-
-# Prompt local del audit-bot (no versionar)
-.agents/prompts/audit.md

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -267,3 +267,7 @@ audit chain/rotation, session recording, CLI helpers y config example strictness
 5. Antes de cada commit: seguir el checklist de
    [CONTRIBUTING.md](CONTRIBUTING.md) (docs vivas) y el de
    [CODING_STYLE.md](CODING_STYLE.md) (gofmt/vet/test).
+6. **Auditoría de seguridad recurrente**: skill `/audit`
+   (`.agents/skills/audit/`) — bucle find→fix→close por categoría, con
+   `audit-issue.sh` para el formato uniforme de las issues (audit-id, dedupe,
+   ledger, report derivados de GitHub).


### PR DESCRIPTION
Turns the recurring security & correctness audit into a versioned, shareable skill and extracts its deterministic mechanics into a helper so **every issue comes out identically formatted**.

Previously the audit ran from a local, gitignored prompt and the mechanics (audit-id, issue body, dedupe, ledger, close-out, report) were hand-rolled with `gh` each run — fragile (a bad `gh issue create --json` once produced a truncated issue that had to be re-edited).

## What's added
- **`.agents/skills/audit/SKILL.md`** — the judgment layer + loop (categories, high-risk zones, triage/fix/verify/commit, guardrails incl. no `Co-Authored-By`). Auto-discovered as `/audit` via the existing `.claude/skills` symlink.
- **`.agents/skills/audit/audit-issue.sh`** — deterministic helper (bash; deps `gh`+`git`): `id`, `create` (fixed body + labels + dedupe by audit-id, `--dry-run`), `closeout`, `needs-human`, `ledger`, `report`, `labels-init`. **Ledger and report are derived live from GitHub** (the `audit-bot` label + `audit-id` in the body) — no local state to drift.
- Retire `.agents/prompts/audit.md` + its `.gitignore` line; pointer in `HANDOFF.md`.

## Design notes
- **Bash, not Python** — zero new deps, consistent with `signer.sh`/`install.sh`.
- Ledger from GitHub rather than a local TSV → survives across runs/machines.
- `create` dedupes by audit-id (never a second issue for one finding).

## Verified
bash -n clean · audit-id deterministic + CWD-path-normalized · `labels-init` idempotent · `create --dry-run` emits the canonical body **without** mutating GitHub · `report` reproduces the audit-bot counts from GitHub · strict mkdocs build passes.