### PR TITLE
feat: opt-in secret redaction (threat-model gap #8) — v1.32.0

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/control"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
 	"github.com/luisgf/ssh-broker/internal/monitor"
+	"github.com/luisgf/ssh-broker/internal/redact"
 	"github.com/luisgf/ssh-broker/internal/signer"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
@@ -101,6 +102,15 @@ type Config struct {
 	// (liveness) and /metrics (Prometheus text format). No authentication —
 	// bind to localhost or a private scrape interface. Empty = disabled.
 	MonitorListen string `json:"monitor_listen,omitempty"`
+
+	// Redact enables secret redaction on the control plane's persistent and
+	// outbound sinks: the audit log's free-text fields and the approval
+	// notification payload (log/webhook/Teams). Present (even empty,
+	// "redact": {}) = built-in default patterns; absent = disabled (backward
+	// compatible). The approval registry itself keeps the original command:
+	// the mTLS approval UI and API show the approver exactly what will run,
+	// and the approved request forwarded to the signer is untouched.
+	Redact *redact.Config `json:"redact,omitempty"`
 }
 
 type server struct {
@@ -109,6 +119,7 @@ type server struct {
 	notifier   control.Notifier
 	behavior   *control.BehaviorTracker
 	audit      *audit.Log
+	redactor   *redact.Redactor // nil = redaction disabled; applied to notifier payloads
 	approveCN  map[string]struct{}
 	signCN     map[string]struct{} // CNs allowed on the signing path (brokers); empty = any non-approver
 	forwarders map[string]struct{} // CNs whose end_user claim is trusted (guardrail subject)
@@ -177,6 +188,17 @@ func main() {
 	}
 	defer auditLog.Close()
 
+	var redactor *redact.Redactor
+	if cfg.Redact != nil {
+		redactor, err = redact.New(cfg.Redact)
+		if err != nil {
+			log.Fatalf("redact: %v", err)
+		}
+		if redactor != nil {
+			auditLog.SetRedactor(redactor)
+		}
+	}
+
 	var notifier control.Notifier = control.LogNotifier{}
 	switch cfg.Approval.Notifier {
 	case "", "log":
@@ -204,6 +226,7 @@ func main() {
 		notifier:   notifier,
 		behavior:   control.NewBehaviorTracker(cfg.Behavior),
 		audit:      auditLog,
+		redactor:   redactor,
 		approveCN:  cnSet(cfg.Approval.Callers),
 		signCN:     cnSet(cfg.SignCallers),
 		forwarders: cnSet(cfg.TrustedForwarders),
@@ -418,7 +441,14 @@ func (s *server) requireApproval(w http.ResponseWriter, brokerCN string, req sig
 		http.Error(w, "could not create approval request", http.StatusInternalServerError)
 		return
 	}
-	if nerr := s.notifier.Notify(*a); nerr != nil {
+	// Notify with a redacted copy: the notification persists in the process log
+	// or leaves the host (webhook/Teams). The registry keeps the original — the
+	// mTLS approval UI shows the approver the exact command.
+	notifyCopy := *a
+	if s.redactor != nil {
+		notifyCopy = notifyCopy.WithRedactedCommand(s.redactor)
+	}
+	if nerr := s.notifier.Notify(notifyCopy); nerr != nil {
 		log.Printf("warning: approval notification failed: %v", nerr)
 	}
 	s.auditE(audit.Entry{Caller: brokerCN, Host: req.Host, Command: req.Command, Outcome: "approval-required", ApprovalID: a.ID, PolicyRule: rule, Anomaly: anomaly})

--- a/cmd/control-plane/redact_test.go
+++ b/cmd/control-plane/redact_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luisgf/ssh-broker/internal/control"
+	"github.com/luisgf/ssh-broker/internal/redact"
+)
+
+// captureNotifier records the last approval it was asked to notify.
+type captureNotifier struct{ last control.Approval }
+
+func (c *captureNotifier) Notify(a control.Approval) error {
+	c.last = a
+	return nil
+}
+
+// TestApprovalNotificationRedacted verifies the redaction split on the
+// approval flow: the notifier payload (log/webhook/Teams — persists or leaves
+// the host) is redacted, while the registry keeps the original command so the
+// mTLS approval UI/API shows the approver exactly what will run, and the
+// audit log free-text is redacted.
+func TestApprovalNotificationRedacted(t *testing.T) {
+	sig := stubSigner(t)
+	defer sig.Close()
+	s := testServer(t, sig.URL)
+
+	redactor, err := redact.New(&redact.Config{}) // defaults
+	if err != nil {
+		t.Fatalf("redact.New: %v", err)
+	}
+	s.redactor = redactor
+	s.audit.SetRedactor(redactor)
+	notifier := &captureNotifier{}
+	s.notifier = notifier
+
+	// "reboot ..." requires approval in the stub signer.
+	const cmd = "reboot --password=hunter2"
+	w := httptest.NewRecorder()
+	s.handleSign(w, req(t, "POST", "/v1/sign", "broker-1", wireReq(t, cmd)))
+	if w.Code != 202 {
+		t.Fatalf("expected 202 approval-required, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Outbound sink: redacted.
+	if strings.Contains(notifier.last.Command, "hunter2") {
+		t.Errorf("notifier payload must be redacted: %q", notifier.last.Command)
+	}
+	if !strings.Contains(notifier.last.Command, "[REDACTED:flag-password]") {
+		t.Errorf("notifier payload missing the redaction marker: %q", notifier.last.Command)
+	}
+
+	// Approver-facing registry (mTLS UI/API): the original command, untouched.
+	a, ok := s.registry.Get(resp["approval_id"])
+	if !ok {
+		t.Fatal("approval not found in registry")
+	}
+	if a.Command != cmd {
+		t.Errorf("registry must keep the original command for the approver: %q", a.Command)
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/confcheck"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
 	"github.com/luisgf/ssh-broker/internal/monitor"
+	"github.com/luisgf/ssh-broker/internal/redact"
 	"github.com/luisgf/ssh-broker/internal/signer"
 	"github.com/luisgf/ssh-broker/internal/version"
 )
@@ -75,6 +76,13 @@ type Config struct {
 	// (liveness) and /metrics (Prometheus text format). No authentication —
 	// bind to localhost or a private scrape interface. Empty = disabled.
 	MonitorListen string `json:"monitor_listen,omitempty"`
+
+	// Redact enables secret redaction on the signer's audit log free-text
+	// fields. Present (even empty, "redact": {}) = built-in default patterns;
+	// absent = disabled (backward compatible). The signer's audit carries
+	// request metadata rather than the raw command, but errors can embed user
+	// text — every persistent sink applies the same invariant.
+	Redact *redact.Config `json:"redact,omitempty"`
 
 	// MaxGrantTTLSeconds: optional upper bound on a runtime grant's TTL
 	// (POST /v1/policy/hosts/{host}/grants). 0 or absent = no cap.
@@ -148,6 +156,16 @@ func main() {
 		log.Fatalf("audit: %v", err)
 	}
 	defer auditLog.Close()
+
+	if cfg.Redact != nil {
+		redactor, rerr := redact.New(cfg.Redact)
+		if rerr != nil {
+			log.Fatalf("redact: %v", rerr)
+		}
+		if redactor != nil {
+			auditLog.SetRedactor(redactor)
+		}
+	}
 
 	tlsCfg, err := auth.ServerTLSConfig(cfg.ServerCert, cfg.ServerKey, cfg.ClientCA)
 	if err != nil {

--- a/config.example.json
+++ b/config.example.json
@@ -27,6 +27,9 @@
   "_recording_comment": "Optional session recording. When set, shell and pty sessions are recorded to ASCIIcast v2 files in this directory. One file per session: <session_id>.cast. Files are playable with 'asciinema play'. Correlate with audit log via session_id. Empty or absent = recording disabled.",
   "session_recording_dir": "",
 
+  "_redact_comment": "Optional secret redaction (threat-model gap #8) on this broker's persistent/outbound sinks: the audit log free-text fields (command, err, warning, anomaly) and session recordings. Present — even empty {} — enables the built-in default patterns (password/token flags, mysql -p<pass>, VAR=secret assignments, URI user:pass@, Authorization headers, JWTs, AWS/GitHub/GitLab/Slack tokens, private-key blocks); a secret is replaced by [REDACTED:<rule>]. 'patterns' adds operator rules (RE2 regex; a (?P<secret>...) group masks only the secret, otherwise the whole match); 'disable_defaults' keeps only the operator rules. Redaction happens BEFORE the entry is signed, so 'broker-ctl audit verify' is unaffected — and the original is irrecoverable by design. Best-effort pattern matching, not DLP (see docs/SECURITY.md). NEVER touches the decision path: the signer and the certificate force-command always see the original command. Absent = disabled (previous behaviour).",
+  "redact": {},
+
   "_file_transfer_comment": "Optional cap (bytes) on a single ssh_put_file / ssh_get_file transfer, per host that sets allow_file_transfer. A transfer larger than the cap is an error, not a truncation. 0 or absent = the built-in default (524288 = 512 KiB).",
   "file_transfer_max_bytes": 524288,
 

--- a/control-plane.example.json
+++ b/control-plane.example.json
@@ -42,5 +42,8 @@
   "audit_key": "pki/control_plane_audit.seed",
 
   "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: controlplane_events_total{outcome}, controlplane_approvals_pending, audit_append_failures_total.",
-  "monitor_listen": "127.0.0.1:9170"
+  "monitor_listen": "127.0.0.1:9170",
+
+  "_redact_comment": "Optional secret redaction (threat-model gap #8) on the control plane's persistent/outbound sinks: the audit log free-text fields AND the approval notification payload (log/webhook/Teams — the notification persists in a log or leaves the host). Present — even empty {} — enables the built-in default patterns; 'patterns' adds operator RE2 rules ((?P<secret>...) masks only the secret); 'disable_defaults' keeps only the operator rules. The approval registry keeps the ORIGINAL command: the mTLS approval UI (/ui/approvals) and GET /v1/approvals show the approver exactly what will run, and the approved request forwarded to the signer is untouched. Absent = disabled.",
+  "redact": {}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [v1.32.0] - 2026-07-02
+
+Secret redaction (threat-model gap #8): an opt-in `redact` config block on the
+three services masks secrets embedded in commands at every persistent or
+outbound sink, replacing them with `[REDACTED:<rule>]`.
+
+### Added
+- New `internal/redact` package: named RE2 rules, built-in defaults
+  (password/token flags, the attached `mysql -p<pass>` form, `VAR=secret`
+  assignments with `_`-delimited keyword matching, URI `user:pass@`,
+  `Authorization` headers, JWTs, AWS/GitHub/GitLab/Slack tokens, private-key
+  blocks) plus operator-defined `patterns` (a `(?P<secret>...)` group masks
+  only the secret and keeps the rest of the match as forensic context;
+  `disable_defaults` keeps only the operator rules). An invalid pattern is a
+  startup error (fail-closed), and overlapping rules never re-mask another
+  rule's marker.
+- Redaction choke-points, so no call site can be missed:
+  - `audit.Log`: the free-text fields (`command`, `err`, `warning`, `anomaly`)
+    are masked **before the entry is signed** — the Ed25519 signature and hash
+    chain cover the redacted content, `broker-ctl audit verify` is unaffected,
+    and the original text is never persisted (irrecoverable by design).
+  - `recording.Recorder`: every ASCIIcast event is masked. Input events carry
+    one full command line per event (reliable); output arrives in arbitrary
+    chunks, so a split secret can escape a pattern (documented best-effort).
+  - Control-plane notifier: the approval notification payload
+    (log/webhook/Teams) is masked. The approval registry keeps the original
+    command — the mTLS approval UI (`/ui/approvals`) and `GET /v1/approvals`
+    show the approver exactly what will run, and the approved request
+    forwarded to the signer is untouched.
+- `redact` config key in the broker (`config.json`), signer (`signer.json`)
+  and control plane (`control-plane.json`). Present — even empty `{}` —
+  enables the built-in defaults; absent = disabled (backward compatible).
+  Redaction never touches the decision path: the signer and the certificate
+  force-command always see the original command.
+
+### Documentation
+- New "Redaction is best-effort" section in SECURITY.md (limits: regex ≠ DLP,
+  chunked output, decision path untouched by design, false-positive escape
+  hatch); THREAT_MODEL gap #8 updated from "no redaction" to "opt-in,
+  best-effort"; `redact` blocks in the three example configs; config reference
+  regenerated.
+
 ## [v1.31.1] - 2026-07-02
 
 ### Fixed

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,16 @@
 # Handoff: SSH Broker con CA Efímera para Agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-06-30 (post-v1.23.5 audit hardening).
+> actualización: 2026-07-02 (v1.32.0, redacción de secretos).
 >
 > Estado reciente:
+> - **v1.32.0**: redacción de secretos opt-in (gap #8): bloque `redact` en los
+>   tres servicios; `internal/redact` (reglas RE2 con nombre, defaults +
+>   patrones de operador) aplicado en choke-points — `audit.Log` (campos de
+>   texto libre, antes de firmar: la cadena cubre el contenido ya redactado),
+>   `recording.Recorder` (eventos ASCIIcast) y el notifier de aprobaciones
+>   (log/webhook/Teams). El decision path y la approval UI mTLS ven siempre el
+>   comando original.
 > - **post-v1.23.5**: los waivers approve-and-learn quedan acotados al broker y
 >   `end_user` aprobados; el lector de sesiones `shell`/`pty` limita líneas sin
 >   newline antes de bufferizarlas; `broker-ctl reload` solo envía SIGHUP si el

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -56,3 +56,37 @@ tamper with the audit chain undetected.
   git-ignored). Treat any accidental commit as a key-rotation event.
 - Audit seeds (`pki/*.seed`) must not be rotated casually — doing so breaks the
   hash/signature chain of existing logs.
+
+## Redaction is best-effort
+
+The optional `redact` config block (broker, signer, control plane) masks
+secrets embedded in commands before they reach a **persistent or outbound
+sink**: the audit log's free-text fields (`command`, `err`, `warning`,
+`anomaly`), session recordings (`.cast`), and the approval notification payload
+(log/webhook/Teams). A matched secret is replaced by `[REDACTED:<rule>]`;
+masking happens **before** the audit entry is signed, so `broker-ctl audit
+verify` is unaffected — and the original text is irrecoverable by design.
+
+Know its limits before relying on it:
+
+- **Regex matching is not DLP.** The built-in rules cover common shapes
+  (password/token flags, `mysql -p<pass>`, `VAR=secret` assignments, URI
+  `user:pass@`, `Authorization` headers, JWTs, AWS/GitHub/GitLab/Slack tokens,
+  private-key blocks). A secret in an unanticipated format survives. Extend
+  coverage with operator `patterns` (RE2; a `(?P<secret>...)` group masks only
+  the secret and keeps the rest of the match as forensic context).
+- **Recording output is chunked.** Session **input** is recorded one full
+  command line per event, where patterns match reliably; **output** arrives in
+  arbitrary chunks, so a secret split across two events can escape a pattern.
+- **The decision path is never redacted, by design.** The signer authorizes,
+  and the certificate `force-command` enforces, the original command; the mTLS
+  approval UI (`/ui/approvals`) and `GET /v1/approvals` show the approver the
+  original command so the human decides on real information. sshd's own logs on
+  the target host are outside the broker's control.
+- **False positives cost forensics.** The `[REDACTED:<rule>]` marker names the
+  rule that fired; if a default rule masks something you need, disable the
+  defaults (`disable_defaults`) and supply your own `patterns`.
+
+The first line of defence remains unchanged: prefer credential-free
+invocations (env files on the host, `~/.pgpass`, secret managers) over inline
+secrets.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -226,16 +226,27 @@ Local/lab mode loads the CA key from a PEM file into process memory (a runtime
 HSM/KMS-backed `crypto.Signer`. The seam exists; using PEM in production is an
 operator error the code warns about but cannot prevent.
 
-### 8. Secrets in commands are logged and recorded verbatim
-A command is written as-is to the broker and signer audit logs and, for
-`shell`/`pty` sessions, to the ASCIIcast recording. A credential passed inline —
+### 8. Secrets in commands: redaction is opt-in and best-effort
+A command is written to the broker and signer audit logs and, for `shell`/`pty`
+sessions, to the ASCIIcast recording; the control plane additionally sends it
+in approval notifications (log/webhook/Teams). A credential passed inline —
 `mysql -psecret`, `PGPASSWORD=… pg_dump`, `curl -H "Authorization: Bearer …"` —
-is therefore persisted in plaintext in the chained audit log and in the `.cast`
-file. There is **no redaction or masking**.
-- **Mitigation today:** prefer credential-free invocations (env files on the
-  host, `~/.pgpass`, secret managers) and treat audit logs / recordings as
-  sensitive at rest (`0600`, restricted directories). A configurable masking
-  pattern set is a roadmap item.
+would otherwise persist in plaintext in every one of those sinks.
+- **Mitigation:** the opt-in `redact` config block (all three services) masks
+  secrets at every persistent/outbound sink — audit log free-text fields,
+  session recordings, and the approval notification payload — using built-in
+  patterns plus operator-defined RE2 rules, replacing the secret with
+  `[REDACTED:<rule>]` **before** the audit entry is signed (verification is
+  unaffected; the original is irrecoverable). Redaction never touches the
+  decision path: the signer, the certificate force-command, and the mTLS
+  approval UI see the original command.
+- **Residual risk:** pattern matching is best-effort, not DLP (see
+  [SECURITY.md](SECURITY.md#redaction-is-best-effort)) — an unanticipated
+  secret format survives, and output recorded in `.cast` files arrives in
+  arbitrary chunks that can split a secret across two events. Prefer
+  credential-free invocations (env files on the host, `~/.pgpass`, secret
+  managers) and keep treating audit logs / recordings as sensitive at rest
+  (`0600`, restricted directories).
 
 ### 9. Audit failure is fail-open
 If writing an audit entry fails (disk full, I/O error), the failure is logged

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -25,6 +25,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `session_idle_seconds` | `int` | Persistent session idle-close and maximum lifetime. |
 | `session_max_seconds` | `int` | default 1800 |
 | `session_recording_dir` | `string` | SessionRecordingDir: directory for session recordings in ASCIIcast v2 format (.cast files). One file per session: <session_id>.cast. Empty = recording disabled. |
+| `redact` | `*redact.Config` | Redact enables secret redaction on this broker's persistent/outbound sinks: the audit log's free-text fields and session recordings. Present (even empty, "redact": {}) = built-in default patterns; absent = disabled (backward compatible). Redaction never touches the decision path — the signer and the certificate force-command always see the original command. |
 | `hosts` | `map[string]HostConfig` | Hosts: used only in local mode (single-binary). In remote mode the host list is fetched from the signer via /v1/hosts and refreshed periodically. |
 | `command_policies` | `map[string]signer.CommandPolicy` | CommandPolicies (local mode) is a named library of command policies, attachable to groups. GroupCommandPolicies maps a group name to the policy names that apply to its hosts; the reserved group "_default" applies to every host. A host's effective firewall is the composition of its inline command_policy and the policies of all its groups (additive union; deny wins). |
 | `group_command_policies` | `map[string][]string` |  |
@@ -112,6 +113,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `auto_reload_seconds` | `int` | AutoReloadSeconds: if > 0, the signer polls signer.json's mtime every N seconds and hot-reloads on change — same validated, atomic path as SIGHUP / POST /v1/reload, so a transiently-invalid in-progress save is rejected and the previous good state is kept. 0 or absent = disabled (default). |
 | `sign_rate_limit_per_min` | `int` | SignRateLimitPerMin caps POST /v1/sign requests per authenticated client CN per minute (token bucket: burst up to the cap, continuous refill). Keyed on the mTLS peer CN — not on_behalf_of — and enforced before body parsing; excess requests get 429 with a Retry-After hint. Hot-reloadable. 0 or absent = disabled (backward compatible). |
 | `monitor_listen` | `string` | MonitorListen: optional plain-HTTP monitoring listener serving /healthz (liveness) and /metrics (Prometheus text format). No authentication — bind to localhost or a private scrape interface. Empty = disabled. |
+| `redact` | `*redact.Config` | Redact enables secret redaction on the signer's audit log free-text fields. Present (even empty, "redact": {}) = built-in default patterns; absent = disabled (backward compatible). The signer's audit carries request metadata rather than the raw command, but errors can embed user text — every persistent sink applies the same invariant. |
 | `max_grant_ttl_seconds` | `int` | MaxGrantTTLSeconds: optional upper bound on a runtime grant's TTL (POST /v1/policy/hosts/{host}/grants). 0 or absent = no cap. |
 | `reload_callers` | `[]string` | ReloadCallers: client cert CNs authorised to invoke POST /v1/reload. Empty = HTTP endpoint disabled (403); SIGHUP still works locally. |
 | `trusted_forwarders` | `[]string` | TrustedForwarders: client cert CNs authorised to act on behalf of another broker (on_behalf_of field / X-On-Behalf-Of header). This is the control plane CN. Only these CNs may impersonate a broker for RBAC; any other CN sending on_behalf_of is rejected. |
@@ -148,6 +150,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `audit_log` | `string` | Audit log for the control plane (independent of broker and signer). |
 | `audit_key` | `string` |  |
 | `monitor_listen` | `string` | MonitorListen: optional plain-HTTP monitoring listener serving /healthz (liveness) and /metrics (Prometheus text format). No authentication — bind to localhost or a private scrape interface. Empty = disabled. |
+| `redact` | `*redact.Config` | Redact enables secret redaction on the control plane's persistent and outbound sinks: the audit log's free-text fields and the approval notification payload (log/webhook/Teams). Present (even empty, "redact": {}) = built-in default patterns; absent = disabled (backward compatible). The approval registry itself keeps the original command: the mTLS approval UI and API show the approver exactly what will run, and the approved request forwarded to the signer is untouched. |
 
 ## Control-plane behaviour guardrails (`behavior`)
 
@@ -195,6 +198,24 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `deny` | `[]string` | Deny: in denylist mode, the command must not match any. |
 | `require_approval` | `[]string` | RequireApproval: commands that match require out-of-band human approval. Evaluated independently of the mode (orchestrated by the control plane). |
 | `shell_parse` | `bool` | ShellParse: if true, the command is parsed as POSIX sh before evaluating the policy. Each simple command is evaluated separately; dangerous nodes (subshells, process substitution, file redirects) are rejected unconditionally. Backward compatible: false by default. |
+
+## Secret redaction (`redact`, all three services)
+
+`Config` in `internal/redact/redact.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `patterns` | `[]Pattern` | Patterns are extra operator-defined rules, applied after the built-in defaults. See Pattern for the regex contract. |
+| `disable_defaults` | `bool` | DisableDefaults turns off the built-in default rules, leaving only the operator's Patterns. Escape hatch when a default rule produces false positives that hurt forensics. |
+
+## Redaction pattern (`redact.patterns[]`)
+
+`Pattern` in `internal/redact/redact.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `name` | `string` | Name identifies the rule inside the [REDACTED:<name>] marker. |
+| `regex` | `string` | Regex is an RE2 expression (linear-time, no catastrophic backtracking — same engine and rationale as the command-policy rules). If it defines a capturing group named "secret", only that group is masked; otherwise the whole match is masked. |
 
 ## Vocabulary (enumerated constants)
 

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -85,12 +85,21 @@ type Entry struct {
 	Sig      string `json:"sig"`
 }
 
+// Redactor masks secrets in free-text entry fields before an entry is signed
+// and persisted. It is satisfied by *redact.Redactor; declared here so audit
+// does not import the redact package (the dependency stays one-way, wired by
+// each service at startup).
+type Redactor interface {
+	Redact(string) string
+}
+
 // Log is a concurrent audit writer that chains and signs entries.
 type Log struct {
 	mu          sync.Mutex
 	f           logFile
 	path        string
 	signKey     ed25519.PrivateKey
+	redactor    Redactor // nil = no redaction
 	prevHash    string
 	seq         uint64
 	maxFileSize int64 // 0 = no rotation
@@ -240,6 +249,18 @@ func (l *Log) ensureOpen() error {
 	return nil
 }
 
+// SetRedactor installs a secret redactor applied to the free-text fields of
+// every subsequent entry (Command, Err, Warning, Anomaly) BEFORE the entry is
+// signed — the Ed25519 signature and the hash chain cover the redacted
+// content, so verification is unaffected and the original text is never
+// persisted. Redaction must only run on this sink: the decision path (what
+// the signer authorizes) always sees the original command.
+func (l *Log) SetRedactor(r Redactor) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.redactor = r
+}
+
 // appendFailures counts Append errors across every log this process holds, so
 // operators can alert on audit-trail gaps (the call sites only log a warning —
 // the operation deliberately continues).
@@ -259,6 +280,16 @@ func (l *Log) Append(e Entry) error {
 func (l *Log) doAppend(e Entry) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
+	// Gap #8: mask secrets in the free-text fields before signing, so neither
+	// the signature nor the persisted line ever contains the original secret.
+	// The other fields are broker/signer-generated metadata, not user text.
+	if l.redactor != nil {
+		e.Command = l.redactor.Redact(e.Command)
+		e.Err = l.redactor.Redact(e.Err)
+		e.Warning = l.redactor.Redact(e.Warning)
+		e.Anomaly = l.redactor.Redact(e.Anomaly)
+	}
 
 	// L2: rotate if the file has reached the size limit.
 	l.maybeRotate()

--- a/internal/audit/redact_test.go
+++ b/internal/audit/redact_test.go
@@ -1,0 +1,97 @@
+package audit
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// maskRedactor is a trivial Redactor for tests: it replaces every occurrence
+// of "hunter2" with a marker, mirroring the real redact package's contract.
+type maskRedactor struct{}
+
+func (maskRedactor) Redact(s string) string {
+	return strings.ReplaceAll(s, "hunter2", "[REDACTED:test]")
+}
+
+// TestAppendRedactaCamposLibres verifies that a configured redactor masks the
+// free-text fields (Command, Err, Warning, Anomaly) in the persisted line and
+// leaves the metadata fields untouched.
+func TestAppendRedactaCamposLibres(t *testing.T) {
+	t.Parallel()
+	l, path := openTmp(t)
+	l.SetRedactor(maskRedactor{})
+
+	if err := l.Append(Entry{
+		Caller:  "agent",
+		Host:    "db01",
+		Command: "mysql -phunter2 app",
+		Err:     "exec failed: mysql -phunter2",
+		Warning: "would_deny: mysql -phunter2",
+		Anomaly: "new-command:mysql -phunter2",
+		Outcome: "executed",
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	entries := readEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0].e
+	for name, got := range map[string]string{
+		"Command": e.Command, "Err": e.Err, "Warning": e.Warning, "Anomaly": e.Anomaly,
+	} {
+		if strings.Contains(got, "hunter2") {
+			t.Errorf("%s: secret survived redaction: %q", name, got)
+		}
+		if !strings.Contains(got, "[REDACTED:test]") {
+			t.Errorf("%s: marker missing: %q", name, got)
+		}
+	}
+	if strings.Contains(string(entries[0].raw), "hunter2") {
+		t.Error("secret present in the raw persisted line")
+	}
+	if e.Caller != "agent" || e.Host != "db01" || e.Outcome != "executed" {
+		t.Errorf("metadata fields must not be altered: %+v", e)
+	}
+}
+
+// TestAppendFirmaCubreContenidoRedactado verifies that the Ed25519 signature
+// is computed over the REDACTED content: the persisted line must verify as-is,
+// so redaction is invisible to `broker-ctl audit verify` and the chain.
+func TestAppendFirmaCubreContenidoRedactado(t *testing.T) {
+	t.Parallel()
+	key := testKey()
+	pub := key.Public().(ed25519.PublicKey)
+
+	path := filepath.Join(t.TempDir(), "audit.log")
+	l, err := Open(path, key)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer l.Close()
+	l.SetRedactor(maskRedactor{})
+
+	if err := l.Append(Entry{Outcome: "executed", Command: "mysql -phunter2"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	entries := readEntries(t, path)
+	e := entries[0].e
+	sigBytes, err := base64.StdEncoding.DecodeString(e.Sig)
+	if err != nil {
+		t.Fatalf("signature is not base64: %v", err)
+	}
+	e.Sig = ""
+	payload, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal for verification: %v", err)
+	}
+	if !ed25519.Verify(pub, payload, sigBytes) {
+		t.Error("signature must verify over the redacted content")
+	}
+}

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/ca"
 	"github.com/luisgf/ssh-broker/internal/confcheck"
 	"github.com/luisgf/ssh-broker/internal/monitor"
+	"github.com/luisgf/ssh-broker/internal/redact"
 	"github.com/luisgf/ssh-broker/internal/signer"
 	sshrun "github.com/luisgf/ssh-broker/internal/ssh"
 )
@@ -84,6 +85,13 @@ type Config struct {
 	// format (.cast files). One file per session: <session_id>.cast.
 	// Empty = recording disabled.
 	SessionRecordingDir string `json:"session_recording_dir,omitempty"`
+
+	// Redact enables secret redaction on this broker's persistent/outbound
+	// sinks: the audit log's free-text fields and session recordings. Present
+	// (even empty, "redact": {}) = built-in default patterns; absent = disabled
+	// (backward compatible). Redaction never touches the decision path — the
+	// signer and the certificate force-command always see the original command.
+	Redact *redact.Config `json:"redact,omitempty"`
 
 	// Hosts: used only in local mode (single-binary). In remote mode the host
 	// list is fetched from the signer via /v1/hosts and refreshed periodically.
@@ -274,6 +282,7 @@ type Engine struct {
 	sgn      signer.Signer
 	fetcher  hostFetcher // nil in local mode
 	auditLog *audit.Log
+	redactor *redact.Redactor // nil = redaction disabled
 	maxTTL   time.Duration
 	sessions *sessionManager
 
@@ -325,6 +334,19 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		return nil, err
 	}
 
+	// An invalid redact pattern is a startup error (fail-closed), not a
+	// silently smaller rule set.
+	var redactor *redact.Redactor
+	if cfg.Redact != nil {
+		redactor, err = redact.New(cfg.Redact)
+		if err != nil {
+			return nil, fmt.Errorf("compiling redact config: %w", err)
+		}
+		if redactor != nil {
+			al.SetRedactor(redactor)
+		}
+	}
+
 	idle := time.Duration(cfg.SessionIdleSeconds) * time.Second
 	if idle <= 0 {
 		idle = 5 * time.Minute
@@ -334,7 +356,7 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		maxLife = 30 * time.Minute
 	}
 
-	e := &Engine{cfg: cfg, sgn: sgn, fetcher: fetcher, auditLog: al, maxTTL: maxTTL}
+	e := &Engine{cfg: cfg, sgn: sgn, fetcher: fetcher, auditLog: al, redactor: redactor, maxTTL: maxTTL}
 	e.sessions = newSessionManager(idle, maxLife, func(s *liveSession) {
 		e.auditE(audit.Entry{Caller: s.caller, Host: s.host, Serial: s.serial,
 			SessionID: s.id, Outcome: "session_close", Err: "reaped (idle/lifetime)"})

--- a/internal/broker/redact_wiring_test.go
+++ b/internal/broker/redact_wiring_test.go
@@ -1,0 +1,90 @@
+package broker
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/luisgf/ssh-broker/internal/redact"
+)
+
+// redactEngineConfig builds a minimal local-mode config (CA key + audit key in
+// a temp dir) carrying the given redact config.
+func redactEngineConfig(t *testing.T, rc *redact.Config) *Config {
+	t.Helper()
+	dir := t.TempDir()
+
+	_, caPriv, _ := ed25519.GenerateKey(rand.Reader)
+	blk, err := ssh.MarshalPrivateKey(caPriv, "ca-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(dir, "ca")
+	if err := os.WriteFile(caPath, pem.EncodeToMemory(blk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedPath := filepath.Join(dir, "audit.seed")
+	if err := os.WriteFile(seedPath, make([]byte, 32), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &Config{
+		CAKey:         caPath,
+		AuditLog:      filepath.Join(dir, "audit.log"),
+		AuditKey:      seedPath,
+		SourceAddress: "127.0.0.1",
+		MaxTTLSeconds: 120,
+		Redact:        rc,
+		Hosts: map[string]HostConfig{
+			"web01": {Addr: "10.0.0.21:22", User: "deploy", Principal: "host:web01",
+				HostKey: "ssh-ed25519 AAAAC3Nz"},
+		},
+	}
+}
+
+// TestNewEngineRedactWiring verifies that a "redact" config block reaches the
+// engine's audit log: an entry written by the engine must be persisted with
+// the secret masked.
+func TestNewEngineRedactWiring(t *testing.T) {
+	cfg := redactEngineConfig(t, &redact.Config{}) // empty block = defaults
+	e, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer e.Close()
+	if e.redactor == nil {
+		t.Fatal("engine must hold the compiled redactor for session recorders")
+	}
+
+	// Unknown host: Execute audits a denial that carries the command verbatim.
+	_, err = e.Execute(context.Background(), Caller{ID: "tester"}, "nope", "mysql --password=hunter2", 0, ExecOptions{})
+	if err == nil {
+		t.Fatal("unknown host must fail")
+	}
+
+	raw, err := os.ReadFile(cfg.AuditLog)
+	if err != nil {
+		t.Fatalf("reading audit log: %v", err)
+	}
+	if strings.Contains(string(raw), "hunter2") {
+		t.Errorf("secret survived in the engine audit log: %s", raw)
+	}
+	if !strings.Contains(string(raw), "[REDACTED:flag-password]") {
+		t.Errorf("redaction marker missing in the engine audit log: %s", raw)
+	}
+}
+
+// TestNewEngineInvalidRedactPatternFailsClosed pins the fail-closed contract:
+// an invalid redact pattern is a startup error, not a silently smaller rule set.
+func TestNewEngineInvalidRedactPatternFailsClosed(t *testing.T) {
+	cfg := redactEngineConfig(t, &redact.Config{Patterns: []redact.Pattern{{Name: "bad", Regex: "("}}})
+	if _, err := NewEngine(cfg); err == nil {
+		t.Fatal("NewEngine must fail on an invalid redact pattern")
+	}
+}

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -389,6 +389,9 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 		if err != nil {
 			log.Printf("warning: could not open recording file %s: %v", castPath, err)
 		} else {
+			if e.redactor != nil {
+				rec.SetRedactor(e.redactor)
+			}
 			s.recorder = rec
 			s.shell.SetRecorder(rec)
 		}

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -57,6 +57,27 @@ type Approval struct {
 	issuing bool
 }
 
+// Redactor masks secrets in an approval's command for notification sinks. It
+// is satisfied by *redact.Redactor; declared here so control does not import
+// the redact package (the dependency stays one-way, wired by the control
+// plane at startup).
+type Redactor interface {
+	Redact(string) string
+}
+
+// WithRedactedCommand returns a copy of the approval whose Command has been
+// passed through r, for notification sinks that persist or leave the host
+// (process log, webhook, Teams). The registry entry keeps the original
+// command: the mTLS approval UI/API must show the approver exactly what will
+// run, and the approved request forwarded to the signer is untouched. A nil r
+// returns the approval unchanged.
+func (a Approval) WithRedactedCommand(r Redactor) Approval {
+	if r != nil {
+		a.Command = r.Redact(a.Command)
+	}
+	return a
+}
+
 // Registry keeps approval requests in memory with TTL-based expiry.
 type Registry struct {
 	mu    sync.Mutex

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -53,15 +53,24 @@ type brokerMeta struct {
 // cap is reached. 0 disables the cap.
 const DefaultMaxBytes int64 = 100 * 1024 * 1024 // 100 MiB
 
+// Redactor masks secrets in event data before it is written to the .cast
+// file. It is satisfied by *redact.Redactor; declared here so recording does
+// not import the redact package (the dependency stays one-way, wired by the
+// broker at session open).
+type Redactor interface {
+	Redact(string) string
+}
+
 // Recorder writes an ASCIIcast v2 recording file for a single session.
 // All methods are safe for concurrent use.
 type Recorder struct {
 	mu       sync.Mutex
 	f        *os.File
 	started  time.Time
-	written  int64 // bytes written to the file so far (header + events)
-	maxBytes int64 // 0 = unlimited
-	capped   bool  // true once the cap was reached and the truncation note written
+	redactor Redactor // nil = no redaction
+	written  int64    // bytes written to the file so far (header + events)
+	maxBytes int64    // 0 = unlimited
+	capped   bool     // true once the cap was reached and the truncation note written
 }
 
 // Open creates a new recording file at path and writes the ASCIIcast header.
@@ -121,6 +130,17 @@ func Open(path string, m Meta) (*Recorder, error) {
 	return &Recorder{f: f, started: time.Now(), written: int64(n), maxBytes: DefaultMaxBytes}, nil
 }
 
+// SetRedactor installs a secret redactor applied to every subsequent event's
+// data before it is written. Input events carry one full command line per
+// event (reliable matching); output arrives in arbitrary chunks, so a secret
+// split across two chunks can escape a pattern — redaction here is
+// best-effort by design (see docs/SECURITY.md).
+func (r *Recorder) SetRedactor(rd Redactor) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.redactor = rd
+}
+
 // WriteOutput records a chunk of stdout (or merged PTY output) as type "o".
 func (r *Recorder) WriteOutput(data string) error {
 	return r.write("o", data)
@@ -158,6 +178,9 @@ func (r *Recorder) write(eventType, data string) error {
 	defer r.mu.Unlock()
 	if r.f == nil {
 		return nil
+	}
+	if r.redactor != nil {
+		data = r.redactor.Redact(data)
 	}
 	if r.maxBytes > 0 && r.written >= r.maxBytes {
 		// Cap reached: write a single truncation note as an output event, then

--- a/internal/recording/redact_test.go
+++ b/internal/recording/redact_test.go
@@ -1,0 +1,63 @@
+package recording
+
+import (
+	"strings"
+	"testing"
+)
+
+// maskRedactor is a trivial Redactor for tests, mirroring the real redact
+// package's contract.
+type maskRedactor struct{}
+
+func (maskRedactor) Redact(s string) string {
+	return strings.ReplaceAll(s, "hunter2", "[REDACTED:test]")
+}
+
+// TestRedactorMasksEvents verifies that a configured redactor masks input,
+// output, and stderr event data before it reaches the .cast file.
+func TestRedactorMasksEvents(t *testing.T) {
+	r, path := openTmp(t)
+	r.SetRedactor(maskRedactor{})
+
+	if err := r.WriteInput("mysql -phunter2 app\n"); err != nil {
+		t.Fatalf("WriteInput: %v", err)
+	}
+	if err := r.WriteOutput("Enter password: hunter2\r\n"); err != nil {
+		t.Fatalf("WriteOutput: %v", err)
+	}
+	if err := r.WriteStderr("auth failed for hunter2\n"); err != nil {
+		t.Fatalf("WriteStderr: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	lines := readLines(t, path)
+	if len(lines) != 4 { // header + 3 events
+		t.Fatalf("expected 4 lines, got %d", len(lines))
+	}
+	for i, l := range lines[1:] {
+		if strings.Contains(l, "hunter2") {
+			t.Errorf("event %d: secret survived redaction: %q", i, l)
+		}
+		if !strings.Contains(l, "[REDACTED:test]") {
+			t.Errorf("event %d: marker missing: %q", i, l)
+		}
+	}
+}
+
+// TestNoRedactorUnchanged pins the nil-redactor behaviour: without SetRedactor
+// the data is written verbatim (today's behaviour).
+func TestNoRedactorUnchanged(t *testing.T) {
+	r, path := openTmp(t)
+	if err := r.WriteInput("mysql -phunter2\n"); err != nil {
+		t.Fatalf("WriteInput: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	lines := readLines(t, path)
+	if !strings.Contains(lines[1], "hunter2") {
+		t.Errorf("without a redactor the data must be verbatim: %q", lines[1])
+	}
+}

--- a/internal/redact/defaults.go
+++ b/internal/redact/defaults.go
@@ -1,0 +1,70 @@
+package redact
+
+// Defaults is the built-in rule set. Ordering matters: rules run in sequence
+// and a segment already masked by an earlier rule is never re-masked (the
+// marker-skip in apply), so more specific rules go first. All expressions are
+// RE2 (linear time).
+//
+// Design notes:
+//   - Rules that keep context (flag names, variable names, usernames) mark
+//     the secret with the (?P<secret>...) group; rules where the whole token
+//     is the secret (JWTs, vendor tokens, key blocks) mask the full match.
+//   - The env-assignment rule requires the sensitive keyword to be a full
+//     "_"-delimited component of the variable name, so AUTH matches AUTH= and
+//     BASIC_AUTH= but not AUTHOR= or XAUTHORITY= (real-world false positives).
+//   - The mysql rule covers the attached short form (mysql -psecret) — the
+//     canonical example of threat-model gap #8 — and is scoped to the mysql
+//     client family because a bare "-p<value>" is far too ambiguous (ports,
+//     paths, profiles...).
+var Defaults = []Pattern{
+	{
+		Name:  "flag-password",
+		Regex: `(?i)--?(?:password|passwd|pwd|pass|token|secret|api[-_]?key)[= ]+(?P<secret>"[^"]+"|'[^']+'|[^\s"']+)`,
+	},
+	{
+		Name:  "mysql-p-attached",
+		Regex: `(?i)\b(?:mysql|mysqldump|mysqladmin|mariadb|mariadb-dump)\b[^\n|;&]*?\s-p(?P<secret>[^\s-][^\s]*)`,
+	},
+	{
+		Name:  "env-assignment",
+		Regex: `(?i)\b(?:[A-Z0-9]+_)*(?:PASSWORD|PASSWD|PWD|PASSPHRASE|SECRET|TOKEN|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIALS?|AUTH)(?:_[A-Z0-9]+)*=(?P<secret>"[^"]+"|'[^']+'|[^\s"']+)`,
+	},
+	{
+		Name:  "uri-userinfo",
+		Regex: `://[^/\s:@]+:(?P<secret>[^@\s/]+)@`,
+	},
+	{
+		Name:  "auth-header",
+		Regex: `(?i)\b(?:authorization|proxy-authorization)\b['"]?\s*[:=]\s*['"]?(?:bearer|basic|token)\s+(?P<secret>[A-Za-z0-9+/=_.~-]+)`,
+	},
+	{
+		Name:  "curl-user",
+		Regex: `(?:^|\s)(?:-u|--user)[= ]+[^\s:]+:(?P<secret>"[^"]+"|'[^']+'|[^\s"']+)`,
+	},
+	{
+		// JWTs (three base64url segments). Also catches Kubernetes
+		// ServiceAccount tokens and most OIDC access tokens.
+		Name:  "jwt",
+		Regex: `\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b`,
+	},
+	{
+		Name:  "aws-key-id",
+		Regex: `\b(?:AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}\b`,
+	},
+	{
+		Name:  "github-token",
+		Regex: `\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b`,
+	},
+	{
+		Name:  "gitlab-token",
+		Regex: `\bglpat-[A-Za-z0-9_-]{20,}\b`,
+	},
+	{
+		Name:  "slack-token",
+		Regex: `\bxox[baprs]-[A-Za-z0-9-]{10,}\b`,
+	},
+	{
+		Name:  "private-key-block",
+		Regex: `-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----(?s:.*?)(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|\z)`,
+	},
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,146 @@
+// Package redact masks secrets embedded in free text (typically command
+// lines) before the text reaches a persistent or outbound sink: the audit
+// log, a session recording, or an approval notification.
+//
+// Redaction is best-effort pattern matching, not DLP: it shrinks the blast
+// radius of a secret typed into a command, it does not guarantee removal
+// (see docs/SECURITY.md). It must NEVER run on the decision path — what the
+// signer authorizes, what the certificate force-command enforces, and what
+// the human approver reviews over mTLS is always the original text.
+package redact
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Marker is the prefix of the replacement written in place of a secret. The
+// full replacement is "[REDACTED:<rule-name>]" so a redacted record points
+// back at the rule that fired.
+const Marker = "[REDACTED:"
+
+// SecretGroup is the name of the capturing group that marks the secret part
+// of a pattern. With the group, only its capture is masked and the rest of
+// the match is preserved as forensic context; without it, the whole match is
+// masked.
+const SecretGroup = "secret"
+
+// Config is the operator-facing redaction configuration, embedded in each
+// service's config file under the "redact" key. Absent/empty = redaction
+// disabled (current behaviour).
+type Config struct {
+	// Patterns are extra operator-defined rules, applied after the built-in
+	// defaults. See Pattern for the regex contract.
+	Patterns []Pattern `json:"patterns,omitempty"`
+	// DisableDefaults turns off the built-in default rules, leaving only the
+	// operator's Patterns. Escape hatch when a default rule produces false
+	// positives that hurt forensics.
+	DisableDefaults bool `json:"disable_defaults,omitempty"`
+}
+
+// Pattern is one named redaction rule.
+type Pattern struct {
+	// Name identifies the rule inside the [REDACTED:<name>] marker.
+	Name string `json:"name"`
+	// Regex is an RE2 expression (linear-time, no catastrophic backtracking —
+	// same engine and rationale as the command-policy rules). If it defines a
+	// capturing group named "secret", only that group is masked; otherwise the
+	// whole match is masked.
+	Regex string `json:"regex"`
+}
+
+// rule is one compiled redaction rule.
+type rule struct {
+	name string
+	re   *regexp.Regexp
+	// secretIdx is the index of the "secret" capturing group, or -1 when the
+	// whole match is the secret.
+	secretIdx int
+}
+
+// Redactor applies an ordered set of compiled redaction rules. It is
+// immutable after New and safe for concurrent use. A nil *Redactor is valid
+// and redacts nothing.
+type Redactor struct {
+	rules []rule
+}
+
+// reValidName constrains rule names so the [REDACTED:<name>] marker stays a
+// single unambiguous token in logs.
+var reValidName = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,64}$`)
+
+// New compiles the configured rules (defaults first, operator extras after).
+// Any invalid rule is a hard error: the caller is expected to fail startup
+// (fail-closed) rather than run with a silently smaller rule set. A nil cfg
+// selects the defaults only. Returns nil (redaction disabled) when the
+// effective rule set is empty.
+func New(cfg *Config) (*Redactor, error) {
+	var pats []Pattern
+	if cfg == nil || !cfg.DisableDefaults {
+		pats = append(pats, Defaults...)
+	}
+	if cfg != nil {
+		pats = append(pats, cfg.Patterns...)
+	}
+	if len(pats) == 0 {
+		return nil, nil
+	}
+	r := &Redactor{rules: make([]rule, 0, len(pats))}
+	for i, p := range pats {
+		if !reValidName.MatchString(p.Name) {
+			return nil, fmt.Errorf("redact: pattern %d: invalid name %q", i, p.Name)
+		}
+		re, err := regexp.Compile(p.Regex)
+		if err != nil {
+			return nil, fmt.Errorf("redact: pattern %q: %w", p.Name, err)
+		}
+		r.rules = append(r.rules, rule{name: p.Name, re: re, secretIdx: re.SubexpIndex(SecretGroup)})
+	}
+	return r, nil
+}
+
+// Redact returns s with every rule applied in order. Each rule rewrites the
+// output of the previous one, so a later rule can still fire on the context
+// an earlier rule preserved.
+func (r *Redactor) Redact(s string) string {
+	if r == nil || s == "" {
+		return s
+	}
+	for _, ru := range r.rules {
+		s = ru.apply(s)
+	}
+	return s
+}
+
+// apply masks every non-overlapping occurrence of ru in s. A candidate whose
+// content already is a redaction marker is skipped, so two rules that overlap
+// (e.g. a flag rule and an assignment rule matching the same "--password=x")
+// cannot cascade into masking each other's marker and losing the rule name.
+func (ru rule) apply(s string) string {
+	matches := ru.re.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		return s
+	}
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		if gi := ru.secretIdx; gi > 0 && 2*gi+1 < len(m) && m[2*gi] >= 0 {
+			start, end = m[2*gi], m[2*gi+1]
+		}
+		if start < last { // overlap with a segment this rule already rewrote
+			continue
+		}
+		if strings.HasPrefix(s[start:], Marker) { // already redacted by an earlier rule
+			continue
+		}
+		b.WriteString(s[last:start])
+		b.WriteString(Marker)
+		b.WriteString(ru.name)
+		b.WriteString("]")
+		last = end
+	}
+	b.WriteString(s[last:])
+	return b.String()
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,163 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// mustNew builds a defaults-only Redactor or fails the test.
+func mustNew(t *testing.T) *Redactor {
+	t.Helper()
+	r, err := New(nil)
+	if err != nil {
+		t.Fatalf("New(nil): %v", err)
+	}
+	if r == nil {
+		t.Fatal("New(nil) returned a nil redactor with defaults enabled")
+	}
+	return r
+}
+
+func TestDefaultsRedact(t *testing.T) {
+	r := mustNew(t)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// flag-password: long-form flags keep the flag as context.
+		{"flag equals", "mysql --password=hunter2 -h db", "mysql --password=[REDACTED:flag-password] -h db"},
+		{"flag space", "vault login --token hunter2", "vault login --token [REDACTED:flag-password]"},
+		{"flag quoted", `cmd --password="h 2" x`, `cmd --password=[REDACTED:flag-password] x`},
+		{"flag apikey", "tool --api-key=abc123", "tool --api-key=[REDACTED:flag-password]"},
+		{"two flags", "cmd --password=a --token=b", "cmd --password=[REDACTED:flag-password] --token=[REDACTED:flag-password]"},
+
+		// mysql-p-attached: the gap #8 example. Scoped to the mysql family.
+		{"mysql attached", "mysql -u root -phunter2 db", "mysql -u root -p[REDACTED:mysql-p-attached] db"},
+		{"mysqldump attached", "mysqldump -pS3cr3t! app", "mysqldump -p[REDACTED:mysql-p-attached] app"},
+		{"mysql prompt form", "mysql -p -u root db", "mysql -p -u root db"},         // -p alone prompts; nothing to mask
+		{"non-mysql -p", "ssh -p 2222 host uptime", "ssh -p 2222 host uptime"},      // port, not a password
+		{"scope breaks at ;", "mysql db; rm -paxos.txt", "mysql db; rm -paxos.txt"}, // -p after a separator is out of scope
+
+		// env-assignment: keyword must be a full _-delimited component.
+		{"env password", "export DB_PASSWORD=hunter2", "export DB_PASSWORD=[REDACTED:env-assignment]"},
+		{"env token", "GITHUB_TOKEN=ghx123 make deploy", "GITHUB_TOKEN=[REDACTED:env-assignment] make deploy"},
+		{"env quoted", `SECRET="two words" run`, `SECRET=[REDACTED:env-assignment] run`},
+		{"env auth alone", "AUTH=abc cmd", "AUTH=[REDACTED:env-assignment] cmd"},
+		{"env author untouched", "AUTHOR=luis git commit", "AUTHOR=luis git commit"},
+		{"env xauthority untouched", "XAUTHORITY=/home/x/.Xauthority startx", "XAUTHORITY=/home/x/.Xauthority startx"},
+
+		// uri-userinfo: only the password component is masked.
+		{"uri", "curl https://user:hunter2@example.com/x", "curl https://user:[REDACTED:uri-userinfo]@example.com/x"},
+		{"uri no pass", "curl https://example.com/a:b@c", "curl https://example.com/a:b@c"},
+
+		// auth-header.
+		{"auth header", "curl -H 'Authorization: Bearer abc.def-123'", "curl -H 'Authorization: Bearer [REDACTED:auth-header]'"},
+
+		// curl-user.
+		{"curl user", "curl -u admin:hunter2 https://x", "curl -u admin:[REDACTED:curl-user] https://x"},
+		{"curl user no pass", "useradd -u 1000 luis", "useradd -u 1000 luis"},
+
+		// Whole-match vendor tokens.
+		{"jwt", "kubectl --token eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJ4In0abcdefgh.sig-abcdefgh123", "kubectl --token [REDACTED:flag-password]"},
+		{"aws key id", "aws --profile x AKIAIOSFODNN7EXAMPLE", "aws --profile x [REDACTED:aws-key-id]"},
+		{"github token", "git clone https://ghp_abcdefghijklmnopqrstuvwxyz012345@github.com/x", "git clone https://[REDACTED:github-token]@github.com/x"},
+
+		// Neutral commands must pass through byte-identical.
+		{"neutral", "systemctl restart nginx && df -h /", "systemctl restart nginx && df -h /"},
+		{"neutral passwd file", "cat /etc/passwd", "cat /etc/passwd"},
+		{"neutral flag path", "restic --password-file=/etc/restic.pass backup", "restic --password-file=/etc/restic.pass backup"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := r.Redact(tc.in); got != tc.want {
+				t.Errorf("Redact(%q)\n got  %q\n want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrivateKeyBlock(t *testing.T) {
+	r := mustNew(t)
+	pem := "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXk\nmore\n-----END OPENSSH PRIVATE KEY-----"
+	got := r.Redact("echo '" + pem + "' > key")
+	if strings.Contains(got, "b3BlbnNzaC1rZXk") {
+		t.Fatalf("key material survived: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED:private-key-block]") {
+		t.Fatalf("marker missing: %q", got)
+	}
+	// A truncated block (chunk boundary) must still be masked to the end.
+	got = r.Redact("-----BEGIN RSA PRIVATE KEY-----\nAAAA...")
+	if strings.Contains(got, "AAAA") {
+		t.Fatalf("truncated key material survived: %q", got)
+	}
+}
+
+// TestNoCascade: two rules whose patterns overlap on the same input must not
+// re-mask each other's marker (the rule name in the marker is forensic data).
+func TestNoCascade(t *testing.T) {
+	r := mustNew(t)
+	got := r.Redact("run --password=hunter2")
+	if got != "run --password=[REDACTED:flag-password]" {
+		t.Fatalf("marker was cascaded: %q", got)
+	}
+	if strings.Count(got, Marker) != 1 {
+		t.Fatalf("expected exactly one marker: %q", got)
+	}
+}
+
+func TestOperatorPatterns(t *testing.T) {
+	r, err := New(&Config{Patterns: []Pattern{{Name: "acme-id", Regex: `\bACME-[0-9]{6}\b`}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := r.Redact("login ACME-123456 --password=x")
+	if !strings.Contains(got, "[REDACTED:acme-id]") || !strings.Contains(got, "[REDACTED:flag-password]") {
+		t.Fatalf("operator pattern must compose with defaults: %q", got)
+	}
+
+	// DisableDefaults leaves only the operator's rules.
+	r, err = New(&Config{DisableDefaults: true, Patterns: []Pattern{{Name: "acme-id", Regex: `\bACME-[0-9]{6}\b`}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got = r.Redact("login ACME-123456 --password=x")
+	if !strings.Contains(got, "[REDACTED:acme-id]") || strings.Contains(got, "flag-password") {
+		t.Fatalf("defaults must be off: %q", got)
+	}
+
+	// DisableDefaults with no patterns = redaction disabled.
+	r, err = New(&Config{DisableDefaults: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r != nil {
+		t.Fatal("empty effective rule set must return a nil redactor")
+	}
+}
+
+func TestNewValidation(t *testing.T) {
+	if _, err := New(&Config{Patterns: []Pattern{{Name: "bad", Regex: `(`}}}); err == nil {
+		t.Fatal("invalid regex must fail New (fail-closed)")
+	}
+	if _, err := New(&Config{Patterns: []Pattern{{Name: "spaces not ok", Regex: `x`}}}); err == nil {
+		t.Fatal("invalid rule name must fail New")
+	}
+}
+
+func TestNilRedactor(t *testing.T) {
+	var r *Redactor
+	if got := r.Redact("mysql -phunter2"); got != "mysql -phunter2" {
+		t.Fatalf("nil redactor must be a no-op, got %q", got)
+	}
+}
+
+// TestDefaultsCompile guards the built-in list itself: every default must
+// compile and carry a valid name (New already enforces it; this test makes a
+// broken default fail loudly on its own).
+func TestDefaultsCompile(t *testing.T) {
+	if _, err := New(nil); err != nil {
+		t.Fatalf("defaults must compile: %v", err)
+	}
+}

--- a/signer.example.json
+++ b/signer.example.json
@@ -37,6 +37,9 @@
   "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: signer_sign_requests_total{outcome} (includes outcome='rate-limited', which is not audited by design), audit_append_failures_total.",
   "monitor_listen": "127.0.0.1:9160",
 
+  "_redact_comment": "Optional secret redaction on the signer's audit log free-text fields (threat-model gap #8). The signer's audit records request metadata rather than the raw command, but error strings can embed user text — every persistent sink applies the same invariant. Present — even empty {} — enables the built-in default patterns; 'patterns' adds operator RE2 rules; 'disable_defaults' keeps only the operator rules. Applied before the entry is signed (verification unaffected). Absent = disabled.",
+  "redact": {},
+
   "_sign_rate_limit_comment": "Optional per-CN rate limit on POST /v1/sign (threat-model gap #4): token bucket keyed on the authenticated mTLS peer CN — burst up to the cap, continuous refill — checked before the request body is parsed. Excess requests get 429 with a Retry-After hint; rejections are deliberately NOT written to the audit log (the log must not become the flooding amplifier). Hot-reloadable. 0 or absent = disabled. Recommended in production; size it to your busiest legitimate broker (each ssh_execute is one sign call, each ssh_session_exec one preflight call).",
   "sign_rate_limit_per_min": 120,
 

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -238,6 +238,8 @@ var configStructs = []struct{ file, name, title string }{
 	{"internal/control/behavior.go", "BehaviorConfig", "Control-plane behaviour guardrails (`behavior`)"},
 	{"internal/signer/signer.go", "HostPolicy", "Host policy (`hosts.<name>`)"},
 	{"internal/signer/cmdpolicy.go", "CommandPolicy", "Command policy (`command_policy`)"},
+	{"internal/redact/redact.go", "Config", "Secret redaction (`redact`, all three services)"},
+	{"internal/redact/redact.go", "Pattern", "Redaction pattern (`redact.patterns[]`)"},
 }
 
 var enumDecls = []struct{ file, title string }{


### PR DESCRIPTION
Closes threat-model gap #8: secrets typed into commands were persisted verbatim in the audit logs, the ASCIIcast recordings and the approval notification payload.

## What
- New `internal/redact` package: named RE2 rules, built-in defaults (password/token flags, attached `mysql -p<pass>`, `VAR=secret` assignments with `_`-delimited keyword matching, URI `user:pass@`, `Authorization` headers, JWTs, AWS/GitHub/GitLab/Slack tokens, private-key blocks) + operator `patterns` / `disable_defaults`. Invalid pattern = startup error (fail-closed).
- Choke-point application (no per-call-site instrumentation):
  - `audit.Log`: `command`/`err`/`warning`/`anomaly` masked **before signing** — the Ed25519 chain covers the redacted content; `broker-ctl audit verify` unaffected.
  - `recording.Recorder`: every ASCIIcast event (input = one command line per event; output chunked → documented best-effort).
  - Control-plane notifier (log/webhook/Teams). The registry keeps the original: the mTLS approval UI shows the approver the exact command; the forwarded approved request is untouched.
- New optional `redact` config block in broker/signer/control-plane; absent = disabled (backward compatible). The decision path is never redacted.

## Docs
SECURITY.md "Redaction is best-effort" (limits), THREAT_MODEL gap #8 updated, example configs, regenerated config reference.

## Tests
Per-pattern table incl. known false positives (`AUTHOR=`, `XAUTHORITY=`, `ssh -p 2222`, `--password-file=`), signature-over-redacted-content, nil-redactor byte-identical, engine wiring + fail-closed, control-plane split (notifier redacted / registry original). `go vet` + `go test -race ./...` clean.