### PR TITLE
feat: Kubernetes target — credential-broker via bound ServiceAccount tokens (v1.34.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This README is a landing page. The detail lives in focused, single-source docs:
 | [THREAT_MODEL.md](docs/THREAT_MODEL.md) | Actors, trust boundaries, security controls, and explicit non-goals/gaps |
 | [OPERATIONS.md](docs/OPERATIONS.md) | Runbook: startup, adding hosts, hot-reload, `broker-ctl`, PKI rotation, configs |
 | [API.md](docs/API.md) | HTTP endpoint reference for all services |
-| [USAGE.md](docs/USAGE.md) | Guide to the 7 MCP tools, dry-run, and audit review (for the model / operator) |
+| [USAGE.md](docs/USAGE.md) | Guide to the MCP tools (SSH + Kubernetes), dry-run, and audit review (for the model / operator) |
 | [SECURITY.md](docs/SECURITY.md) | Vulnerability disclosure policy |
 | [CONTRIBUTING.md](docs/CONTRIBUTING.md) · [CODING_STYLE.md](docs/CODING_STYLE.md) | Workflow, versioning, Go style |
 

--- a/cmd/broker-ctl/cluster.go
+++ b/cmd/broker-ctl/cluster.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+// cmdCluster dispatches the `cluster` subcommands.
+func cmdCluster(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: broker-ctl cluster list --remote")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "list":
+		cmdClusterList(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown cluster subcommand: %q\n", args[0])
+		os.Exit(1)
+	}
+}
+
+// wireClusterInfo mirrors signer.WireClusterInfo for decoding GET /v1/clusters
+// without importing the signer package here.
+type wireClusterInfo struct {
+	APIServer      string   `json:"api_server"`
+	CACertPEM      string   `json:"ca_cert_pem"`
+	Groups         []string `json:"groups,omitempty"`
+	ExtraResources []struct {
+		Resource string `json:"resource"`
+	} `json:"extra_resources,omitempty"`
+}
+
+// cmdClusterList reads the Kubernetes clusters the caller may reach from the
+// signer's GET /v1/clusters (mTLS) and renders them. The recommended
+// post-deploy check for a k8s target — the endpoint is caller-scoped, so a
+// non-200 is a hard failure (no silent fallback).
+func cmdClusterList(args []string) {
+	fs := flag.NewFlagSet("cluster list", flag.ExitOnError)
+	remote := fs.Bool("remote", false, "read the live cluster list from the signer over mTLS (required)")
+	urlFlag, cert, key, ca := signerFlags(fs)
+	must(fs.Parse(args))
+	if !*remote {
+		fatalf("cluster list requires --remote (clusters live only in the signer, not the local config)")
+	}
+	resolveSignerTarget(fs)
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+
+	resp, err := client.Get(base + "/v1/clusters")
+	if err != nil {
+		fatalf("GET %s/v1/clusters: %v", base, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fatalf("signer rejected the request (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	var clusters map[string]wireClusterInfo
+	if err := json.Unmarshal(rb, &clusters); err != nil {
+		fatalf("decoding clusters: %v", err)
+	}
+	if len(clusters) == 0 {
+		fmt.Println("(no kubernetes clusters configured or visible to this caller)")
+		return
+	}
+	names := make([]string, 0, len(clusters))
+	for n := range clusters {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tAPI SERVER\tGROUPS\tEXTRA RESOURCES")
+	for _, n := range names {
+		c := clusters[n]
+		extra := make([]string, 0, len(c.ExtraResources))
+		for _, r := range c.ExtraResources {
+			extra = append(extra, r.Resource)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", n, c.APIServer,
+			joinOrDash(c.Groups), joinOrDash(extra))
+	}
+	tw.Flush()
+}
+
+func joinOrDash(s []string) string {
+	if len(s) == 0 {
+		return "-"
+	}
+	return strings.Join(s, ",")
+}

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -88,6 +88,8 @@ func main() {
 		cmdAudit(args[1:])
 	case "policy":
 		cmdPolicy(args[1:])
+	case "cluster":
+		cmdCluster(args[1:])
 	case "version":
 		cmdVersion(args[1:])
 	case "help":
@@ -158,6 +160,7 @@ Commands:
   broker-ctl policy grant   --host <n> --allow <regex> [--ttl 2h]  Create a runtime, expiring grant (signer API, mTLS)
   broker-ctl policy grants  [--json]                        List active runtime grants
   broker-ctl policy revoke  <grant-id>                      Revoke a runtime grant
+  broker-ctl cluster list  --remote                         List Kubernetes clusters live from the signer (mTLS)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/cmd/control-plane/k8s_test.go
+++ b/cmd/control-plane/k8s_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+// stubK8sSigner is a signer that returns a bound token for allowed k8s
+// actions, and gates "delete" behind approval. It mirrors the SSH stub.
+func stubK8sSigner(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req signer.WireRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		needsApproval := req.K8sVerb == "delete"
+		if req.DryRun {
+			_ = json.NewEncoder(w).Encode(signer.WireResponse{Decision: &signer.DecisionInfo{Allowed: true, RequireApproval: needsApproval}})
+			return
+		}
+		if needsApproval && !req.Approved {
+			_ = json.NewEncoder(w).Encode(signer.WireResponse{Decision: &signer.DecisionInfo{Allowed: true, RequireApproval: true, MatchedRule: "require_approval:delete"}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(signer.WireResponse{K8sToken: "bound-" + req.K8sVerb, Serial: 9})
+	}))
+}
+
+func k8sSignReq(t *testing.T, cn, verb, resource, namespace, name string) *http.Request {
+	t.Helper()
+	canonical := verb + " " + resource + " " + namespace + "/" + name
+	return req(t, "POST", "/v1/sign", cn, signer.WireRequest{
+		TargetType: signer.TargetTypeK8s, Host: "lab-k8s", Role: signer.RoleTarget, Purpose: signer.PurposeOneshot,
+		Command: canonical, K8sVerb: verb, K8sResource: resource, K8sNamespace: namespace, K8sName: name,
+	})
+}
+
+// TestControlPlaneForwardsK8sToken: an allowed k8s action returns the bound
+// token straight through (no certificate path).
+func TestControlPlaneForwardsK8sToken(t *testing.T) {
+	sig := stubK8sSigner(t)
+	defer sig.Close()
+	s := testServer(t, sig.URL)
+
+	w := httptest.NewRecorder()
+	s.handleSign(w, k8sSignReq(t, "broker-1", "get", "pods", "prod", "web-1"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("allowed k8s action must return 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp signer.WireResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.K8sToken != "bound-get" || resp.Certificate != "" {
+		t.Errorf("expected a bound token, got %+v", resp)
+	}
+}
+
+// TestControlPlaneK8sApprovalFlow: a delete is gated, the approver sees the
+// canonical action, and the approved poll returns the bound token.
+func TestControlPlaneK8sApprovalFlow(t *testing.T) {
+	sig := stubK8sSigner(t)
+	defer sig.Close()
+	s := testServer(t, sig.URL)
+
+	w := httptest.NewRecorder()
+	s.handleSign(w, k8sSignReq(t, "broker-1", "delete", "pods", "prod", "web-1"))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("delete must be gated (202), got %d: %s", w.Code, w.Body.String())
+	}
+	var acc map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &acc); err != nil {
+		t.Fatal(err)
+	}
+	id := acc["approval_id"]
+
+	// The approver sees the canonical action in the registry.
+	a, ok := s.registry.Get(id)
+	if !ok || a.Command != "delete pods prod/web-1" {
+		t.Fatalf("approver must see the canonical action: %+v", a)
+	}
+
+	// Approve, then poll: the bound token comes back.
+	if _, err := s.registry.Decide(id, true, "broker-admin", 0); err != nil {
+		t.Fatal(err)
+	}
+	pw := httptest.NewRecorder()
+	pr := req(t, "GET", "/v1/sign/result/"+id, "broker-1", nil)
+	pr.SetPathValue("id", id)
+	s.handleResult(pw, pr)
+	if pw.Code != http.StatusOK {
+		t.Fatalf("approved poll must return 200, got %d: %s", pw.Code, pw.Body.String())
+	}
+	var resp signer.WireResponse
+	if err := json.Unmarshal(pw.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.K8sToken != "bound-delete" {
+		t.Errorf("approved k8s poll must return the bound token, got %+v", resp)
+	}
+}
+
+// TestControlPlaneForwardsClusters: GET /v1/clusters is forwarded to the
+// signer with the broker CN in X-On-Behalf-Of.
+func TestControlPlaneForwardsClusters(t *testing.T) {
+	var gotOBO string
+	sig := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOBO = r.Header.Get(signer.HeaderOnBehalfOf)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]signer.WireClusterInfo{
+			"lab-k8s": {APIServer: "https://10.0.0.5:6443", CACertPEM: "pem", Groups: []string{"platform"}},
+		})
+	}))
+	defer sig.Close()
+	s := testServer(t, sig.URL)
+
+	w := httptest.NewRecorder()
+	s.handleClusters(w, req(t, "GET", "/v1/clusters", "broker-1", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("clusters forward must return 200, got %d", w.Code)
+	}
+	if gotOBO != "broker-1" {
+		t.Errorf("on-behalf-of must carry the broker CN, got %q", gotOBO)
+	}
+	if !strings.Contains(w.Body.String(), "lab-k8s") {
+		t.Errorf("cluster list must be forwarded: %s", w.Body.String())
+	}
+}

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -265,6 +265,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/sign", srv.handleSign)
 	mux.HandleFunc("GET /v1/hosts", srv.handleHosts)
+	mux.HandleFunc("GET /v1/clusters", srv.handleClusters)
 	mux.HandleFunc("GET /v1/sign/result/{id}", srv.handleResult)
 	mux.HandleFunc("GET /v1/approvals", srv.handleApprovalsList)
 	mux.HandleFunc("POST /v1/approvals/{id}", srv.handleApprovalDecide)
@@ -439,12 +440,27 @@ func (s *server) forwardSignResult(w http.ResponseWriter, _ *http.Request, broke
 		})
 		return
 	}
+	// Kubernetes: the signer returned a bound token instead of a certificate.
+	if issued.K8sToken != "" {
+		s.auditE(audit.Entry{
+			Caller: brokerCN, Host: req.Host, Command: req.Command, Serial: issued.Serial,
+			Outcome: "forwarded", TargetType: signer.TargetTypeK8s,
+			PolicyRule: decisionRule(issued.Decision), Warning: decisionWarning(issued.Decision),
+		})
+		writeJSON(w, http.StatusOK, signer.WireResponse{
+			K8sToken:       issued.K8sToken,
+			K8sTokenExpiry: issued.K8sTokenExpiry,
+			Serial:         issued.Serial,
+			Decision:       issued.Decision,
+		})
+		return
+	}
 	if issued.Decision != nil && issued.Decision.RequireApproval {
 		s.requireApproval(w, brokerCN, req, issued.Decision.MatchedRule, "")
 		return
 	}
-	// Unexpected state: no cert, not dry-run, not approval.
-	http.Error(w, "signer response missing certificate", http.StatusBadGateway)
+	// Unexpected state: no credential, not dry-run, not approval.
+	http.Error(w, "signer response missing credential", http.StatusBadGateway)
 }
 
 // requireApproval creates an approval request, notifies, and responds 202.
@@ -556,6 +572,22 @@ func (s *server) handleResult(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
 			return
 		}
+		// Kubernetes approved action: the signer returns a bound token.
+		if req.TargetType == signer.TargetTypeK8s {
+			if issued.K8sToken == "" {
+				s.auditE(audit.Entry{Caller: a.Caller, Host: a.Host, Command: a.Command, Outcome: "error", ApprovalID: a.ID, TargetType: signer.TargetTypeK8s, Err: "signer response missing token"})
+				http.Error(w, "signing after approval failed", http.StatusBadGateway)
+				return
+			}
+			consumeOK = true
+			s.learnBehaviorApproval(a, req)
+			s.auditE(audit.Entry{Caller: a.Caller, Host: a.Host, Command: a.Command, Serial: issued.Serial, Outcome: "approval-granted", ApprovalID: a.ID, ApprovedBy: a.DecidedBy, TargetType: signer.TargetTypeK8s})
+			writeJSON(w, http.StatusOK, signer.WireResponse{
+				K8sToken: issued.K8sToken, K8sTokenExpiry: issued.K8sTokenExpiry,
+				Serial: issued.Serial, Decision: issued.Decision,
+			})
+			return
+		}
 		if issued.Certificate == nil {
 			s.auditE(audit.Entry{Caller: a.Caller, Host: a.Host, Command: a.Command, Outcome: "error", ApprovalID: a.ID, Err: "signer response missing certificate"})
 			http.Error(w, "signing after approval failed", http.StatusBadGateway)
@@ -602,6 +634,29 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 			// filtering in ssh_list_servers (otherwise an OIDC user with groups
 			// sees zero hosts behind the control plane).
 			Groups: h.Groups,
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// handleClusters forwards GET /v1/clusters to the signer on behalf of the
+// broker, so the broker sees the same group-filtered cluster list it would
+// see directly. Mirrors handleHosts.
+func (s *server) handleClusters(w http.ResponseWriter, r *http.Request) {
+	brokerCN, ok := s.signCaller(w, r)
+	if !ok {
+		return
+	}
+	clusters, err := s.remote.FetchClusters(r.Context(), brokerCN)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	out := make(map[string]signer.WireClusterInfo, len(clusters))
+	for name, c := range clusters {
+		out[name] = signer.WireClusterInfo{
+			APIServer: c.APIServer, CACertPEM: c.CACertPEM,
+			Groups: c.Groups, ExtraResources: c.ExtraResources,
 		}
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -713,18 +768,13 @@ func (s *server) auditE(e audit.Entry) {
 // intentFrom converts an incoming WireRequest into an Intent for the signer,
 // setting on_behalf_of (broker CN) and, optionally, approved.
 func intentFrom(req signer.WireRequest, onBehalfOf string, approved bool) (signer.Intent, error) {
-	pub, err := signer.ParsePublicKey(req.PublicKey)
-	if err != nil {
-		return signer.Intent{}, err
-	}
-	return signer.Intent{
+	in := signer.Intent{
 		Host:          req.Host,
 		Role:          req.Role,
 		Purpose:       req.Purpose,
 		SessionMode:   req.SessionMode,
 		Command:       req.Command,
 		RequestedTTL:  time.Duration(req.TTLSeconds) * time.Second,
-		PublicKey:     pub,
 		Sudo:          req.Sudo,
 		SudoUser:      req.SudoUser,
 		PTY:           req.PTY,
@@ -735,7 +785,27 @@ func intentFrom(req signer.WireRequest, onBehalfOf string, approved bool) (signe
 		Approved:      approved,
 		EndUser:       req.EndUser,
 		EndUserGroups: req.EndUserGroups,
-	}, nil
+	}
+	// Kubernetes: no ephemeral public key; carry the structured action so
+	// Remote.SignIntent re-serialises the k8s fields to the signer. The signer
+	// re-validates the action and its canonical form.
+	if req.TargetType == signer.TargetTypeK8s {
+		in.TargetType = signer.TargetTypeK8s
+		in.K8s = &signer.K8sAction{
+			Verb:      req.K8sVerb,
+			Resource:  req.K8sResource,
+			Group:     req.K8sGroup,
+			Namespace: req.K8sNamespace,
+			Name:      req.K8sName,
+		}
+		return in, nil
+	}
+	pub, err := signer.ParsePublicKey(req.PublicKey)
+	if err != nil {
+		return signer.Intent{}, err
+	}
+	in.PublicKey = pub
+	return in, nil
 }
 
 func cnSet(cns []string) map[string]struct{} {

--- a/cmd/signer/grants.go
+++ b/cmd/signer/grants.go
@@ -165,7 +165,9 @@ func (s *server) handleGrantRevoke(w http.ResponseWriter, r *http.Request) {
 // is audited but never fails the sign. The waiver is scoped to the effective
 // broker caller and end-user that were approved, and matches the exact command.
 func (s *server) maybeLearnWaiver(caller string, req signer.WireRequest, issued *signer.Issued) {
-	if req.LearnTTLSeconds <= 0 || req.DryRun || issued == nil || issued.Certificate == nil {
+	// A credential was issued when either an SSH certificate or a k8s bound
+	// token came back; approve-and-learn applies to both targets.
+	if req.LearnTTLSeconds <= 0 || req.DryRun || issued == nil || (issued.Certificate == nil && issued.K8sToken == "") {
 		return
 	}
 	if issued.Decision == nil || !issued.Decision.RequireApproval {

--- a/cmd/signer/handlers_test.go
+++ b/cmd/signer/handlers_test.go
@@ -42,6 +42,8 @@ func (c *captureLocalSigner) HostAllowlistActive(string) (bool, bool) {
 	return false, false
 }
 
+func (c *captureLocalSigner) Clusters() signer.ClusterTable { return nil }
+
 func signRequestAs(t *testing.T, cn string, body signer.WireRequest) *http.Request {
 	t.Helper()
 	_, pub, err := ca.GenerateEphemeralKey()

--- a/cmd/signer/k8s.go
+++ b/cmd/signer/k8s.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/luisgf/ssh-broker/internal/audit"
+	"github.com/luisgf/ssh-broker/internal/auth"
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+// handleSignK8s is the Kubernetes branch of /v1/sign. The generic gates
+// (rate limit, body decode, identity token-char checks, caller resolution,
+// forwarder/approved) already ran in handleSign; here we do the k8s-specific
+// group authorization, build the k8s intent, sign (mint a bound token), and
+// audit with the canonical action.
+func (s *server) handleSignK8s(w http.ResponseWriter, r *http.Request, caller string, req signer.WireRequest, isForwarder, effectiveApproved bool, local localSigner, callers signer.CallerTable) {
+	clusters := local.Clusters()
+	if _, ok := clusters[req.Host]; !ok {
+		s.auditK8s(caller, req, 0, "denied", nil, fmt.Errorf("no policy for cluster %q", req.Host))
+		http.Error(w, "unknown cluster", http.StatusForbidden)
+		return
+	}
+	// Per-caller group RBAC over the cluster table (mirrors HostSetForCaller).
+	if set, restricted := signer.ClusterSetForCaller(caller, clusters, callers); restricted {
+		if _, ok := set[req.Host]; !ok {
+			s.auditK8s(caller, req, 0, "denied", nil, fmt.Errorf("cluster %q outside group for %q", req.Host, caller))
+			http.Error(w, "cluster not authorised", http.StatusForbidden)
+			return
+		}
+	}
+
+	action := signer.K8sAction{
+		Verb:      req.K8sVerb,
+		Resource:  req.K8sResource,
+		Group:     req.K8sGroup,
+		Namespace: req.K8sNamespace,
+		Name:      req.K8sName,
+	}
+	in := signer.Intent{
+		Caller:        caller,
+		Host:          req.Host,
+		TargetType:    signer.TargetTypeK8s,
+		K8s:           &action,
+		Role:          signer.RoleTarget,
+		Purpose:       signer.PurposeOneshot,
+		Command:       req.Command,
+		DryRun:        req.DryRun,
+		Preflight:     req.Preflight,
+		Approved:      effectiveApproved,
+		EndUser:       req.EndUser,
+		EndUserGroups: req.EndUserGroups,
+	}
+	issued, err := local.SignIntent(r.Context(), in)
+	if err != nil {
+		s.auditK8s(caller, req, 0, "denied", nil, err)
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	if isForwarder && req.LearnTTLSeconds > 0 {
+		s.maybeLearnWaiver(caller, req, issued)
+	}
+	s.respondSignK8s(w, caller, req, issued)
+}
+
+// respondSignK8s audits and writes the response for the three k8s cases:
+// dry-run, approval-required, and token issued.
+func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer.WireRequest, issued *signer.Issued) {
+	if req.DryRun {
+		outcome := "dry_run_allowed"
+		if issued.Decision != nil && !issued.Decision.Allowed {
+			outcome = "dry_run_denied"
+		}
+		s.auditK8s(caller, req, 0, outcome, issued.Decision, nil)
+		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
+		return
+	}
+	if issued.K8sToken == "" {
+		s.auditK8s(caller, req, 0, "approval-required", issued.Decision, nil)
+		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
+		return
+	}
+	s.auditK8s(caller, req, issued.Serial, "issued", issued.Decision, nil)
+	writeJSON(w, http.StatusOK, signer.WireResponse{
+		K8sToken:       issued.K8sToken,
+		K8sTokenExpiry: issued.K8sTokenExpiry,
+		Serial:         issued.Serial,
+		Decision:       issued.Decision,
+	})
+}
+
+// auditK8s records a k8s issuance decision. The canonical action is the
+// Command; the api_server is the audited Host. A k8s_apply manifest is never
+// logged verbatim (it can carry a Secret) — its sha256 rides in body_sha256,
+// added by the broker's execution entry, not here.
+func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, outcome string, dec *signer.DecisionInfo, err error) {
+	signRequestsTotal.With(outcome).Inc()
+	host := req.Host
+	if cp, ok := s.currentClusters()[req.Host]; ok {
+		host = cp.APIServer
+	}
+	cmd := "target=k8s action=" + req.Command
+	if req.EndUser != "" {
+		cmd += " user=" + req.EndUser
+	}
+	e := audit.Entry{
+		Caller:     caller,
+		Host:       host,
+		Command:    cmd,
+		Serial:     serial,
+		Outcome:    outcome,
+		TargetType: signer.TargetTypeK8s,
+	}
+	if dec != nil {
+		e.PolicyRule = dec.MatchedRule
+		e.Warning = dec.Warning
+	}
+	if err != nil {
+		e.Err = err.Error()
+	}
+	s.appendAudit(e)
+}
+
+// currentClusters returns the compiled cluster table under RLock.
+func (s *server) currentClusters() signer.ClusterTable {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.local.Clusters()
+}
+
+// handleClusters serves GET /v1/clusters: the connectivity data for the
+// clusters accessible to the caller (group-filtered like /v1/hosts, and
+// gated by per-cluster allowed_callers). Internal policy — token_file, SA
+// bindings, rules — is never exposed.
+func (s *server) handleClusters(w http.ResponseWriter, r *http.Request) {
+	caller, err := auth.CallerCN(r)
+	if err != nil {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	s.mu.RLock()
+	clusters := s.local.Clusters()
+	callers := s.callers
+	forwarders := s.forwarders
+	s.mu.RUnlock()
+
+	caller, ok := resolveCaller(caller, r.Header.Get(signer.HeaderOnBehalfOf), forwarders)
+	if !ok {
+		http.Error(w, "on_behalf_of not allowed for this caller", http.StatusForbidden)
+		return
+	}
+
+	result := make(map[string]signer.WireClusterInfo, len(clusters))
+	for name, cp := range clusters {
+		if !cp.AllowsCaller(caller) {
+			continue
+		}
+		wire := signer.WireClusterInfo{
+			APIServer: cp.APIServer,
+			CACertPEM: string(cp.CAPEM),
+			Groups:    cp.Groups,
+		}
+		for _, rd := range cp.ExtraResources {
+			wire.ExtraResources = append(wire.ExtraResources, signer.ResourceDef{
+				Resource: rd.Resource, Group: rd.Group, Version: rd.Version,
+				Kind: rd.Kind, Namespaced: rd.Namespaced,
+			})
+		}
+		result[name] = wire
+	}
+	if set, restricted := signer.ClusterSetForCaller(caller, clusters, callers); restricted {
+		for name := range result {
+			if _, ok := set[name]; !ok {
+				delete(result, name)
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, result)
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luisgf/ssh-broker/internal/ca"
 	"github.com/luisgf/ssh-broker/internal/confcheck"
 	"github.com/luisgf/ssh-broker/internal/httpserve"
+	"github.com/luisgf/ssh-broker/internal/k8s"
 	"github.com/luisgf/ssh-broker/internal/monitor"
 	"github.com/luisgf/ssh-broker/internal/redact"
 	"github.com/luisgf/ssh-broker/internal/signer"
@@ -127,6 +128,17 @@ type Config struct {
 	// and the policies of all its groups (additive union; deny wins).
 	CommandPolicies      map[string]signer.CommandPolicy `json:"command_policies,omitempty"`
 	GroupCommandPolicies map[string][]string             `json:"group_command_policies,omitempty"`
+
+	// Kubernetes is the optional Kubernetes target: a parallel map of clusters,
+	// each with its own default-deny ActionPolicy, ServiceAccount bindings, and
+	// a minter credential (token_file) whose RBAC is only `create` on
+	// serviceaccounts/token. Absent = SSH-only signer (backward compatible).
+	Kubernetes *K8sConfig `json:"kubernetes,omitempty"`
+}
+
+// K8sConfig groups the Kubernetes clusters under the "kubernetes" config key.
+type K8sConfig struct {
+	Clusters signer.ClusterTable `json:"clusters"`
 }
 
 func main() {
@@ -227,6 +239,9 @@ func main() {
 	// (caller-scoped connectivity view) it exposes every internal policy field,
 	// so it shares the mutation trust tier. Used by `broker-ctl host list --remote`.
 	mux.HandleFunc("GET /v1/policy/hosts", srv.handlePolicyHostsRead)
+	// Kubernetes cluster connectivity for the broker (group-filtered like
+	// /v1/hosts). No-op when no clusters are configured.
+	mux.HandleFunc("GET /v1/clusters", srv.handleClusters)
 
 	// Hot-reload via SIGHUP (in addition to the HTTP endpoint). Local to the
 	// host, so it bypasses the reload_callers allowlist.
@@ -338,12 +353,38 @@ func buildState(ctx context.Context, cfg *Config, grants signer.GrantProvider) (
 	if defaultTTL <= 0 {
 		defaultTTL = 5 * time.Minute
 	}
-	return signer.NewLocalWithGrants(defaultCA, groupCAs, compiled, defaultTTL, grants), nil
+	local := signer.NewLocalWithGrants(defaultCA, groupCAs, compiled, defaultTTL, grants)
+
+	// Optional Kubernetes target: compile the clusters (validates + reads each
+	// ca_cert, disjoint from host names) and build the bound-token minter.
+	if cfg.Kubernetes != nil && len(cfg.Kubernetes.Clusters) > 0 {
+		clusters, err := signer.CompileClusterPolicies(cfg.Kubernetes.Clusters, cfg.Hosts)
+		if err != nil {
+			return nil, fmt.Errorf("invalid kubernetes policy: %w", err)
+		}
+		minter := k8s.NewMinter(minterTargets(clusters))
+		local.WithK8s(clusters, minter)
+	}
+	return local, nil
+}
+
+// minterTargets projects the compiled clusters into the minter's per-cluster
+// token-request targets (API server, CA PEM, and the minter credential path).
+func minterTargets(clusters signer.ClusterTable) map[string]k8s.MinterTarget {
+	targets := make(map[string]k8s.MinterTarget, len(clusters))
+	for name, cp := range clusters {
+		targets[name] = k8s.MinterTarget{
+			Target:    k8s.Target{APIServer: cp.APIServer, CAPEM: cp.CAPEM},
+			TokenFile: cp.TokenFile,
+		}
+	}
+	return targets
 }
 
 type localSigner interface {
 	signer.Signer
 	HostAllowlistActive(host string) (exists, allowlist bool)
+	Clusters() signer.ClusterTable
 }
 
 // reloadSet converts the list of admin CNs into a set for O(1) lookup.
@@ -469,11 +510,6 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	pub, err := signer.ParsePublicKey(req.PublicKey)
-	if err != nil {
-		http.Error(w, "invalid pubkey", http.StatusBadRequest)
-		return
-	}
 
 	// Reject identity/intent fields that would splice forged tokens into the
 	// signer audit record (auditEmission builds Entry.Command as a space-separated
@@ -514,6 +550,18 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// the resolved value covers both on_behalf_of and the raw CN in one place.
 	if signer.HasUnsafeTokenChar(caller) {
 		http.Error(w, "invalid caller identity: control or whitespace characters not allowed", http.StatusBadRequest)
+		return
+	}
+
+	// Kubernetes target: separate descriptor, group table, and audit shape.
+	if req.TargetType == signer.TargetTypeK8s {
+		s.handleSignK8s(w, r, caller, req, isForwarder, effectiveApproved, local, callers)
+		return
+	}
+
+	pub, err := signer.ParsePublicKey(req.PublicKey)
+	if err != nil {
+		http.Error(w, "invalid pubkey", http.StatusBadRequest)
 		return
 	}
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,7 @@ AI model (Claude / OpenCode)
     │                           │  Authorization: Bearer <OIDC token>
     ▼                           ▼
 cmd/mcp-broker                cmd/mcp-broker-http        ← never hold the CA key
-    │  same 7 tools            │  validates JWT via JWKS (go-oidc)
+    │  same tool surface       │  validates JWT via JWKS (go-oidc)
     │  caller="mcp-stdio"      │  caller={sub, groups from token}
     │                          │  propagates EndUser+EndUserGroups to the signer
     └─────────────┬────────────┘
@@ -477,6 +477,53 @@ shared with stdio via `internal/mcpserver.Register`; the only difference is
 `CallerFunc(ctx) → broker.Caller`. **Fail-closed (v1.11.2):** missing groups
 claim (when configured) or missing `iat` (when `max_token_age_seconds > 0`)
 rejects the token.
+
+### Kubernetes target (v1.34.0)
+
+The signer can also broker access to **Kubernetes clusters**, reusing the whole
+control plane (identity, RBAC, approval, grants, signed audit) with a new
+*action grammar* instead of the shell one. It is a **credential-broker**, the
+same posture as SSH: the signer mints a short-lived, narrowly-scoped credential
+and steps out of the data path — the agent never holds a cluster credential.
+
+- **Authentication (how the signer proves identity to the cluster): bound
+  ServiceAccount tokens.** Per cluster the signer holds one minimal-privilege
+  *minter* credential (`token_file`) whose entire RBAC is `create` on
+  `serviceaccounts/token` for the bound SAs. For an authorised action it calls
+  the **TokenRequest API** to mint a bound token (TTL 600–900s) for the
+  ServiceAccount selected by the end user's groups (`sa_bindings`), and returns
+  it to the broker over the existing mTLS channel — exactly as it returns an SSH
+  certificate. The broker runs the one API call with that token (plain REST,
+  `net/http`; no client-go) and discards it.
+- **Authorization has two layers, like SSH.** *Layer A* is the broker's PDP: a
+  per-cluster **default-deny** `ActionPolicy` (structured `{verbs, resources,
+  namespaces, names, effect}` rules). Each action is reduced to a **canonical
+  string** — `<verb> <resource[.group]> <namespace>/<name>` (e.g. `delete pods
+  prod/web-1`) — built from charset-validated fields (never parsed), so it is
+  injection-free. The rules compile at load into the *same* `PolicySet`
+  machinery as `command_policy`, so deny-wins composition, runtime grants,
+  approve-and-learn waivers, and `policy recommend` all apply to k8s actions
+  **unchanged**. The broker sends the structured fields **and** the canonical
+  string; the signer recomputes the string and rejects a mismatch, so the
+  approver and the audit log see exactly what runs. *Layer B* is the cluster's
+  own RBAC on the bound SA — the enforcer that replaces sshd.
+- **What does not transfer.** SSH's headline guarantee — an inevadible
+  *per-command* firewall via the certificate `force-command` enforced by sshd —
+  has no Kubernetes equivalent: a token grants the SA's whole RBAC, not "only
+  this one call". So k8s granularity is the SA's RBAC (layer B) refined by the
+  broker's action policy (layer A), not "only this exact object". This is the
+  documented trade of the credential-broker posture ([THREAT_MODEL.md](THREAT_MODEL.md)).
+- **Surface.** Six curated MCP tools registered only when a cluster is visible:
+  `k8s_list_clusters`, `k8s_get`, `k8s_list`, `k8s_logs` (read), plus `k8s_apply`
+  and `k8s_delete` (mutating, policy/approval-gated). No pod-exec, port-forward,
+  watch, or sessions in this phase. A `k8s_apply` manifest never travels to the
+  signer or into the audit log verbatim (it can carry a Secret) — only its
+  sha256 is recorded (`body_sha256`), mirroring file transfers.
+
+Cluster names must be **disjoint** from SSH host names (grants and the audit
+`host` field are indexed by that shared name). Clusters are a **parallel map**
+(`kubernetes.clusters` in `signer.json`) with their own `ClusterPolicy` type —
+`HostPolicy` is untouched.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## [v1.34.0] - 2026-07-03
+
+Kubernetes target (credential-broker): the signer can now broker access to
+Kubernetes clusters, reusing the whole control plane (identity, RBAC, approval,
+grants, signed audit) with a structured action grammar instead of the shell
+one. The agent never holds a cluster credential — the signer mints a
+short-lived bound ServiceAccount token per authorised action and the cluster's
+native RBAC enforces it.
+
+### Added
+- **Six curated MCP tools**, registered only when the broker sees a cluster
+  (an SSH-only deployment does not offer them): `k8s_list_clusters`,
+  `k8s_get`, `k8s_list` (label/field selectors, limit), `k8s_logs`
+  (container, tail, since) — read-only — plus `k8s_apply` (server-side apply)
+  and `k8s_delete`, both policy- and approval-gated. No pod-exec, port-forward,
+  watch, or sessions in this phase.
+- **Per-cluster ActionPolicy, default-deny.** Structured rules
+  (`{verbs, resources, namespaces, names, effect}`; effect `allow` | `deny` |
+  `require_approval`) compile at load into the *same* `PolicySet` machinery as
+  `command_policy`, over a **canonical action string**
+  `<verb> <resource[.group]> <namespace>/<name>` built from charset-validated
+  fields (never parsed → injection-free). So deny-wins composition, runtime
+  grants, approve-and-learn waivers, and `policy recommend` all apply to k8s
+  actions unchanged. The broker sends the structured fields **and** the
+  canonical string; the signer recomputes it and rejects a mismatch, so the
+  approver and the audit log see exactly what runs.
+- **Bound ServiceAccount tokens.** The signer holds one minimal-privilege
+  minter credential per cluster (`token_file`; RBAC = `create` on
+  `serviceaccounts/token` for the bound SAs) and calls the TokenRequest API to
+  mint a bound token (TTL 600–900s) for the SA selected by the end user's
+  groups (`sa_bindings`). The token travels back over the existing mTLS channel
+  like an SSH certificate.
+- **Dependency-free k8s client** (`internal/k8s`): the five verbs plus
+  TokenRequest as plain REST over `net/http` (no client-go), pinned to the
+  cluster CA, with a curated core resource table plus per-cluster
+  `extra_resources` (no API discovery).
+- **New config** `kubernetes.clusters.<name>` in `signer.json` (parallel to
+  `hosts`; cluster names must be disjoint from host names — grants and audit
+  are indexed by that shared name). New signer endpoint `GET /v1/clusters`
+  (caller-scoped connectivity, forwarded by the control plane) and
+  `broker-ctl cluster list --remote`.
+- `audit.Entry` gains `target_type` and `body_sha256`: a `k8s_apply` manifest
+  is never logged verbatim (it can carry a Secret) — only its sha256, mirroring
+  file transfers.
+- New e2e lab `lab/run_k8s_lab.sh` (mock API server, no cluster needed): mints a
+  bound token for an allowed action, gates a delete behind approval and issues
+  the token after approval, and enforces default-deny and deny-wins.
+
+### Security
+- The Kubernetes credential-broker's structural trade is documented as
+  threat-model gap #10: a bound token grants the ServiceAccount's whole RBAC
+  for its TTL, not a single call (no `force-command` equivalent). Scope agent
+  ServiceAccounts to least privilege; the minter credential is deliberately
+  minimal (only token-minting for the bound SAs).
+
 ## [v1.33.0] - 2026-07-02
 
 Dynamic state persists across restarts: an opt-in SQLite `state_db` (pure-Go

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,20 @@
 # Handoff: SSH Broker con CA Efímera para Agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-02 (v1.33.0, persistencia SQLite del estado dinámico).
+> actualización: 2026-07-03 (v1.34.0, target Kubernetes).
 >
 > Estado reciente:
+> - **v1.34.0**: target Kubernetes (credential-broker). El signer acuña bound
+>   ServiceAccount tokens (TokenRequest) para acciones autorizadas; el agente
+>   nunca ve credencial de cluster. ActionPolicy estructurada por cluster
+>   (default-deny) compilada sobre la string canónica `<verb> <resource[.group]>
+>   <ns>/<name>` → reutiliza `PolicySet` (grants/waivers/recommend gratis).
+>   6 tools MCP (`k8s_list_clusters/get/list/logs/apply/delete`, registro
+>   condicional), cliente REST sin client-go (`internal/k8s`), `kubernetes.clusters`
+>   en signer.json (nombres disjuntos de hosts), `GET /v1/clusters`,
+>   `broker-ctl cluster list --remote`. `audit.Entry` += `target_type`/`body_sha256`
+>   (el manifest de apply nunca verbatim). Gap #10 del threat model: el token da
+>   todo el RBAC de la SA durante su TTL, no una sola llamada. Lab `run_k8s_lab.sh`.
 > - **v1.33.0**: `state_db` opt-in (SQLite puro-Go, `internal/statedb`):
 >   grants/waivers del signer y approvals del control plane sobreviven
 >   restarts (write-through; el mapa in-memory sigue siendo el único estado
@@ -70,7 +81,7 @@
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Ramas, versionado X.Y.Z, checklist pre-commit, idioma |
 | [CODING_STYLE.md](CODING_STYLE.md) | Reglas Go con verificación mecánica |
 | [API.md](API.md) | Referencia de endpoints HTTP de todos los servicios |
-| [USAGE.md](USAGE.md) | Guía de las 7 tools MCP para el modelo |
+| [USAGE.md](USAGE.md) | Guía de las tools MCP para el modelo (7 SSH + 6 Kubernetes) |
 
 ---
 
@@ -106,7 +117,7 @@ ssh-broker/
 │   ├── ca/                   # loader (PEM/AKV), akv, sign (BuildAndSign), GenerateEphemeralKey
 │   ├── signer/               # Signer/Local, PolicyTable.Resolve, cmdpolicy, remote (Wire*)
 │   ├── broker/               # Engine, Caller, ExecOptions, sessionManager, session
-│   ├── mcpserver/            # New + Register (7 tools compartidas stdio/HTTP)
+│   ├── mcpserver/            # New + Register (7 SSH + RegisterK8s 6, compartidas stdio/HTTP)
 │   ├── oauth/                # Verifier OIDC (JWKS, fail-closed groups/iat)
 │   ├── ssh/                  # Dial/ExecOnce/Run, OpenShell/OpenShellPTY
 │   ├── audit/                # log append-only encadenado y firmado (Ed25519)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -123,14 +123,76 @@ Create `/etc/ssh/auth_principals/<user>` with the host's `principal` (e.g.
 [ARCHITECTURE.md § Privilege elevation](ARCHITECTURE.md#privilege-elevation-sudo-nopasswd).
 See also `deploy/sshd_config.snippet`.
 
+### 2.1 Adding a Kubernetes cluster (optional)
+
+The signer can also broker Kubernetes access (credential-broker; see
+[ARCHITECTURE.md § Kubernetes target](ARCHITECTURE.md#kubernetes-target-v1340)).
+Clusters live under `kubernetes.clusters` in `signer.json`, are **default-deny**,
+and are hot-reloadable like hosts. Setup has two sides — in the cluster and in
+`signer.json`.
+
+**In the cluster:** create a least-privilege *minter* ServiceAccount whose only
+RBAC is minting bound tokens for the agent SAs, and one or more agent SAs with
+the Roles the agent actually needs (layer B):
+
+```yaml
+# The minter: its ENTIRE RBAC is `create` on serviceaccounts/token for the
+# agent SAs. A signer compromise yields token-minting for those SAs, nothing more.
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: ssh-broker-minter, namespace: agents }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: ssh-broker-minter, namespace: agents }
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    resourceNames: ["broker-platform", "broker-readonly"]  # the agent SAs
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: ssh-broker-minter, namespace: agents }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: ssh-broker-minter }
+subjects: [{ kind: ServiceAccount, name: ssh-broker-minter, namespace: agents }]
+---
+# An agent SA (layer B). Give it exactly the cluster RBAC the agent may use;
+# the broker's action policy (layer A) can only narrow this, never widen it.
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: broker-platform, namespace: agents }
+# ...bind it to Roles/ClusterRoles for the resources your rules allow.
+```
+
+Mint the minter's own token and store it where `token_file` points (0600,
+owned by the service user); the signer re-reads it per mint, so you can rotate
+it out-of-band:
+
+```bash
+kubectl -n agents create token ssh-broker-minter --duration=8760h \
+  > /var/lib/ssh-broker/signer/pki/prod-k8s-minter.token
+kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
+  | base64 -d > /var/lib/ssh-broker/signer/pki/prod-k8s-ca.crt
+```
+
+**In `signer.json`:** add the cluster under `kubernetes.clusters` (see
+`signer.example.json` for a fully-commented block). Cluster names must be
+**disjoint** from host names. Verify end-to-end after a reload:
+
+```bash
+broker-ctl cluster list --remote      # the caller-scoped cluster view (mTLS)
+```
+
 ---
 
 ## 3. Hot reload
 
 The signer re-reads `signer.json` without restarting, atomically replacing the
-**hosts policy**, `max_ttl_seconds`, `reload_callers`, and the CA key(s). If the
-new config is invalid, the previous state is preserved. `listen`, TLS, and
-`audit_log` require a full restart.
+**hosts policy**, the **Kubernetes clusters**, `max_ttl_seconds`,
+`reload_callers`, and the CA key(s). If the new config is invalid (including a
+bad cluster rule or an unreadable `ca_cert`/`token_file`), the previous state is
+preserved. `listen`, TLS, and `audit_log` require a full restart.
 
 ```bash
 broker-ctl reload          # SIGHUP if local, else POST /v1/reload (mTLS)

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -272,7 +272,35 @@ fail-closed toggle (not yet implemented).
   the trail has a gap. The process log also carries `error writing audit log`
   warnings. Keep the audit volume healthy.
 
-### 10. Out of scope entirely
+### 10. Kubernetes: token grants the SA's RBAC, not a single call
+The Kubernetes target (v1.34.0) is a **credential-broker**: for an authorised
+action the signer mints a bound ServiceAccount token and the broker runs the
+one API call with it. Two structural differences from SSH follow, by design:
+- **No inevadible per-call firewall.** SSH bakes a `force-command` into the
+  certificate and sshd enforces it, so the credential does exactly one thing.
+  A Kubernetes token instead carries the **whole RBAC** of its ServiceAccount
+  for its lifetime (600–900s), so within that window it can do anything that SA
+  may do — not only the approved action. Granularity is therefore the SA's
+  native RBAC (layer B) refined by the broker's action policy (layer A), not
+  "only this exact object". **Mitigation:** scope each agent ServiceAccount to
+  least privilege (the layer-A default-deny policy bounds what the broker will
+  *request*, but layer B is what the token actually *grants*); keep the bound
+  TTL at the 600s floor; do not add `secrets` to an allow rule unless required.
+- **The signer holds a standing cluster credential.** The per-cluster minter
+  token (`token_file`) is a long-lived credential — unlike the SSH CA, which
+  signs but never authenticates as a principal. Its RBAC is deliberately
+  minimal (only `create` on `serviceaccounts/token` for the bound SAs), so a
+  signer compromise yields token-minting for those SAs, not cluster-admin.
+  **Mitigation:** the minter SA's Role must grant nothing else; rotate the
+  `token_file` out-of-band (the signer re-reads it per mint).
+
+The reused control plane keeps its guarantees: the action's canonical string is
+recomputed by the signer and must match the structured request (so the approver
+and the audit log see what runs), a `k8s_apply` manifest is never logged
+verbatim (only its sha256), and `require_approval`, grants, and approve-and-learn
+apply to k8s actions exactly as to shell commands.
+
+### 11. Out of scope entirely
 - Confidentiality of command **output** beyond transport TLS (the model sees it
   by design).
 - Compromise of the **signer host** or the **operator's** credentials (top of
@@ -291,6 +319,7 @@ fail-closed toggle (not yet implemented).
 | Compromised agent, sessions | **Partial** — every `ssh_session_exec` is broker-preflighted; `shell`/`pty` rejected once policy is active; host-enforced guarantee remains one-shot only |
 | Compromised broker forging access | **Mitigated** — no CA key; signer derives all constraints |
 | Stolen cert reuse within TTL | **Accepted risk** — no revocation; bounded by minutes-long TTL |
+| Compromised agent, Kubernetes actions | **Partial** — layer-A default-deny action policy + approval; layer-B is the SA's RBAC (a bound token grants the SA's whole RBAC for its TTL, not one call — gap #10) |
 | Signer/operator compromise | **Out of scope** — trusted root |
 
 The credential-custody story is strong and complete. The action-control story is

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -988,3 +988,73 @@ params:
 - Every transfer writes two correlated audit entries (same `serial`): the
   regular `executed` entry with the transfer command, and a `file_put` /
   `file_get` entry carrying `path=… bytes=… sha256=…` for content integrity.
+
+## 10. Kubernetes tools (`k8s_*`)
+
+These tools appear **only** when the broker is configured with at least one
+Kubernetes cluster; an SSH-only deployment does not expose them. Like SSH, the
+model never sees a cluster credential: for an authorised action the signer mints
+a short-lived bound ServiceAccount token, the broker makes the one API call, and
+the token is discarded.
+
+Every cluster is **default-deny**: an action runs only if the cluster policy has
+an `allow` (or `require_approval`) rule matching its `verb`, `resource`,
+`namespace`, and `name`. If a tool returns "not allowed", **do not retry** —
+tell the user the cluster policy forbids it.
+
+### 10.1 List the reachable clusters
+
+```
+tool: k8s_list_clusters
+```
+
+Always call this first to learn the cluster names (filtered to the user's RBAC
+groups).
+
+### 10.2 Read: get, list, logs
+
+```
+tool: k8s_get
+params: { cluster: "prod-k8s", resource: "pods", namespace: "prod", name: "web-1" }
+
+tool: k8s_list
+params: { cluster: "prod-k8s", resource: "deployments", namespace: "prod", label_selector: "app=web" }
+
+tool: k8s_logs
+params: { cluster: "prod-k8s", namespace: "prod", pod: "web-1", container: "app", tail_lines: 100 }
+```
+
+- Omit `group` for core resources (pods, services, configmaps, nodes…); the
+  broker fills it in from the cluster's resource table. Omit `namespace` only
+  for cluster-scoped resources (nodes, namespaces, persistentvolumes) or to
+  `k8s_list` across all namespaces the ServiceAccount can read.
+- `k8s_get`/`k8s_list`/`k8s_logs` return the API server's JSON (or plain-text
+  logs) in `output`.
+
+### 10.3 Mutate: apply, delete
+
+```
+tool: k8s_apply
+params:
+  cluster:  "prod-k8s"
+  resource: "deployments"
+  namespace: "staging"
+  name:     "api"
+  manifest: '{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","namespace":"staging"},"spec":{...}}'
+
+tool: k8s_delete
+params: { cluster: "prod-k8s", resource: "pods", namespace: "prod", name: "web-1" }
+```
+
+- `k8s_apply` is a **server-side apply** (create-or-update); the manifest's
+  `apiVersion`/`kind`/`metadata.name`/`metadata.namespace` must match the
+  arguments.
+- Mutating actions are frequently `require_approval`: the tool then blocks until
+  a human approves (or the request times out). This is the same approval flow as
+  SSH — the approver sees the canonical action (e.g. `delete pods prod/web-1`).
+
+### 10.4 Dry-run
+
+Every k8s tool accepts `dry_run: true` to preview the **broker policy** decision
+(allowed / denied / requires approval) without calling the API server. Use it
+before a mutating action to check whether it will be allowed or gated.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,6 +34,7 @@ Commands:
   broker-ctl policy grant   --host <n> --allow <regex> [--ttl 2h]  Create a runtime, expiring grant (signer API, mTLS)
   broker-ctl policy grants  [--json]                        List active runtime grants
   broker-ctl policy revoke  <grant-id>                      Revoke a runtime grant
+  broker-ctl cluster list  --remote                         List Kubernetes clusters live from the signer (mTLS)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -122,6 +122,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `callers` | `signer.CallerTable` | Callers: group-based RBAC. Maps broker mTLS cert CN → allowed groups. A CN absent from the table has no group restriction (backward compatible) unless a reserved "_default" entry exists, in which case absent CNs inherit its allowed_groups — `"_default": {"allowed_groups": []}` makes the table default-deny. A CN present can only see and sign hosts whose groups field intersects with its allowed_groups. |
 | `command_policies` | `map[string]signer.CommandPolicy` | CommandPolicies is a named library of command policies, attachable to groups. GroupCommandPolicies maps a group name to the policy names that apply to its hosts; the reserved group "_default" applies to every host. A host's effective firewall is the composition of its inline command_policy and the policies of all its groups (additive union; deny wins). |
 | `group_command_policies` | `map[string][]string` |  |
+| `kubernetes` | `*K8sConfig` | Kubernetes is the optional Kubernetes target: a parallel map of clusters, each with its own default-deny ActionPolicy, ServiceAccount bindings, and a minter credential (token_file) whose RBAC is only `create` on serviceaccounts/token. Absent = SSH-only signer (backward compatible). |
 
 ## Control-plane config (`control-plane.json`)
 
@@ -218,6 +219,56 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 |---|---|---|
 | `name` | `string` | Name identifies the rule inside the [REDACTED:<name>] marker. |
 | `regex` | `string` | Regex is an RE2 expression (linear-time, no catastrophic backtracking — same engine and rationale as the command-policy rules). If it defines a capturing group named "secret", only that group is masked; otherwise the whole match is masked. |
+
+## Kubernetes cluster policy (`kubernetes.clusters.<name>`)
+
+`ClusterPolicy` in `internal/signer/k8spolicy.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `api_server` | `string` | Connectivity — exposed to the broker via /v1/clusters. |
+| `ca_cert` | `string` | path to the cluster CA bundle (PEM) |
+| `token_file` | `string` | TokenFile is the signer's minter credential for this cluster: a ServiceAccount token whose entire RBAC is `create` on `serviceaccounts/token` for the bound SAs below. Never exposed. |
+| `token_ttl_seconds` | `int` | TokenTTLSeconds bounds the minted bound-token lifetime. 0 selects 600; the valid range is [600, 900] (TokenRequest refuses less than 600). |
+| `groups` | `[]string` | Groups / AllowedCallers: same RBAC semantics as HostPolicy. |
+| `allowed_callers` | `[]string` |  |
+| `sa_bindings` | `[]SABinding` | SABindings select the ServiceAccount (layer B: its native cluster RBAC) per end-user group. At least one binding is required. |
+| `rules` | `[]K8sRule` | Rules is the cluster's ActionPolicy. Unlike SSH hosts (default-allow without a command_policy, for backward compatibility), a cluster is DEFAULT-DENY: at least one allow/require_approval rule is required, and anything unmatched is refused. There is no legacy to preserve here. |
+| `extra_resources` | `[]k8s.ResourceDef` | ExtraResources extends the curated core resource table for this cluster (explicit CRDs — no API discovery). |
+
+## Kubernetes SA binding (`kubernetes.clusters.<name>.sa_bindings[]`)
+
+`SABinding` in `internal/signer/k8spolicy.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `groups` | `[]string` |  |
+| `namespace` | `string` |  |
+| `service_account` | `string` |  |
+
+## Kubernetes action rule (`kubernetes.clusters.<name>.rules[]`)
+
+`K8sRule` in `internal/signer/k8spolicy.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `verbs` | `[]string` |  |
+| `resources` | `[]string` |  |
+| `namespaces` | `[]string` |  |
+| `names` | `[]string` |  |
+| `effect` | `string` | allow \| deny \| require_approval |
+
+## Kubernetes resource (`kubernetes.clusters.<name>.extra_resources[]`)
+
+`ResourceDef` in `internal/k8s/resources.go`
+
+| JSON key | Type | Description |
+|---|---|---|
+| `resource` | `string` | Resource is the lowercase plural name used in tool calls, policy rules, and REST paths (e.g. "deployments"). |
+| `group` | `string` | Group is the API group; empty = core ("" → /api/v1, else /apis/<group>). |
+| `version` | `string` | Version is the served API version (e.g. "v1"). |
+| `kind` | `string` | Kind is the manifest kind (e.g. "Deployment"), used to resolve a k8s_apply manifest to its resource. |
+| `namespaced` | `bool` | Namespaced marks namespace-scoped resources. |
 
 ## Vocabulary (enumerated constants)
 

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -15,6 +15,7 @@ Every route registered across the services, extracted from the `mux.HandleFunc` 
 | `/v1/sign` | `srv.handleSign` |
 | `DELETE /v1/policy/grants/{id}` | `srv.handleGrantRevoke` |
 | `DELETE /v1/policy/hosts/{host}/allow` | `srv.handlePolicyAllow` |
+| `GET /v1/clusters` | `srv.handleClusters` |
 | `GET /v1/policy/grants` | `srv.handleGrantList` |
 | `GET /v1/policy/hosts` | `srv.handlePolicyHostsRead` |
 | `POST /v1/policy/hosts/{host}/allow` | `srv.handlePolicyAllow` |
@@ -29,6 +30,7 @@ Every route registered across the services, extracted from the `mux.HandleFunc` 
 | `GET /ui/approvals` | `srv.handleUIList` |
 | `GET /ui/approvals/{id}` | `srv.handleUIDetail` |
 | `GET /v1/approvals` | `srv.handleApprovalsList` |
+| `GET /v1/clusters` | `srv.handleClusters` |
 | `GET /v1/hosts` | `srv.handleHosts` |
 | `GET /v1/sign/result/{id}` | `srv.handleResult` |
 | `POST /v1/approvals/{id}` | `srv.handleApprovalDecide` |

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -4,6 +4,70 @@
 
 The tools exposed by the MCP frontends (`cmd/mcp-broker`, `cmd/mcp-broker-http`), with their input schemas — enumerated from the live server (`internal/mcpserver.Register`). See [Tool usage](../USAGE.md) for guidance.
 
+## `k8s_apply`
+
+Create or update a Kubernetes object from a JSON manifest (server-side apply). REQUIRES an allow rule for verb=apply; the action may be approval-gated (a human must approve before it runs). Use dry_run=true to preview the BROKER policy decision. The manifest's apiVersion/kind/metadata must match the resource/group/namespace/name arguments.
+
+- `cluster` (string) *(required)* — logical name of the target cluster (see k8s_list_clusters)
+- `dry_run` (boolean) — if true, SIMULATE the policy decision without applying (this is the BROKER policy dry-run, not the API server's --dry-run)
+- `group` (string) — API group; omit for core resources
+- `manifest` (string) *(required)* — the object manifest as a JSON document (server-side apply). Must include apiVersion, kind, and metadata.name/namespace matching the fields above.
+- `name` (string) *(required)* — object name; must match metadata.name in the manifest
+- `namespace` (string) — namespace; omit only for cluster-scoped resources
+- `resource` (string) *(required)* — lowercase plural resource of the manifest, e.g. deployments
+
+## `k8s_delete`
+
+Delete one Kubernetes object. REQUIRES an allow rule for verb=delete; the action may be approval-gated. Use dry_run=true to preview the policy decision without deleting.
+
+- `cluster` (string) *(required)* — logical name of the target cluster (see k8s_list_clusters)
+- `dry_run` (boolean) — if true, SIMULATE: report whether the action would be allowed by the cluster policy (allow/deny/approval) WITHOUT calling the API server
+- `group` (string) — API group; omit for core resources (pods, services...). The broker fills it in from the cluster's resource table.
+- `name` (string) *(required)* — object name
+- `namespace` (string) — namespace; omit only for cluster-scoped resources (nodes, namespaces, persistentvolumes)
+- `resource` (string) *(required)* — lowercase plural resource, e.g. pods, deployments, services, configmaps
+
+## `k8s_get`
+
+Get one Kubernetes object as JSON. REQUIRES an allow rule for this verb/resource in the cluster policy; if the broker returns not allowed, DO NOT retry — inform the user. Use dry_run=true to preview whether the action is permitted.
+
+- `cluster` (string) *(required)* — logical name of the target cluster (see k8s_list_clusters)
+- `dry_run` (boolean) — if true, SIMULATE: report whether the action would be allowed by the cluster policy (allow/deny/approval) WITHOUT calling the API server
+- `group` (string) — API group; omit for core resources (pods, services...). The broker fills it in from the cluster's resource table.
+- `name` (string) *(required)* — object name
+- `namespace` (string) — namespace; omit only for cluster-scoped resources (nodes, namespaces, persistentvolumes)
+- `resource` (string) *(required)* — lowercase plural resource, e.g. pods, deployments, services, configmaps
+
+## `k8s_list`
+
+List Kubernetes objects of a resource type as JSON, optionally filtered by label/field selectors. Omit namespace to list across all namespaces the ServiceAccount can read. REQUIRES an allow rule; use dry_run=true to preview.
+
+- `cluster` (string) *(required)* — logical name of the target cluster (see k8s_list_clusters)
+- `dry_run` (boolean) — if true, SIMULATE the policy decision without calling the API server
+- `field_selector` (string) — field selector, e.g. status.phase=Running
+- `group` (string) — API group; omit for core resources
+- `label_selector` (string) — label selector, e.g. app=nginx,tier=frontend
+- `limit` (integer) — maximum number of items to return
+- `namespace` (string) — namespace to list in; omit to list across all namespaces the ServiceAccount can read
+- `resource` (string) *(required)* — lowercase plural resource, e.g. pods, deployments
+
+## `k8s_list_clusters`
+
+List the Kubernetes clusters accessible to the caller (clusters outside the user's RBAC groups are not listed). ALWAYS call before the other k8s_* tools to learn the available cluster names.
+
+
+## `k8s_logs`
+
+Read a pod's container logs (plain text). REQUIRES an allow rule for verb=logs; use dry_run=true to preview.
+
+- `cluster` (string) *(required)* — logical name of the target cluster (see k8s_list_clusters)
+- `container` (string) — container name; omit for a single-container pod
+- `dry_run` (boolean) — if true, SIMULATE the policy decision without fetching logs
+- `namespace` (string) *(required)* — namespace of the pod
+- `pod` (string) *(required)* — pod name
+- `since_seconds` (integer) — only logs newer than this many seconds
+- `tail_lines` (integer) — number of lines from the end to return (default 200)
+
 ## `ssh_execute`
 
 Execute a single command on a Linux host via SSH with an ephemeral credential. Prefer this tool over ssh_session_open when you only need to run one command or independent commands. Returns stdout, stderr and exit_code. exit_code != 0 means remote command failure, NOT a tool error; treat it like a process that exits with an error. BEFORE calling: use ssh_list_servers to learn the host capabilities. sudo=true ONLY if allow_sudo=true; if allow_sudo=false, DO NOT retry with sudo and inform the user. pty=true ONLY if allow_pty=true and the command needs a TTY (with pty, stdout and stderr are merged). ttl_seconds is optional; omit to use the maximum allowed by the host policy.

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -55,13 +55,20 @@ type Entry struct {
 	Host      string    `json:"host"`                 // destination
 	User      string    `json:"user"`                 // remote account
 	Principal string    `json:"principal"`            // principal of the ephemeral cert
-	Command   string    `json:"command"`              // requested command
+	Command   string    `json:"command"`              // requested command (canonical action for k8s)
 	TTL       string    `json:"ttl"`                  // issued validity window
-	Serial    uint64    `json:"serial"`               // cert serial (correlates with sshd)
+	Serial    uint64    `json:"serial"`               // cert serial (correlates with sshd), or k8s issuance serial
 	SessionID string    `json:"session_id,omitempty"` // persistent session, if applicable
-	Outcome   string    `json:"outcome"`              // executed|denied|error|session_*|dry_run_*|approval_*|grant_*|...
-	ExitCode  int       `json:"exit_code"`            // exit code if executed
-	Err       string    `json:"err,omitempty"`
+
+	// TargetType distinguishes the target family: "" (SSH, backward compatible)
+	// or "k8s". BodySHA256 records the sha256 of a request body that must never
+	// be logged verbatim — a k8s_apply manifest can carry a Secret — mirroring
+	// the file-transfer entries.
+	TargetType string `json:"target_type,omitempty"`
+	BodySHA256 string `json:"body_sha256,omitempty"`
+	Outcome    string `json:"outcome"`   // executed|denied|error|session_*|dry_run_*|approval_*|grant_*|...
+	ExitCode   int    `json:"exit_code"` // exit code if executed
+	Err        string `json:"err,omitempty"`
 
 	// Elevation and PTY (privilege traceability).
 	Elevation string `json:"elevation,omitempty"` // e.g. "sudo:root" or "sudo:deploy"

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -276,6 +276,12 @@ type hostFetcher interface {
 	FetchHosts(context.Context, string) (map[string]signer.HostInfo, error)
 }
 
+// clusterFetcher retrieves the Kubernetes cluster list from the signer.
+// Implemented by *signer.Remote; nil in local mode (no k8s target).
+type clusterFetcher interface {
+	FetchClusters(context.Context, string) (map[string]signer.ClusterInfo, error)
+}
+
 // Engine executes commands by signing ephemeral credentials and auditing.
 type Engine struct {
 	cfg      *Config
@@ -286,8 +292,15 @@ type Engine struct {
 	maxTTL   time.Duration
 	sessions *sessionManager
 
+	// clusterFetcher fetches the k8s cluster list; nil when no k8s target is
+	// configured (local mode, or a signer with no clusters).
+	clusterFetcher clusterFetcher
+
 	mu    sync.RWMutex
 	hosts map[string]signer.HostInfo // cache refreshed periodically (remote mode)
+	// clusters is the k8s cluster connectivity cache, refreshed alongside hosts
+	// (remote mode). Empty when no k8s target is configured.
+	clusters map[string]signer.ClusterInfo
 	// In local mode hosts come from cfg.Hosts; the hosts map is not used.
 
 	// hostKeyCache memoises parsed host keys, content-addressed by the
@@ -377,6 +390,22 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		e.hosts = h
 		log.Printf("hosts loaded from signer: %d entries", len(h))
 
+		// Optional k8s target: load the cluster list too. A signer with no
+		// clusters returns an empty map (the endpoint always exists), so a
+		// fetch error is a real failure, not a missing feature.
+		if cf, ok := fetcher.(clusterFetcher); ok {
+			cl, err := cf.FetchClusters(context.Background(), "")
+			if err != nil {
+				al.Close()
+				return nil, fmt.Errorf("initial cluster load from signer: %w", err)
+			}
+			e.clusterFetcher = cf
+			e.clusters = cl
+			if len(cl) > 0 {
+				log.Printf("k8s clusters loaded from signer: %d entries", len(cl))
+			}
+		}
+
 		refresh := time.Duration(cfg.HostsRefreshSeconds) * time.Second
 		if refresh <= 0 {
 			refresh = 5 * time.Minute
@@ -409,6 +438,16 @@ func (e *Engine) startHostRefresh(interval time.Duration) {
 				e.hosts = h
 				e.mu.Unlock()
 				log.Printf("hosts reloaded from signer: %d entries", len(h))
+				if e.clusterFetcher != nil {
+					cl, err := e.clusterFetcher.FetchClusters(context.Background(), "")
+					if err != nil {
+						log.Printf("warning: cluster refresh failed: %v (keeping previous cache)", err)
+						continue
+					}
+					e.mu.Lock()
+					e.clusters = cl
+					e.mu.Unlock()
+				}
 			}
 		}
 	}()

--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -1,0 +1,218 @@
+package broker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/luisgf/ssh-broker/internal/audit"
+	"github.com/luisgf/ssh-broker/internal/k8s"
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+// ClusterInfo is a Kubernetes cluster visible to the caller (name only; the
+// broker never exposes the API server address or credentials to the model).
+type ClusterInfo struct {
+	Name string
+}
+
+// K8sResult is the outcome of a Kubernetes action.
+type K8sResult struct {
+	// Output is the API server's JSON response (get/list/delete/apply) or the
+	// plain-text logs (logs).
+	Output string
+	// Serial correlates the broker's execution entry with the signer's
+	// issuance entry (there is no certificate serial for k8s).
+	Serial uint64
+	// Warnings carries audit-mode policy observations, like the SSH path.
+	Warnings []string
+	// DryRun holds the policy decision for a dry-run (no action performed).
+	DryRun *signer.DecisionInfo
+}
+
+// K8sClusters returns the clusters visible to the caller, filtered by end-user
+// groups exactly like ServerInfos (so the model is never offered a cluster it
+// cannot use). Empty when no k8s target is configured.
+func (e *Engine) K8sClusters(c Caller) []ClusterInfo {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]ClusterInfo, 0, len(e.clusters))
+	for name, ci := range e.clusters {
+		if c.Groups != nil && !groupsIntersect(ci.Groups, c.Groups) {
+			continue
+		}
+		out = append(out, ClusterInfo{Name: name})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// clusterInfo returns the cached connectivity for a cluster.
+func (e *Engine) clusterInfo(name string) (signer.ClusterInfo, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	ci, ok := e.clusters[name]
+	return ci, ok
+}
+
+// K8sExecuteOpts carries the optional per-verb knobs (list selectors, log
+// tail) from the MCP tools.
+type K8sExecuteOpts struct {
+	List k8s.ListOptions
+	Logs k8s.LogOptions
+}
+
+// K8sExecute authorises and runs one Kubernetes action. It follows the same
+// credential-broker shape as SSH: it asks the signer to authorise the action
+// and mint a short-lived bound ServiceAccount token, runs the API call with
+// that token, and discards it — the agent never sees a cluster credential.
+// Layer-B enforcement is the SA's native RBAC in the cluster.
+//
+// manifest is the k8s_apply body; it is never sent to the signer (it can carry
+// a Secret) — only its sha256 is audited. dryRun previews the policy decision
+// without minting a token or calling the cluster.
+func (e *Engine) K8sExecute(ctx context.Context, c Caller, cluster string, action signer.K8sAction, manifest []byte, dryRun bool, opts K8sExecuteOpts) (*K8sResult, error) {
+	ci, ok := e.clusterInfo(cluster)
+	if !ok {
+		e.auditE(audit.Entry{Caller: c.ID, Host: cluster, TargetType: signer.TargetTypeK8s,
+			Outcome: "denied", Command: "target=k8s", Err: "unknown cluster"})
+		return nil, fmt.Errorf("unknown cluster: %q", cluster)
+	}
+	if err := action.Validate(); err != nil {
+		return nil, err
+	}
+	// Normalize the action's group against this cluster's resource table (core
+	// plus extra_resources), so the canonical string the broker sends matches
+	// the one the signer recomputes — the anti-mismatch invariant.
+	table, err := resourceTable(ci)
+	if err != nil {
+		return nil, err
+	}
+	def, err := k8s.Resolve(table, action.Resource, action.Group)
+	if err != nil {
+		return nil, err
+	}
+	action.Group = def.Group
+	canonical := action.Canonical()
+
+	in := signer.Intent{
+		Caller:        localCaller,
+		Host:          cluster,
+		TargetType:    signer.TargetTypeK8s,
+		K8s:           &action,
+		Role:          signer.RoleTarget,
+		Purpose:       signer.PurposeOneshot,
+		Command:       canonical,
+		DryRun:        dryRun,
+		EndUser:       c.ID,
+		EndUserGroups: c.Groups,
+	}
+	issued, err := e.sgn.SignIntent(ctx, in)
+	if err != nil {
+		e.auditK8s(c, cluster, canonical, 0, "denied", nil, err)
+		return nil, err
+	}
+	if dryRun {
+		return &K8sResult{DryRun: issued.Decision}, nil
+	}
+	if issued.K8sToken == "" {
+		// Approval-gated and not yet approved (or the client is not configured
+		// to wait): surface it like the SSH approval path.
+		return nil, approvalError(cluster, issued.Decision)
+	}
+
+	// Run the action with the ephemeral token, then let it fall out of scope.
+	client, err := k8s.NewClient(k8s.Target{APIServer: ci.APIServer, CAPEM: []byte(ci.CACertPEM)}, issued.K8sToken, 30*time.Second)
+	if err != nil {
+		e.auditK8s(c, cluster, canonical, issued.Serial, "error", issued.Decision, err)
+		return nil, err
+	}
+	out, runErr := runK8sAction(ctx, client, def, action, manifest, opts)
+	outcome := "executed"
+	if runErr != nil {
+		outcome = "error"
+	}
+	e.auditK8s(c, cluster, canonical, issued.Serial, outcome, issued.Decision, runErr, manifest...)
+	if runErr != nil {
+		return nil, runErr
+	}
+	return &K8sResult{Output: out, Serial: issued.Serial, Warnings: decisionWarnings(issued.Decision)}, nil
+}
+
+// runK8sAction dispatches on the verb.
+func runK8sAction(ctx context.Context, client *k8s.Client, def k8s.ResourceDef, a signer.K8sAction, manifest []byte, opts K8sExecuteOpts) (string, error) {
+	switch a.Verb {
+	case signer.K8sVerbGet:
+		return client.Get(ctx, def, a.Namespace, a.Name)
+	case signer.K8sVerbList:
+		return client.List(ctx, def, a.Namespace, opts.List)
+	case signer.K8sVerbLogs:
+		return client.Logs(ctx, a.Namespace, a.Name, opts.Logs)
+	case signer.K8sVerbDelete:
+		return client.Delete(ctx, def, a.Namespace, a.Name)
+	case signer.K8sVerbApply:
+		if len(manifest) == 0 {
+			return "", fmt.Errorf("k8s apply requires a manifest")
+		}
+		return client.Apply(ctx, def, a.Namespace, a.Name, manifest, false)
+	default:
+		return "", fmt.Errorf("unsupported k8s verb %q", a.Verb)
+	}
+}
+
+// resourceTable builds the effective resource table for a cluster from its
+// cached extra_resources.
+func resourceTable(ci signer.ClusterInfo) (map[string]k8s.ResourceDef, error) {
+	extra := make([]k8s.ResourceDef, 0, len(ci.ExtraResources))
+	for _, rd := range ci.ExtraResources {
+		extra = append(extra, k8s.ResourceDef{
+			Resource: rd.Resource, Group: rd.Group, Version: rd.Version,
+			Kind: rd.Kind, Namespaced: rd.Namespaced,
+		})
+	}
+	return k8s.Resources(extra)
+}
+
+// auditK8s records a k8s execution entry. The canonical action is the Command;
+// a k8s_apply manifest is never logged verbatim (it can carry a Secret) — its
+// sha256 rides in body_sha256.
+func (e *Engine) auditK8s(c Caller, cluster, canonical string, serial uint64, outcome string, dec *signer.DecisionInfo, err error, manifest ...byte) {
+	e.mu.RLock()
+	ci, ok := e.clusters[cluster]
+	e.mu.RUnlock()
+	host := cluster
+	if ok {
+		host = ci.APIServer
+	}
+	cmd := "target=k8s action=" + canonical
+	if c.ID != "" {
+		cmd += " user=" + c.ID
+	}
+	ent := audit.Entry{
+		Caller:     c.ID,
+		Host:       host,
+		Command:    cmd,
+		Serial:     serial,
+		Outcome:    outcome,
+		TargetType: signer.TargetTypeK8s,
+	}
+	if len(manifest) > 0 {
+		sum := sha256.Sum256(manifest)
+		ent.BodySHA256 = hex.EncodeToString(sum[:])
+	}
+	if dec != nil {
+		ent.PolicyRule = dec.MatchedRule
+		ent.Warning = dec.Warning
+	}
+	if err != nil {
+		ent.Err = err.Error()
+	}
+	eventsTotal.With(outcome).Inc()
+	if aerr := e.auditLog.Append(ent); aerr != nil {
+		log.Printf("warning: error writing audit log: %v", aerr)
+	}
+}

--- a/internal/broker/k8s_test.go
+++ b/internal/broker/k8s_test.go
@@ -1,0 +1,268 @@
+package broker
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luisgf/ssh-broker/internal/audit"
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+// openTestAudit opens an audit log in a temp file for a test.
+func openTestAudit(t *testing.T) *audit.Log {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "audit.log")
+	al, err := audit.Open(path, ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize)))
+	if err != nil {
+		t.Fatalf("audit.Open: %v", err)
+	}
+	t.Cleanup(func() { al.Close() })
+	t.Cleanup(func() { auditPaths[t.Name()] = path })
+	auditPaths[t.Name()] = path
+	return al
+}
+
+// auditPaths maps a test name to its audit log path so readAuditLog can find
+// it without threading the path through the engine.
+var auditPaths = map[string]string{}
+
+// readAuditLog returns the audit log lines written by the engine under test.
+func readAuditLog(t *testing.T, _ *Engine) []string {
+	t.Helper()
+	f, err := os.Open(auditPaths[t.Name()])
+	if err != nil {
+		t.Fatalf("open audit log: %v", err)
+	}
+	defer f.Close()
+	var lines []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 256*1024), 256*1024)
+	for sc.Scan() {
+		if s := strings.TrimSpace(sc.Text()); s != "" {
+			lines = append(lines, s)
+		}
+	}
+	return lines
+}
+
+// fakeK8sSigner is a signer.Signer that authorises a fixed set of canonical
+// actions and returns a bound token; anything else is denied. It records the
+// last intent for assertions.
+type fakeK8sSigner struct {
+	allow    map[string]bool // canonical → allowed
+	approval map[string]bool // canonical → requires approval
+	last     signer.Intent
+}
+
+func (f *fakeK8sSigner) SignIntent(_ context.Context, in signer.Intent) (*signer.Issued, error) {
+	f.last = in
+	if in.TargetType != signer.TargetTypeK8s {
+		return nil, context.Canceled
+	}
+	canonical := in.K8s.Canonical()
+	if in.Command != canonical {
+		return nil, errString("canonical mismatch")
+	}
+	if !f.allow[canonical] {
+		if in.DryRun {
+			return &signer.Issued{Decision: &signer.DecisionInfo{Allowed: false, Reason: "denied"}}, nil
+		}
+		return nil, errString("not allowed by cluster policy")
+	}
+	if f.approval[canonical] && !in.Approved {
+		return &signer.Issued{Decision: &signer.DecisionInfo{Allowed: true, RequireApproval: true}}, nil
+	}
+	if in.DryRun {
+		return &signer.Issued{Decision: &signer.DecisionInfo{Allowed: true}}, nil
+	}
+	return &signer.Issued{K8sToken: "ephemeral", K8sTokenExpiry: time.Now().Add(time.Minute), Serial: 7,
+		Decision: &signer.DecisionInfo{Allowed: true}}, nil
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// newK8sEngine builds an engine wired to the fake signer and a fake API
+// server, with one cluster in the cache.
+func newK8sEngine(t *testing.T, sgn signer.Signer) (*Engine, *fakeAPIServer) {
+	t.Helper()
+	api := newFakeAPIServer(t)
+	al := openTestAudit(t)
+	e := &Engine{
+		cfg:      &Config{},
+		sgn:      sgn,
+		auditLog: al,
+		maxTTL:   time.Minute,
+		clusters: map[string]signer.ClusterInfo{
+			"prod-k8s": {APIServer: api.srv.URL, CACertPEM: api.caPEM, Groups: []string{"platform"}},
+		},
+	}
+	return e, api
+}
+
+// fakeAPIServer records the last path and returns a canned body.
+type fakeAPIServer struct {
+	srv     *httptest.Server
+	caPEM   string
+	lastURL string
+}
+
+func newFakeAPIServer(t *testing.T) *fakeAPIServer {
+	t.Helper()
+	f := &fakeAPIServer{}
+	f.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.lastURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"kind":"Pod","metadata":{"name":"web-1"}}`))
+	}))
+	t.Cleanup(f.srv.Close)
+	f.caPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: f.srv.Certificate().Raw}))
+	return f
+}
+
+func TestK8sExecuteHappyPath(t *testing.T) {
+	sgn := &fakeK8sSigner{allow: map[string]bool{"get pods prod/web-1": true}}
+	e, api := newK8sEngine(t, sgn)
+
+	res, err := e.K8sExecute(context.Background(), Caller{ID: "alice", Groups: []string{"platform"}},
+		"prod-k8s", signer.K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"},
+		nil, false, K8sExecuteOpts{})
+	if err != nil {
+		t.Fatalf("K8sExecute: %v", err)
+	}
+	if !strings.Contains(res.Output, "web-1") || res.Serial != 7 {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if api.lastURL != "/api/v1/namespaces/prod/pods/web-1" {
+		t.Errorf("API path = %q", api.lastURL)
+	}
+	// The intent the signer saw must carry the k8s target and canonical command.
+	if sgn.last.TargetType != signer.TargetTypeK8s || sgn.last.Command != "get pods prod/web-1" {
+		t.Errorf("intent: %+v", sgn.last)
+	}
+	if sgn.last.EndUser != "alice" {
+		t.Errorf("end user not propagated: %+v", sgn.last)
+	}
+}
+
+func TestK8sExecuteGroupNormalization(t *testing.T) {
+	// The caller omits the group; the broker must fill in "apps" from the table
+	// so the canonical form matches what the signer authorises.
+	sgn := &fakeK8sSigner{allow: map[string]bool{"get deployments.apps prod/api": true}}
+	e, _ := newK8sEngine(t, sgn)
+
+	if _, err := e.K8sExecute(context.Background(), Caller{},
+		"prod-k8s", signer.K8sAction{Verb: "get", Resource: "deployments", Namespace: "prod", Name: "api"},
+		nil, false, K8sExecuteOpts{}); err != nil {
+		t.Fatalf("K8sExecute: %v", err)
+	}
+	if sgn.last.Command != "get deployments.apps prod/api" {
+		t.Errorf("broker must normalize the group into the canonical command: %q", sgn.last.Command)
+	}
+}
+
+func TestK8sExecuteDenied(t *testing.T) {
+	sgn := &fakeK8sSigner{allow: map[string]bool{}}
+	e, _ := newK8sEngine(t, sgn)
+
+	if _, err := e.K8sExecute(context.Background(), Caller{},
+		"prod-k8s", signer.K8sAction{Verb: "delete", Resource: "pods", Namespace: "prod", Name: "web-1"},
+		nil, false, K8sExecuteOpts{}); err == nil {
+		t.Fatal("a denied action must error")
+	}
+}
+
+func TestK8sExecuteApprovalGate(t *testing.T) {
+	sgn := &fakeK8sSigner{
+		allow:    map[string]bool{"delete pods prod/web-1": true},
+		approval: map[string]bool{"delete pods prod/web-1": true},
+	}
+	e, _ := newK8sEngine(t, sgn)
+
+	// Without approval the token is withheld → surfaced as an approval error.
+	_, err := e.K8sExecute(context.Background(), Caller{},
+		"prod-k8s", signer.K8sAction{Verb: "delete", Resource: "pods", Namespace: "prod", Name: "web-1"},
+		nil, false, K8sExecuteOpts{})
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "approval") {
+		t.Fatalf("approval-gated action must surface an approval error, got %v", err)
+	}
+}
+
+func TestK8sExecuteDryRun(t *testing.T) {
+	sgn := &fakeK8sSigner{allow: map[string]bool{"get pods prod/web-1": true}}
+	e, api := newK8sEngine(t, sgn)
+
+	res, err := e.K8sExecute(context.Background(), Caller{},
+		"prod-k8s", signer.K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"},
+		nil, true, K8sExecuteOpts{})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if res.DryRun == nil || !res.DryRun.Allowed {
+		t.Errorf("dry-run must return the decision: %+v", res)
+	}
+	if api.lastURL != "" {
+		t.Error("dry-run must not call the API server")
+	}
+}
+
+func TestK8sExecuteUnknownCluster(t *testing.T) {
+	sgn := &fakeK8sSigner{}
+	e, _ := newK8sEngine(t, sgn)
+	if _, err := e.K8sExecute(context.Background(), Caller{},
+		"nope", signer.K8sAction{Verb: "get", Resource: "pods", Namespace: "p", Name: "x"},
+		nil, false, K8sExecuteOpts{}); err == nil {
+		t.Fatal("unknown cluster must error")
+	}
+}
+
+func TestK8sExecuteApplyAuditsBodyHash(t *testing.T) {
+	sgn := &fakeK8sSigner{allow: map[string]bool{"apply configmaps prod/cfg": true}}
+	e, _ := newK8sEngine(t, sgn)
+	manifest := []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cfg","namespace":"prod"},"data":{"k":"v"}}`)
+
+	if _, err := e.K8sExecute(context.Background(), Caller{},
+		"prod-k8s", signer.K8sAction{Verb: "apply", Resource: "configmaps", Namespace: "prod", Name: "cfg"},
+		manifest, false, K8sExecuteOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// The manifest must never appear verbatim in the audit log; its sha256 does.
+	entries := readAuditLog(t, e)
+	var found bool
+	for _, line := range entries {
+		if strings.Contains(line, `"k":"v"`) {
+			t.Fatal("manifest body leaked into the audit log")
+		}
+		if strings.Contains(line, `"body_sha256"`) && strings.Contains(line, "apply configmaps prod/cfg") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("apply audit entry must record body_sha256")
+	}
+}
+
+func TestK8sClustersFilteredByGroups(t *testing.T) {
+	e, _ := newK8sEngine(t, &fakeK8sSigner{})
+	// A user in the platform group sees the cluster; a user in another group
+	// does not; a caller with no groups (nil) sees all.
+	if got := e.K8sClusters(Caller{Groups: []string{"platform"}}); len(got) != 1 {
+		t.Errorf("platform user must see the cluster: %v", got)
+	}
+	if got := e.K8sClusters(Caller{Groups: []string{"web"}}); len(got) != 0 {
+		t.Errorf("non-member must see no clusters: %v", got)
+	}
+	if got := e.K8sClusters(Caller{}); len(got) != 1 {
+		t.Errorf("identity-less caller sees all clusters: %v", got)
+	}
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,0 +1,280 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Response read caps: a get/list response is JSON the model will consume; logs
+// are additionally bounded by tail_lines at the request level.
+const (
+	apiMaxBytes  = 4 * 1024 * 1024
+	logsMaxBytes = 512 * 1024
+)
+
+// FieldManager identifies this broker in server-side-apply ownership.
+const FieldManager = "ssh-broker"
+
+// Target is the connection identity of one cluster: where the API server is
+// and which CA signs it. Both are public material (they travel from the
+// signer to the broker over /v1/clusters).
+type Target struct {
+	APIServer string // e.g. https://10.0.0.5:6443
+	CAPEM     []byte // PEM bundle of the cluster CA
+}
+
+// httpClientFor builds an http.Client pinned to the target's CA. No system
+// roots: the cluster CA is the only trust anchor (fail-closed).
+func httpClientFor(t Target, timeout time.Duration) (*http.Client, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(t.CAPEM) {
+		return nil, fmt.Errorf("k8s: no CA certificate parsed for %s", t.APIServer)
+	}
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		},
+	}, nil
+}
+
+// Client performs the five curated verbs against one cluster with one
+// short-lived bearer token. It is built per operation and discarded with the
+// token — the broker holds no standing cluster credential.
+type Client struct {
+	target Target
+	token  string
+	http   *http.Client
+}
+
+// NewClient builds a client for one operation. token is the ephemeral bound
+// ServiceAccount token minted by the signer.
+func NewClient(t Target, token string, timeout time.Duration) (*Client, error) {
+	hc, err := httpClientFor(t, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{target: t, token: token, http: hc}, nil
+}
+
+// resourcePath builds the REST path for a resource, with every component
+// path-escaped (they are charset-validated upstream; the escape is defense in
+// depth, not a sanitizer).
+func resourcePath(def ResourceDef, namespace, name string) string {
+	var b strings.Builder
+	if def.Group == "" {
+		b.WriteString("/api/" + url.PathEscape(def.Version))
+	} else {
+		b.WriteString("/apis/" + url.PathEscape(def.Group) + "/" + url.PathEscape(def.Version))
+	}
+	if def.Namespaced && namespace != "" {
+		b.WriteString("/namespaces/" + url.PathEscape(namespace))
+	}
+	b.WriteString("/" + url.PathEscape(def.Resource))
+	if name != "" {
+		b.WriteString("/" + url.PathEscape(name))
+	}
+	return b.String()
+}
+
+// do runs one request and returns the (bounded) response body. A non-2xx
+// answer surfaces the API server's Status message, so the agent sees "pods
+// \"x\" not found" instead of a bare status code.
+func (c *Client) do(ctx context.Context, method, path string, query url.Values, contentType string, body []byte, maxBytes int64) (string, int, error) {
+	u := strings.TrimRight(c.target.APIServer, "/") + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	var rd io.Reader
+	if body != nil {
+		rd = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, rd)
+	if err != nil {
+		return "", 0, fmt.Errorf("k8s: building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("k8s: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	if err != nil {
+		return "", resp.StatusCode, fmt.Errorf("k8s: reading response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", resp.StatusCode, fmt.Errorf("k8s: %s %s: %s", method, path, statusMessage(rb, resp.StatusCode))
+	}
+	return string(rb), resp.StatusCode, nil
+}
+
+// statusMessage extracts the message from a Kubernetes Status error body.
+func statusMessage(body []byte, code int) string {
+	var st struct {
+		Message string `json:"message"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &st); err == nil && st.Message != "" {
+		return fmt.Sprintf("%d %s", code, st.Message)
+	}
+	return fmt.Sprintf("%d %s", code, strings.TrimSpace(string(body)))
+}
+
+// Get retrieves one object as JSON.
+func (c *Client) Get(ctx context.Context, def ResourceDef, namespace, name string) (string, error) {
+	out, _, err := c.do(ctx, http.MethodGet, resourcePath(def, namespace, name), nil, "", nil, apiMaxBytes)
+	return out, err
+}
+
+// ListOptions bound a List call.
+type ListOptions struct {
+	LabelSelector string
+	FieldSelector string
+	Limit         int // 0 = server default
+}
+
+// List retrieves a collection as JSON. An empty namespace on a namespaced
+// resource lists across all namespaces (subject to the SA's RBAC).
+func (c *Client) List(ctx context.Context, def ResourceDef, namespace string, opt ListOptions) (string, error) {
+	q := url.Values{}
+	if opt.LabelSelector != "" {
+		q.Set("labelSelector", opt.LabelSelector)
+	}
+	if opt.FieldSelector != "" {
+		q.Set("fieldSelector", opt.FieldSelector)
+	}
+	if opt.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opt.Limit))
+	}
+	out, _, err := c.do(ctx, http.MethodGet, resourcePath(def, namespace, ""), q, "", nil, apiMaxBytes)
+	return out, err
+}
+
+// LogOptions bound a Logs call.
+type LogOptions struct {
+	Container    string
+	TailLines    int // <=0 selects the 200-line default
+	SinceSeconds int
+}
+
+// Logs retrieves (plain-text) container logs from a pod.
+func (c *Client) Logs(ctx context.Context, namespace, pod string, opt LogOptions) (string, error) {
+	q := url.Values{}
+	if opt.Container != "" {
+		q.Set("container", opt.Container)
+	}
+	tail := opt.TailLines
+	if tail <= 0 {
+		tail = 200
+	}
+	q.Set("tailLines", strconv.Itoa(tail))
+	if opt.SinceSeconds > 0 {
+		q.Set("sinceSeconds", strconv.Itoa(opt.SinceSeconds))
+	}
+	path := "/api/v1/namespaces/" + url.PathEscape(namespace) + "/pods/" + url.PathEscape(pod) + "/log"
+	out, _, err := c.do(ctx, http.MethodGet, path, q, "", nil, logsMaxBytes)
+	return out, err
+}
+
+// Delete removes one object.
+func (c *Client) Delete(ctx context.Context, def ResourceDef, namespace, name string) (string, error) {
+	out, _, err := c.do(ctx, http.MethodDelete, resourcePath(def, namespace, name), nil, "", nil, apiMaxBytes)
+	return out, err
+}
+
+// Apply performs a server-side apply (create-or-update) of a JSON manifest.
+// The API server enforces that the manifest's metadata matches the path, and
+// conflicts with other field managers fail unless the operator opted into
+// force at the tool level.
+func (c *Client) Apply(ctx context.Context, def ResourceDef, namespace, name string, manifest []byte, force bool) (string, error) {
+	q := url.Values{}
+	q.Set("fieldManager", FieldManager)
+	if force {
+		q.Set("force", "true")
+	}
+	out, _, err := c.do(ctx, http.MethodPatch, resourcePath(def, namespace, name), q,
+		"application/apply-patch+yaml", manifest, apiMaxBytes)
+	return out, err
+}
+
+// MinterTarget is one cluster's token-minting identity: the API server, its
+// CA, and the path to the minter credential — a ServiceAccount token whose
+// entire RBAC is `create` on `serviceaccounts/token` for the bound SAs. It is
+// the signer's only standing cluster credential, read per call so an
+// externally rotated file is picked up without a reload.
+type MinterTarget struct {
+	Target
+	TokenFile string
+}
+
+// Minter mints short-lived bound ServiceAccount tokens via the TokenRequest
+// API. It satisfies the signer's TokenMinter interface.
+type Minter struct {
+	targets map[string]MinterTarget
+	timeout time.Duration
+}
+
+// NewMinter builds a minter over the configured clusters.
+func NewMinter(targets map[string]MinterTarget) *Minter {
+	return &Minter{targets: targets, timeout: 15 * time.Second}
+}
+
+// MintToken requests a bound token for namespace/sa on cluster with the given
+// TTL, returning the token and its expiry.
+func (m *Minter) MintToken(ctx context.Context, cluster, namespace, sa string, ttl time.Duration) (string, time.Time, error) {
+	t, ok := m.targets[cluster]
+	if !ok {
+		return "", time.Time{}, fmt.Errorf("k8s: unknown cluster %q", cluster)
+	}
+	minterTok, err := os.ReadFile(t.TokenFile)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("k8s: reading minter token: %w", err)
+	}
+	c, err := NewClient(t.Target, strings.TrimSpace(string(minterTok)), m.timeout)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"apiVersion": "authentication.k8s.io/v1",
+		"kind":       "TokenRequest",
+		"spec":       map[string]any{"expirationSeconds": int(ttl / time.Second)},
+	})
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	path := "/api/v1/namespaces/" + url.PathEscape(namespace) + "/serviceaccounts/" + url.PathEscape(sa) + "/token"
+	out, _, err := c.do(ctx, http.MethodPost, path, nil, "application/json", body, apiMaxBytes)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("minting token for %s/%s on %q: %w", namespace, sa, cluster, err)
+	}
+	var tr struct {
+		Status struct {
+			Token               string    `json:"token"`
+			ExpirationTimestamp time.Time `json:"expirationTimestamp"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &tr); err != nil || tr.Status.Token == "" {
+		return "", time.Time{}, fmt.Errorf("k8s: invalid TokenRequest response for %q", cluster)
+	}
+	return tr.Status.Token, tr.Status.ExpirationTimestamp, nil
+}

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,0 +1,251 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeAPI records the last request and answers with a canned body.
+type fakeAPI struct {
+	srv      *httptest.Server
+	caPEM    []byte
+	lastReq  *http.Request
+	lastBody []byte
+	status   int
+	respond  string
+}
+
+func newFakeAPI(t *testing.T) *fakeAPI {
+	t.Helper()
+	f := &fakeAPI{status: 200, respond: `{"ok":true}`}
+	f.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io_ReadAll(r)
+		f.lastReq = r.Clone(context.Background())
+		f.lastBody = body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.status)
+		w.Write([]byte(f.respond))
+	}))
+	t.Cleanup(f.srv.Close)
+	f.caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: f.srv.Certificate().Raw})
+	return f
+}
+
+func io_ReadAll(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 1024)
+	for {
+		n, err := r.Body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			return buf, nil
+		}
+	}
+}
+
+func (f *fakeAPI) client(t *testing.T) *Client {
+	t.Helper()
+	c, err := NewClient(Target{APIServer: f.srv.URL, CAPEM: f.caPEM}, "test-token", 5*time.Second)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func mustDef(t *testing.T, resource string) ResourceDef {
+	t.Helper()
+	table, err := Resources(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def, err := Resolve(table, resource, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return def
+}
+
+func TestClientPathsAndAuth(t *testing.T) {
+	f := newFakeAPI(t)
+	c := f.client(t)
+	ctx := context.Background()
+
+	// Core namespaced resource.
+	if _, err := c.Get(ctx, mustDef(t, "pods"), "prod", "web-1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := f.lastReq.URL.Path; got != "/api/v1/namespaces/prod/pods/web-1" {
+		t.Errorf("core path = %q", got)
+	}
+	if got := f.lastReq.Header.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("auth header = %q", got)
+	}
+
+	// Grouped resource.
+	if _, err := c.Get(ctx, mustDef(t, "deployments"), "prod", "api"); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.lastReq.URL.Path; got != "/apis/apps/v1/namespaces/prod/deployments/api" {
+		t.Errorf("grouped path = %q", got)
+	}
+
+	// Cluster-scoped list has no namespaces segment; selectors and limit ride
+	// in the query.
+	if _, err := c.List(ctx, mustDef(t, "nodes"), "", ListOptions{LabelSelector: "role=worker", Limit: 5}); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.lastReq.URL.Path; got != "/api/v1/nodes" {
+		t.Errorf("cluster-scoped path = %q", got)
+	}
+	if q := f.lastReq.URL.Query(); q.Get("labelSelector") != "role=worker" || q.Get("limit") != "5" {
+		t.Errorf("list query = %v", f.lastReq.URL.Query())
+	}
+
+	// Logs endpoint with a default tail bound.
+	if _, err := c.Logs(ctx, "prod", "web-1", LogOptions{Container: "app"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.lastReq.URL.Path; got != "/api/v1/namespaces/prod/pods/web-1/log" {
+		t.Errorf("logs path = %q", got)
+	}
+	if q := f.lastReq.URL.Query(); q.Get("tailLines") != "200" || q.Get("container") != "app" {
+		t.Errorf("logs query = %v", f.lastReq.URL.Query())
+	}
+
+	// Delete.
+	if _, err := c.Delete(ctx, mustDef(t, "pods"), "prod", "web-1"); err != nil {
+		t.Fatal(err)
+	}
+	if f.lastReq.Method != http.MethodDelete {
+		t.Errorf("delete method = %q", f.lastReq.Method)
+	}
+}
+
+func TestClientApply(t *testing.T) {
+	f := newFakeAPI(t)
+	c := f.client(t)
+	manifest := []byte(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","namespace":"prod"}}`)
+
+	if _, err := c.Apply(context.Background(), mustDef(t, "deployments"), "prod", "api", manifest, false); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if f.lastReq.Method != http.MethodPatch {
+		t.Errorf("apply method = %q", f.lastReq.Method)
+	}
+	if ct := f.lastReq.Header.Get("Content-Type"); ct != "application/apply-patch+yaml" {
+		t.Errorf("apply content-type = %q", ct)
+	}
+	if q := f.lastReq.URL.Query(); q.Get("fieldManager") != FieldManager || q.Get("force") != "" {
+		t.Errorf("apply query = %v", f.lastReq.URL.Query())
+	}
+	if string(f.lastBody) != string(manifest) {
+		t.Errorf("apply body = %s", f.lastBody)
+	}
+}
+
+func TestClientSurfacesStatusMessage(t *testing.T) {
+	f := newFakeAPI(t)
+	f.status = 404
+	f.respond = `{"kind":"Status","message":"pods \"nope\" not found","reason":"NotFound"}`
+	c := f.client(t)
+
+	_, err := c.Get(context.Background(), mustDef(t, "pods"), "prod", "nope")
+	if err == nil || !strings.Contains(err.Error(), `pods "nope" not found`) {
+		t.Fatalf("expected the API status message, got %v", err)
+	}
+}
+
+func TestClientRequiresParsableCA(t *testing.T) {
+	// No system roots and no TOFU: a client without a parsable cluster CA must
+	// not be constructible at all (fail-closed).
+	if _, err := NewClient(Target{APIServer: "https://x", CAPEM: []byte("not a pem")}, "t", time.Second); err == nil {
+		t.Fatal("an unparsable cluster CA must fail NewClient")
+	}
+	if _, err := NewClient(Target{APIServer: "https://x"}, "t", time.Second); err == nil {
+		t.Fatal("an empty cluster CA must fail NewClient")
+	}
+}
+
+func TestMinter(t *testing.T) {
+	f := newFakeAPI(t)
+	expiry := time.Now().Add(10 * time.Minute).UTC().Truncate(time.Second)
+	respond, _ := json.Marshal(map[string]any{
+		"status": map[string]any{"token": "ephemeral-tok", "expirationTimestamp": expiry},
+	})
+	f.respond = string(respond)
+
+	tokFile := filepath.Join(t.TempDir(), "minter.token")
+	if err := os.WriteFile(tokFile, []byte("minter-credential\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := NewMinter(map[string]MinterTarget{
+		"prod-cluster": {Target: Target{APIServer: f.srv.URL, CAPEM: f.caPEM}, TokenFile: tokFile},
+	})
+
+	tok, exp, err := m.MintToken(context.Background(), "prod-cluster", "agents", "ssh-broker-agent", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	if tok != "ephemeral-tok" || !exp.Equal(expiry) {
+		t.Errorf("token/expiry = %q/%v", tok, exp)
+	}
+	if got := f.lastReq.URL.Path; got != "/api/v1/namespaces/agents/serviceaccounts/ssh-broker-agent/token" {
+		t.Errorf("token path = %q", got)
+	}
+	if got := f.lastReq.Header.Get("Authorization"); got != "Bearer minter-credential" {
+		t.Errorf("minter auth = %q (must be the trimmed file content)", got)
+	}
+	var body struct {
+		Spec struct {
+			ExpirationSeconds int `json:"expirationSeconds"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(f.lastBody, &body); err != nil || body.Spec.ExpirationSeconds != 600 {
+		t.Errorf("TokenRequest body = %s", f.lastBody)
+	}
+
+	if _, _, err := m.MintToken(context.Background(), "nope", "a", "b", time.Minute); err == nil {
+		t.Error("unknown cluster must fail")
+	}
+}
+
+func TestResourcesTable(t *testing.T) {
+	t.Parallel()
+	// Extra resources extend the table; collisions and incomplete entries fail.
+	table, err := Resources([]ResourceDef{{Resource: "certificates", Group: "cert-manager.io", Version: "v1", Kind: "Certificate", Namespaced: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Resolve(table, "certificates", ""); err != nil {
+		t.Errorf("extra resource must resolve: %v", err)
+	}
+	if _, err := Resolve(table, "pods", "apps"); err == nil {
+		t.Error("group mismatch must fail")
+	}
+	if _, err := Resolve(table, "unknownthings", ""); err == nil {
+		t.Error("unknown resource must fail")
+	}
+	if _, err := Resources([]ResourceDef{{Resource: "pods", Version: "v2", Kind: "Pod"}}); err == nil {
+		t.Error("a collision with the core table must fail")
+	}
+	if _, err := Resources([]ResourceDef{{Resource: "widgets"}}); err == nil {
+		t.Error("an incomplete extra resource must fail")
+	}
+
+	def, err := ResolveKind(table, "Deployment", "apps")
+	if err != nil || def.Resource != "deployments" {
+		t.Errorf("ResolveKind(Deployment) = %+v, %v", def, err)
+	}
+	if _, err := ResolveKind(table, "Widget", ""); err == nil {
+		t.Error("unknown kind must fail")
+	}
+}

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -1,0 +1,110 @@
+// Package k8s is the Kubernetes data-plane client: a deliberately small,
+// dependency-free REST layer (net/http against the API server) plus the
+// TokenRequest minter. It carries NO policy — authorization lives in the
+// signer (layer A: the cluster's ActionPolicy) and in the cluster itself
+// (layer B: the ServiceAccount's native RBAC).
+//
+// There is no client-go and no API discovery: the resources the broker can
+// address are a curated core table plus explicit per-cluster extra_resources.
+// Fail-closed and auditable beats dynamic.
+package k8s
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ResourceDef describes one addressable resource type: how it maps to a REST
+// path and to a manifest kind.
+type ResourceDef struct {
+	// Resource is the lowercase plural name used in tool calls, policy rules,
+	// and REST paths (e.g. "deployments").
+	Resource string `json:"resource"`
+	// Group is the API group; empty = core ("" → /api/v1, else /apis/<group>).
+	Group string `json:"group,omitempty"`
+	// Version is the served API version (e.g. "v1").
+	Version string `json:"version"`
+	// Kind is the manifest kind (e.g. "Deployment"), used to resolve a
+	// k8s_apply manifest to its resource.
+	Kind string `json:"kind"`
+	// Namespaced marks namespace-scoped resources.
+	Namespaced bool `json:"namespaced"`
+}
+
+// coreResources is the curated table of well-known resource types. Anything
+// else must be declared per cluster via extra_resources — an explicit,
+// reviewable operator decision instead of API discovery.
+var coreResources = []ResourceDef{
+	{Resource: "pods", Group: "", Version: "v1", Kind: "Pod", Namespaced: true},
+	{Resource: "services", Group: "", Version: "v1", Kind: "Service", Namespaced: true},
+	{Resource: "configmaps", Group: "", Version: "v1", Kind: "ConfigMap", Namespaced: true},
+	{Resource: "secrets", Group: "", Version: "v1", Kind: "Secret", Namespaced: true},
+	{Resource: "serviceaccounts", Group: "", Version: "v1", Kind: "ServiceAccount", Namespaced: true},
+	{Resource: "namespaces", Group: "", Version: "v1", Kind: "Namespace", Namespaced: false},
+	{Resource: "nodes", Group: "", Version: "v1", Kind: "Node", Namespaced: false},
+	{Resource: "events", Group: "", Version: "v1", Kind: "Event", Namespaced: true},
+	{Resource: "persistentvolumeclaims", Group: "", Version: "v1", Kind: "PersistentVolumeClaim", Namespaced: true},
+	{Resource: "persistentvolumes", Group: "", Version: "v1", Kind: "PersistentVolume", Namespaced: false},
+	{Resource: "deployments", Group: "apps", Version: "v1", Kind: "Deployment", Namespaced: true},
+	{Resource: "statefulsets", Group: "apps", Version: "v1", Kind: "StatefulSet", Namespaced: true},
+	{Resource: "daemonsets", Group: "apps", Version: "v1", Kind: "DaemonSet", Namespaced: true},
+	{Resource: "replicasets", Group: "apps", Version: "v1", Kind: "ReplicaSet", Namespaced: true},
+	{Resource: "jobs", Group: "batch", Version: "v1", Kind: "Job", Namespaced: true},
+	{Resource: "cronjobs", Group: "batch", Version: "v1", Kind: "CronJob", Namespaced: true},
+	{Resource: "ingresses", Group: "networking.k8s.io", Version: "v1", Kind: "Ingress", Namespaced: true},
+}
+
+// Resources returns the effective resource table: the curated core plus the
+// cluster's extra definitions. An extra entry whose Resource collides with a
+// core entry (or another extra) is a configuration error — resolution must be
+// unambiguous because the bare resource name is the policy vocabulary.
+func Resources(extra []ResourceDef) (map[string]ResourceDef, error) {
+	table := make(map[string]ResourceDef, len(coreResources)+len(extra))
+	for _, r := range coreResources {
+		table[r.Resource] = r
+	}
+	for _, r := range extra {
+		if r.Resource == "" || r.Version == "" || r.Kind == "" {
+			return nil, fmt.Errorf("extra_resources: resource, version, and kind are required (got %+v)", r)
+		}
+		if prev, ok := table[r.Resource]; ok {
+			return nil, fmt.Errorf("extra_resources: %q collides with %s/%s", r.Resource, prev.Group, prev.Resource)
+		}
+		table[r.Resource] = r
+	}
+	return table, nil
+}
+
+// Resolve looks a resource up in the table by its bare name and, when the
+// caller supplied a group, verifies it matches the table's normalization.
+// Unknown resources are a hard error ("add it to extra_resources"), never a
+// passthrough.
+func Resolve(table map[string]ResourceDef, resource, group string) (ResourceDef, error) {
+	def, ok := table[resource]
+	if !ok {
+		return ResourceDef{}, fmt.Errorf("unknown k8s resource %q: not in the core table nor this cluster's extra_resources", resource)
+	}
+	if group != "" && group != def.Group {
+		return ResourceDef{}, fmt.Errorf("k8s resource %q belongs to group %q, not %q", resource, def.Group, group)
+	}
+	return def, nil
+}
+
+// ResolveKind maps a manifest kind (e.g. "Deployment") plus its apiVersion
+// group to a resource definition, for k8s_apply.
+func ResolveKind(table map[string]ResourceDef, kind, group string) (ResourceDef, error) {
+	var matches []ResourceDef
+	for _, def := range table {
+		if def.Kind == kind && def.Group == group {
+			matches = append(matches, def)
+		}
+	}
+	if len(matches) == 0 {
+		return ResourceDef{}, fmt.Errorf("unknown k8s kind %q (group %q): not in the core table nor this cluster's extra_resources", kind, group)
+	}
+	if len(matches) > 1 { // defensive: Resources() already forbids duplicates
+		sort.Slice(matches, func(i, j int) bool { return matches[i].Resource < matches[j].Resource })
+		return ResourceDef{}, fmt.Errorf("ambiguous k8s kind %q: %v", kind, matches)
+	}
+	return matches[0], nil
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -17,5 +17,10 @@ func New(eng *broker.Engine, callerFn CallerFunc) *mcp.Server {
 		Version: version.String(),
 	}, nil)
 	Register(srv, eng, callerFn)
+	// Register the Kubernetes tool family only when the broker actually sees a
+	// cluster, so an SSH-only deployment does not offer k8s_* tools to the model.
+	if HasK8sClusters(eng) {
+		RegisterK8s(srv, eng, callerFn)
+	}
 	return srv
 }

--- a/internal/mcpserver/tools_k8s.go
+++ b/internal/mcpserver/tools_k8s.go
@@ -1,0 +1,184 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/luisgf/ssh-broker/internal/broker"
+	"github.com/luisgf/ssh-broker/internal/k8s"
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+type k8sListClustersInput struct{}
+
+type clusterEntry struct {
+	Name string `json:"name"`
+}
+
+type k8sListClustersOutput struct {
+	Clusters []clusterEntry `json:"clusters"`
+}
+
+// commonK8sFields are shared by the addressable-object tools.
+type k8sObjectInput struct {
+	Cluster   string `json:"cluster"             jsonschema:"logical name of the target cluster (see k8s_list_clusters)"`
+	Resource  string `json:"resource"            jsonschema:"lowercase plural resource, e.g. pods, deployments, services, configmaps"`
+	Group     string `json:"group,omitempty"     jsonschema:"API group; omit for core resources (pods, services...). The broker fills it in from the cluster's resource table."`
+	Namespace string `json:"namespace,omitempty" jsonschema:"namespace; omit only for cluster-scoped resources (nodes, namespaces, persistentvolumes)"`
+	Name      string `json:"name"                jsonschema:"object name"`
+	DryRun    bool   `json:"dry_run,omitempty"   jsonschema:"if true, SIMULATE: report whether the action would be allowed by the cluster policy (allow/deny/approval) WITHOUT calling the API server"`
+}
+
+type k8sListInput struct {
+	Cluster       string `json:"cluster"                  jsonschema:"logical name of the target cluster (see k8s_list_clusters)"`
+	Resource      string `json:"resource"                 jsonschema:"lowercase plural resource, e.g. pods, deployments"`
+	Group         string `json:"group,omitempty"          jsonschema:"API group; omit for core resources"`
+	Namespace     string `json:"namespace,omitempty"      jsonschema:"namespace to list in; omit to list across all namespaces the ServiceAccount can read"`
+	LabelSelector string `json:"label_selector,omitempty" jsonschema:"label selector, e.g. app=nginx,tier=frontend"`
+	FieldSelector string `json:"field_selector,omitempty" jsonschema:"field selector, e.g. status.phase=Running"`
+	Limit         int    `json:"limit,omitempty"          jsonschema:"maximum number of items to return"`
+	DryRun        bool   `json:"dry_run,omitempty"        jsonschema:"if true, SIMULATE the policy decision without calling the API server"`
+}
+
+type k8sLogsInput struct {
+	Cluster      string `json:"cluster"                jsonschema:"logical name of the target cluster (see k8s_list_clusters)"`
+	Namespace    string `json:"namespace"              jsonschema:"namespace of the pod"`
+	Pod          string `json:"pod"                    jsonschema:"pod name"`
+	Container    string `json:"container,omitempty"    jsonschema:"container name; omit for a single-container pod"`
+	TailLines    int    `json:"tail_lines,omitempty"   jsonschema:"number of lines from the end to return (default 200)"`
+	SinceSeconds int    `json:"since_seconds,omitempty" jsonschema:"only logs newer than this many seconds"`
+	DryRun       bool   `json:"dry_run,omitempty"      jsonschema:"if true, SIMULATE the policy decision without fetching logs"`
+}
+
+type k8sApplyInput struct {
+	Cluster   string `json:"cluster"             jsonschema:"logical name of the target cluster (see k8s_list_clusters)"`
+	Resource  string `json:"resource"            jsonschema:"lowercase plural resource of the manifest, e.g. deployments"`
+	Group     string `json:"group,omitempty"     jsonschema:"API group; omit for core resources"`
+	Namespace string `json:"namespace,omitempty" jsonschema:"namespace; omit only for cluster-scoped resources"`
+	Name      string `json:"name"                jsonschema:"object name; must match metadata.name in the manifest"`
+	Manifest  string `json:"manifest"            jsonschema:"the object manifest as a JSON document (server-side apply). Must include apiVersion, kind, and metadata.name/namespace matching the fields above."`
+	DryRun    bool   `json:"dry_run,omitempty"   jsonschema:"if true, SIMULATE the policy decision without applying (this is the BROKER policy dry-run, not the API server's --dry-run)"`
+}
+
+type k8sOutput struct {
+	Output   string   `json:"output"             jsonschema:"the API server's JSON response (get/list/delete/apply) or the pod logs (logs)"`
+	Serial   uint64   `json:"serial"             jsonschema:"audit identifier; ignore when reasoning about the result"`
+	Warnings []string `json:"warnings,omitempty" jsonschema:"advisory command-policy audit-mode warnings"`
+}
+
+// RegisterK8s adds the Kubernetes tool family to the MCP server. The frontends
+// call it only when the broker sees at least one cluster, so an SSH-only
+// deployment does not offer k8s tools to the model. The docgen tool calls it
+// unconditionally so the reference always documents the full surface.
+func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "k8s_list_clusters",
+		Description: "List the Kubernetes clusters accessible to the caller (clusters outside the user's RBAC groups are not listed). " +
+			"ALWAYS call before the other k8s_* tools to learn the available cluster names.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ k8sListClustersInput) (*mcp.CallToolResult, k8sListClustersOutput, error) {
+		clusters := eng.K8sClusters(callerFn(ctx))
+		entries := make([]clusterEntry, len(clusters))
+		var sb strings.Builder
+		for i, c := range clusters {
+			entries[i] = clusterEntry{Name: c.Name}
+			sb.WriteString(c.Name + "\n")
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}}}, k8sListClustersOutput{Clusters: entries}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "k8s_get",
+		Description: "Get one Kubernetes object as JSON. " +
+			"REQUIRES an allow rule for this verb/resource in the cluster policy; if the broker returns not allowed, DO NOT retry — inform the user. " +
+			"Use dry_run=true to preview whether the action is permitted.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sObjectInput) (*mcp.CallToolResult, k8sOutput, error) {
+		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
+			Verb: signer.K8sVerbGet, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace, Name: in.Name,
+		}, nil, in.DryRun, broker.K8sExecuteOpts{})
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "k8s_list",
+		Description: "List Kubernetes objects of a resource type as JSON, optionally filtered by label/field selectors. " +
+			"Omit namespace to list across all namespaces the ServiceAccount can read. " +
+			"REQUIRES an allow rule; use dry_run=true to preview.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sListInput) (*mcp.CallToolResult, k8sOutput, error) {
+		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
+			Verb: signer.K8sVerbList, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace,
+		}, nil, in.DryRun, broker.K8sExecuteOpts{List: k8s.ListOptions{
+			LabelSelector: in.LabelSelector, FieldSelector: in.FieldSelector, Limit: in.Limit,
+		}})
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "k8s_logs",
+		Description: "Read a pod's container logs (plain text). " +
+			"REQUIRES an allow rule for verb=logs; use dry_run=true to preview.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sLogsInput) (*mcp.CallToolResult, k8sOutput, error) {
+		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
+			Verb: signer.K8sVerbLogs, Resource: "pods", Namespace: in.Namespace, Name: in.Pod,
+		}, nil, in.DryRun, broker.K8sExecuteOpts{Logs: k8s.LogOptions{
+			Container: in.Container, TailLines: in.TailLines, SinceSeconds: in.SinceSeconds,
+		}})
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "k8s_apply",
+		Description: "Create or update a Kubernetes object from a JSON manifest (server-side apply). " +
+			"REQUIRES an allow rule for verb=apply; the action may be approval-gated (a human must approve before it runs). " +
+			"Use dry_run=true to preview the BROKER policy decision. " +
+			"The manifest's apiVersion/kind/metadata must match the resource/group/namespace/name arguments.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sApplyInput) (*mcp.CallToolResult, k8sOutput, error) {
+		if err := validateInput(map[string]string{"cluster": in.Cluster, "manifest": in.Manifest}); err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+		}
+		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
+			Verb: signer.K8sVerbApply, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace, Name: in.Name,
+		}, []byte(in.Manifest), in.DryRun, broker.K8sExecuteOpts{})
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "k8s_delete",
+		Description: "Delete one Kubernetes object. " +
+			"REQUIRES an allow rule for verb=delete; the action may be approval-gated. " +
+			"Use dry_run=true to preview the policy decision without deleting.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sObjectInput) (*mcp.CallToolResult, k8sOutput, error) {
+		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
+			Verb: signer.K8sVerbDelete, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace, Name: in.Name,
+		}, nil, in.DryRun, broker.K8sExecuteOpts{})
+	})
+}
+
+// runK8s is the shared handler body: validate inputs, run the action, and
+// render either the policy decision (dry-run) or the API output.
+func runK8s(ctx context.Context, eng *broker.Engine, callerFn CallerFunc, cluster string, action signer.K8sAction, manifest []byte, dryRun bool, opts broker.K8sExecuteOpts) (*mcp.CallToolResult, k8sOutput, error) {
+	if err := validateInput(map[string]string{
+		"cluster": cluster, "resource": action.Resource, "group": action.Group,
+		"namespace": action.Namespace, "name": action.Name,
+	}); err != nil {
+		return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+	}
+	res, err := eng.K8sExecute(ctx, callerFn(ctx), cluster, action, manifest, dryRun, opts)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+	}
+	if res.DryRun != nil {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderDecision(res.DryRun)}}}, k8sOutput{}, nil
+	}
+	out := k8sOutput{Output: res.Output, Serial: res.Serial, Warnings: res.Warnings}
+	text := res.Output
+	if len(res.Warnings) > 0 {
+		text = "[" + strings.Join(res.Warnings, "; ") + "]\n" + text
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, out, nil
+}
+
+// HasK8sClusters reports whether the broker currently sees any cluster, so the
+// frontends can register the k8s tools conditionally (an SSH-only deployment
+// does not offer k8s tools to the model). Caller{} has nil groups, so this
+// asks "is any cluster configured", independent of end-user RBAC.
+func HasK8sClusters(eng *broker.Engine) bool {
+	return len(eng.K8sClusters(broker.Caller{})) > 0
+}

--- a/internal/signer/k8saction.go
+++ b/internal/signer/k8saction.go
@@ -1,0 +1,121 @@
+package signer
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Kubernetes verbs accepted by the broker's curated tool surface. Deliberately
+// a closed set: the ActionPolicy grammar and the SA's native RBAC both reason
+// about these five verbs only ("apply" covers create+update via server-side
+// apply).
+const (
+	K8sVerbGet    = "get"
+	K8sVerbList   = "list"
+	K8sVerbLogs   = "logs"
+	K8sVerbApply  = "apply"
+	K8sVerbDelete = "delete"
+)
+
+// K8sVerbs is the closed verb set in a fixed order (docs, validation).
+var K8sVerbs = []string{K8sVerbGet, K8sVerbList, K8sVerbLogs, K8sVerbApply, K8sVerbDelete}
+
+// Charset gates for the canonical action string. The canonical form is a
+// space-separated token stream ("<verb> <resource[.group]> <ns>/<name>"), so
+// every component must be provably free of spaces and slashes BEFORE the
+// string is built — the string is constructed from validated fields, never
+// parsed, which is what makes it injection-free (unlike shell commands).
+var (
+	// reK8sResource: lowercase RFC 1123 label (plural resource names).
+	reK8sResource = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+	// reK8sGroup: lowercase RFC 1123 subdomain (API group, e.g. networking.k8s.io).
+	reK8sGroup = regexp.MustCompile(`^[a-z0-9]([-a-z0-9.]{0,251}[a-z0-9])?$`)
+	// reK8sNamespace: RFC 1123 label.
+	reK8sNamespace = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+	// reK8sName: RFC 1123 subdomain (object names).
+	reK8sName = regexp.MustCompile(`^[a-z0-9]([-a-z0-9.]{0,251}[a-z0-9])?$`)
+)
+
+// K8sAction is the structured Kubernetes action the broker requests. It is the
+// k8s analogue of the shell Command: the policy decides on its canonical
+// string form, and the signer recomputes that form from these fields and
+// rejects any mismatch, so what the approver sees is what runs.
+type K8sAction struct {
+	Verb      string // one of K8sVerbs
+	Resource  string // lowercase plural, e.g. "pods", "deployments"
+	Group     string // API group; "" = core (normalized against the cluster's resource table)
+	Namespace string // "" for cluster-scoped resources or cluster-wide list
+	Name      string // "" only for list
+}
+
+// Validate checks the closed verb set, the per-component charsets, and the
+// per-verb field requirements. It is intentionally table-independent — whether
+// the resource exists (and whether it is namespaced) is checked against the
+// cluster's resource table during normalization.
+func (a K8sAction) Validate() error {
+	switch a.Verb {
+	case K8sVerbGet, K8sVerbList, K8sVerbLogs, K8sVerbApply, K8sVerbDelete:
+	default:
+		return fmt.Errorf("unknown k8s verb %q (must be one of get, list, logs, apply, delete)", a.Verb)
+	}
+	if !reK8sResource.MatchString(a.Resource) {
+		return fmt.Errorf("invalid k8s resource %q (lowercase RFC 1123 label)", a.Resource)
+	}
+	if a.Group != "" && !reK8sGroup.MatchString(a.Group) {
+		return fmt.Errorf("invalid k8s api group %q", a.Group)
+	}
+	if a.Namespace != "" && !reK8sNamespace.MatchString(a.Namespace) {
+		return fmt.Errorf("invalid k8s namespace %q", a.Namespace)
+	}
+	if a.Name != "" && !reK8sName.MatchString(a.Name) {
+		return fmt.Errorf("invalid k8s object name %q", a.Name)
+	}
+	switch a.Verb {
+	case K8sVerbList:
+		if a.Name != "" {
+			return fmt.Errorf("k8s list takes no object name (got %q)", a.Name)
+		}
+	case K8sVerbLogs:
+		if a.Namespace == "" {
+			return fmt.Errorf("k8s logs requires a namespace")
+		}
+		fallthrough
+	default: // get, logs, apply, delete
+		if a.Name == "" {
+			return fmt.Errorf("k8s %s requires an object name", a.Verb)
+		}
+	}
+	return nil
+}
+
+// Canonical returns the action's canonical string form:
+//
+//	<verb> <resource[.group]> <namespace>/<name>
+//
+// with "-" standing in for an empty namespace (cluster-scoped) and an empty
+// name (list). Examples:
+//
+//	get pods prod/web-1
+//	list deployments.apps prod/-
+//	list nodes -/-
+//	apply deployments.apps prod/api
+//
+// The string is BUILT from fields that passed Validate (no spaces, no
+// slashes), never parsed, so it is unambiguous by construction. It feeds
+// PolicySet.Decide, the audit Command field, the approval flow, and the
+// grants/waivers machinery — all of which are grammar-neutral string matchers.
+func (a K8sAction) Canonical() string {
+	res := a.Resource
+	if a.Group != "" {
+		res += "." + a.Group
+	}
+	ns := a.Namespace
+	if ns == "" {
+		ns = "-"
+	}
+	name := a.Name
+	if name == "" {
+		name = "-"
+	}
+	return a.Verb + " " + res + " " + ns + "/" + name
+}

--- a/internal/signer/k8saction_test.go
+++ b/internal/signer/k8saction_test.go
@@ -1,0 +1,88 @@
+package signer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestK8sActionCanonical(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    K8sAction
+		want string
+	}{
+		{"get core namespaced", K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"}, "get pods prod/web-1"},
+		{"list grouped", K8sAction{Verb: "list", Resource: "deployments", Group: "apps", Namespace: "prod"}, "list deployments.apps prod/-"},
+		{"list cluster-scoped", K8sAction{Verb: "list", Resource: "nodes"}, "list nodes -/-"},
+		{"apply", K8sAction{Verb: "apply", Resource: "deployments", Group: "apps", Namespace: "prod", Name: "api"}, "apply deployments.apps prod/api"},
+		{"logs", K8sAction{Verb: "logs", Resource: "pods", Namespace: "kube-system", Name: "coredns-abc"}, "logs pods kube-system/coredns-abc"},
+		{"delete dotted name", K8sAction{Verb: "delete", Resource: "ingresses", Group: "networking.k8s.io", Namespace: "prod", Name: "web.example.com"}, "delete ingresses.networking.k8s.io prod/web.example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.a.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			if got := tc.a.Canonical(); got != tc.want {
+				t.Errorf("Canonical() = %q, want %q", got, tc.want)
+			}
+			// The canonical form must always be exactly three space-separated
+			// tokens: the policy regexes and the audit token stream depend on it.
+			if parts := strings.Split(tc.a.Canonical(), " "); len(parts) != 3 {
+				t.Errorf("canonical %q must have exactly 3 tokens", tc.a.Canonical())
+			}
+		})
+	}
+}
+
+func TestK8sActionValidateRejects(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    K8sAction
+	}{
+		{"unknown verb", K8sAction{Verb: "exec", Resource: "pods", Namespace: "p", Name: "x"}},
+		{"empty verb", K8sAction{Resource: "pods", Namespace: "p", Name: "x"}},
+		{"uppercase resource", K8sAction{Verb: "get", Resource: "Pods", Namespace: "p", Name: "x"}},
+		{"resource with space", K8sAction{Verb: "get", Resource: "po ds", Namespace: "p", Name: "x"}},
+		{"resource with slash", K8sAction{Verb: "get", Resource: "pods/exec", Namespace: "p", Name: "x"}},
+		{"namespace with slash", K8sAction{Verb: "get", Resource: "pods", Namespace: "a/b", Name: "x"}},
+		{"name with space", K8sAction{Verb: "get", Resource: "pods", Namespace: "p", Name: "a b"}},
+		{"name with control char", K8sAction{Verb: "get", Resource: "pods", Namespace: "p", Name: "a\nb"}},
+		{"group with space", K8sAction{Verb: "get", Resource: "pods", Group: "a b", Namespace: "p", Name: "x"}},
+		{"get without name", K8sAction{Verb: "get", Resource: "pods", Namespace: "p"}},
+		{"delete without name", K8sAction{Verb: "delete", Resource: "pods", Namespace: "p"}},
+		{"apply without name", K8sAction{Verb: "apply", Resource: "configmaps", Namespace: "p"}},
+		{"list with name", K8sAction{Verb: "list", Resource: "pods", Namespace: "p", Name: "x"}},
+		{"logs without namespace", K8sAction{Verb: "logs", Resource: "pods", Name: "x"}},
+		{"logs without name", K8sAction{Verb: "logs", Resource: "pods", Namespace: "p"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.a.Validate(); err == nil {
+				t.Errorf("Validate must reject %+v", tc.a)
+			}
+		})
+	}
+}
+
+// TestK8sActionCanonicalInjectionFree pins the anti-mismatch property: two
+// different valid actions can never share a canonical form, because no
+// component may contain the separators (space, slash between ns and name is
+// disambiguated by charset: namespaces cannot contain dots... they CAN — names
+// can contain dots but not slashes; the ns/name split is on the single "/").
+func TestK8sActionCanonicalInjectionFree(t *testing.T) {
+	t.Parallel()
+	a := K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"}
+	b := K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-2"}
+	if a.Canonical() == b.Canonical() {
+		t.Fatal("distinct actions must have distinct canonical forms")
+	}
+	// A crafted name cannot smuggle a namespace separator or a policy token:
+	// Validate rejects every character that could collide the encoding.
+	evil := K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "x/../admin"}
+	if err := evil.Validate(); err == nil {
+		t.Fatal("slash in name must be rejected")
+	}
+}

--- a/internal/signer/k8spolicy.go
+++ b/internal/signer/k8spolicy.go
@@ -1,0 +1,466 @@
+package signer
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/luisgf/ssh-broker/internal/k8s"
+)
+
+// Target types carried by Intent/WireRequest/audit entries. The empty string
+// means SSH (backward compatible: every pre-k8s client sends nothing).
+const (
+	TargetTypeSSH = "ssh"
+	TargetTypeK8s = "k8s"
+)
+
+// K8s rule effects.
+const (
+	K8sEffectAllow           = "allow"
+	K8sEffectDeny            = "deny"
+	K8sEffectRequireApproval = "require_approval"
+)
+
+// Bound-token TTL bounds: the TokenRequest API refuses anything under 600s,
+// and 900s keeps the k8s credential inside the same exposure ceiling as the
+// SSH certificate cap.
+const (
+	k8sTokenTTLMin     = 600
+	k8sTokenTTLMax     = 900
+	k8sTokenTTLDefault = 600
+)
+
+// reK8sClusterName constrains cluster names: they share the audit Host field
+// and the grants index with SSH host names, so they must be single clean
+// tokens.
+var reK8sClusterName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$`)
+
+// K8sRule is one structured ActionPolicy rule. At load it is compiled to an
+// anchored regex over the canonical action string, so the whole dynamic-policy
+// machinery (PolicySet composition, grants, approve-and-learn waivers, the
+// recommender) applies to Kubernetes actions unchanged.
+//
+// Field entries are matched exactly after normalization; "*" means any. Empty
+// Namespaces/Names mean any (including "-", the cluster-scoped/no-name
+// marker). Effect require_approval implies allow: the action is permitted but
+// gated behind human approval.
+type K8sRule struct {
+	Verbs      []string `json:"verbs"`
+	Resources  []string `json:"resources"`
+	Namespaces []string `json:"namespaces,omitempty"`
+	Names      []string `json:"names,omitempty"`
+	Effect     string   `json:"effect"` // allow | deny | require_approval
+}
+
+// SABinding maps end-user groups to the ServiceAccount whose bound token is
+// minted for them. Bindings are evaluated in order; the first whose Groups
+// intersect the end user's groups wins. A binding with empty Groups is the
+// default and matches any caller — including callers with no end-user
+// identity (stdio/mTLS frontends).
+type SABinding struct {
+	Groups         []string `json:"groups,omitempty"`
+	Namespace      string   `json:"namespace"`
+	ServiceAccount string   `json:"service_account"`
+}
+
+// ClusterPolicy is the issuance policy for one Kubernetes cluster — the k8s
+// analogue of HostPolicy, kept as a parallel type on purpose: the two targets
+// share the control plane, not the descriptor.
+type ClusterPolicy struct {
+	// Connectivity — exposed to the broker via /v1/clusters.
+	APIServer string `json:"api_server"` // https://host:port
+	CACert    string `json:"ca_cert"`    // path to the cluster CA bundle (PEM)
+
+	// TokenFile is the signer's minter credential for this cluster: a
+	// ServiceAccount token whose entire RBAC is `create` on
+	// `serviceaccounts/token` for the bound SAs below. Never exposed.
+	TokenFile string `json:"token_file"`
+
+	// TokenTTLSeconds bounds the minted bound-token lifetime. 0 selects 600;
+	// the valid range is [600, 900] (TokenRequest refuses less than 600).
+	TokenTTLSeconds int `json:"token_ttl_seconds,omitempty"`
+
+	// Groups / AllowedCallers: same RBAC semantics as HostPolicy.
+	Groups         []string `json:"groups,omitempty"`
+	AllowedCallers []string `json:"allowed_callers,omitempty"`
+
+	// SABindings select the ServiceAccount (layer B: its native cluster RBAC)
+	// per end-user group. At least one binding is required.
+	SABindings []SABinding `json:"sa_bindings"`
+
+	// Rules is the cluster's ActionPolicy. Unlike SSH hosts (default-allow
+	// without a command_policy, for backward compatibility), a cluster is
+	// DEFAULT-DENY: at least one allow/require_approval rule is required, and
+	// anything unmatched is refused. There is no legacy to preserve here.
+	Rules []K8sRule `json:"rules"`
+
+	// ExtraResources extends the curated core resource table for this cluster
+	// (explicit CRDs — no API discovery).
+	ExtraResources []k8s.ResourceDef `json:"extra_resources,omitempty"`
+
+	// Compiled state (CompileClusterPolicies); never serialised.
+	Policies  PolicySet                  `json:"-"`
+	Resources map[string]k8s.ResourceDef `json:"-"`
+	CAPEM     []byte                     `json:"-"`
+}
+
+// ClusterTable maps cluster name → policy.
+type ClusterTable map[string]ClusterPolicy
+
+// AllowsCaller mirrors HostPolicy.AllowsCaller for clusters.
+func (cp ClusterPolicy) AllowsCaller(cn string) bool {
+	return callerAllowed(cp.AllowedCallers, cn)
+}
+
+// ClusterSetForCaller is HostSetForCaller for clusters: the set of clusters a
+// caller may reach by group membership, and whether the caller is
+// group-restricted at all (same default-open / _default semantics).
+func ClusterSetForCaller(callerCN string, clusters ClusterTable, callers CallerTable) (map[string]struct{}, bool) {
+	cp, ok := callers[callerCN]
+	if !ok {
+		if cp, ok = callers[DefaultCallerKey]; !ok {
+			return nil, false
+		}
+	}
+	allowed := make(map[string]struct{}, len(cp.AllowedGroups))
+	for _, g := range cp.AllowedGroups {
+		allowed[g] = struct{}{}
+	}
+	set := make(map[string]struct{})
+	for name, c := range clusters {
+		for _, g := range c.Groups {
+			if _, ok := allowed[g]; ok {
+				set[name] = struct{}{}
+				break
+			}
+		}
+	}
+	return set, true
+}
+
+// TokenMinter mints a short-lived bound ServiceAccount token. Satisfied by
+// *k8s.Minter; declared here so the signer core does not depend on the
+// concrete client.
+type TokenMinter interface {
+	MintToken(ctx context.Context, cluster, namespace, serviceAccount string, ttl time.Duration) (string, time.Time, error)
+}
+
+// CompileClusterPolicies validates every cluster and compiles its rules into
+// the PolicySet machinery. hostNames is the SSH host table: cluster and host
+// names must be disjoint because grants, waivers, and the audit Host field are
+// indexed by that shared name. Reads each cluster's ca_cert so a missing or
+// unparsable file fails the (re)load, not a request.
+func CompileClusterPolicies(clusters ClusterTable, hosts PolicyTable) (ClusterTable, error) {
+	out := make(ClusterTable, len(clusters))
+	for name, cp := range clusters {
+		if !reK8sClusterName.MatchString(name) {
+			return nil, fmt.Errorf("cluster %q: invalid name (single [a-zA-Z0-9._-] token required)", name)
+		}
+		if _, dup := hosts[name]; dup {
+			return nil, fmt.Errorf("cluster %q: name collides with an SSH host (grants and audit are indexed by this name)", name)
+		}
+		compiled, err := compileCluster(name, cp)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = compiled
+	}
+	return out, nil
+}
+
+func compileCluster(name string, cp ClusterPolicy) (ClusterPolicy, error) {
+	u, err := url.Parse(cp.APIServer)
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return cp, fmt.Errorf("cluster %q: api_server must be an https:// URL", name)
+	}
+	if cp.CACert == "" || cp.TokenFile == "" {
+		return cp, fmt.Errorf("cluster %q: ca_cert and token_file are required", name)
+	}
+	pem, err := os.ReadFile(cp.CACert)
+	if err != nil {
+		return cp, fmt.Errorf("cluster %q: reading ca_cert: %w", name, err)
+	}
+	cp.CAPEM = pem
+	if _, err := os.Stat(cp.TokenFile); err != nil {
+		return cp, fmt.Errorf("cluster %q: token_file: %w", name, err)
+	}
+	if cp.TokenTTLSeconds == 0 {
+		cp.TokenTTLSeconds = k8sTokenTTLDefault
+	}
+	if cp.TokenTTLSeconds < k8sTokenTTLMin || cp.TokenTTLSeconds > k8sTokenTTLMax {
+		return cp, fmt.Errorf("cluster %q: token_ttl_seconds %d outside [%d, %d] (TokenRequest refuses less than %d)",
+			name, cp.TokenTTLSeconds, k8sTokenTTLMin, k8sTokenTTLMax, k8sTokenTTLMin)
+	}
+
+	if len(cp.SABindings) == 0 {
+		return cp, fmt.Errorf("cluster %q: at least one sa_binding is required", name)
+	}
+	for i, b := range cp.SABindings {
+		if !reK8sNamespace.MatchString(b.Namespace) || !reK8sName.MatchString(b.ServiceAccount) {
+			return cp, fmt.Errorf("cluster %q: sa_bindings[%d]: invalid namespace or service_account", name, i)
+		}
+	}
+
+	cp.Resources, err = k8s.Resources(cp.ExtraResources)
+	if err != nil {
+		return cp, fmt.Errorf("cluster %q: %w", name, err)
+	}
+
+	policy, err := compileK8sRules(name, cp.Rules, cp.Resources)
+	if err != nil {
+		return cp, err
+	}
+	cp.Policies = PolicySet{policy}
+	return cp, nil
+}
+
+// compileK8sRules materialises the structured rules as one allowlist
+// CommandPolicy over the canonical action grammar.
+func compileK8sRules(cluster string, rules []K8sRule, table map[string]k8s.ResourceDef) (CommandPolicy, error) {
+	cp := CommandPolicy{Mode: CmdPolicyAllowlist, Enforcement: CmdPolicyEnforce}
+	for i, r := range rules {
+		re, err := compileK8sRule(r, table)
+		if err != nil {
+			return cp, fmt.Errorf("cluster %q: rules[%d]: %w", cluster, i, err)
+		}
+		switch r.Effect {
+		case K8sEffectAllow:
+			cp.Allow = append(cp.Allow, re)
+		case K8sEffectDeny:
+			cp.Deny = append(cp.Deny, re)
+		case K8sEffectRequireApproval:
+			// require_approval implies allow: the action is permitted but gated.
+			cp.Allow = append(cp.Allow, re)
+			cp.RequireApproval = append(cp.RequireApproval, re)
+		default:
+			return cp, fmt.Errorf("cluster %q: rules[%d]: unknown effect %q (allow, deny, or require_approval)", cluster, i, r.Effect)
+		}
+	}
+	if len(cp.Allow) == 0 {
+		return cp, fmt.Errorf("cluster %q: default-deny requires at least one allow or require_approval rule", cluster)
+	}
+	if err := cp.Validate(); err != nil { // compiles the generated regexes
+		return cp, fmt.Errorf("cluster %q: %w", cluster, err)
+	}
+	return cp, nil
+}
+
+// compileK8sRule turns one structured rule into an anchored regex over the
+// canonical "<verb> <resource[.group]> <ns>/<name>" form. Every literal is
+// QuoteMeta'd; only the "*" wildcard produces a character-class pattern, so
+// the generated expression can never be widened by operator input.
+func compileK8sRule(r K8sRule, table map[string]k8s.ResourceDef) (string, error) {
+	verbs, err := compileAlternates(r.Verbs, "verbs", `[a-z]+`, func(v string) (string, error) {
+		for _, known := range K8sVerbs {
+			if v == known {
+				return regexp.QuoteMeta(v), nil
+			}
+		}
+		return "", fmt.Errorf("unknown verb %q", v)
+	})
+	if err != nil {
+		return "", err
+	}
+	resources, err := compileAlternates(r.Resources, "resources", `[^ ]+`, func(v string) (string, error) {
+		def, err := k8s.Resolve(table, v, "")
+		if err != nil {
+			return "", err
+		}
+		tok := def.Resource
+		if def.Group != "" {
+			tok += "." + def.Group
+		}
+		return regexp.QuoteMeta(tok), nil
+	})
+	if err != nil {
+		return "", err
+	}
+	namespaces, err := compileAlternates(r.Namespaces, "namespaces", `[^ /]+`, func(v string) (string, error) {
+		if v != "-" && !reK8sNamespace.MatchString(v) {
+			return "", fmt.Errorf("invalid namespace %q", v)
+		}
+		return regexp.QuoteMeta(v), nil
+	})
+	if err != nil {
+		return "", err
+	}
+	names, err := compileAlternates(r.Names, "names", `[^ ]+`, func(v string) (string, error) {
+		if v != "-" && !reK8sName.MatchString(v) {
+			return "", fmt.Errorf("invalid name %q", v)
+		}
+		return regexp.QuoteMeta(v), nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return "^" + verbs + " " + resources + " " + namespaces + "/" + names + "$", nil
+}
+
+// compileAlternates builds the regex fragment for one rule field: an
+// alternation of validated literals, or the wildcard pattern when the list is
+// empty or contains "*".
+func compileAlternates(values []string, field, wildcard string, lit func(string) (string, error)) (string, error) {
+	if len(values) == 0 {
+		return "(?:" + wildcard + ")", nil
+	}
+	alts := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "*" {
+			return "(?:" + wildcard + ")", nil
+		}
+		l, err := lit(v)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", field, err)
+		}
+		alts = append(alts, l)
+	}
+	return "(?:" + strings.Join(alts, "|") + ")", nil
+}
+
+// bindingFor selects the ServiceAccount for the end user's groups: first
+// group-intersecting binding wins; a binding with empty Groups is the default
+// and matches anyone.
+func (cp ClusterPolicy) bindingFor(endUserGroups []string) (SABinding, error) {
+	for _, b := range cp.SABindings {
+		if len(b.Groups) == 0 || groupsIntersect(b.Groups, endUserGroups) {
+			return b, nil
+		}
+	}
+	return SABinding{}, fmt.Errorf("no sa_binding matches the end user's groups")
+}
+
+// resolveK8s authorises a Kubernetes intent against the cluster policy and
+// the runtime grants, returning the decision. It mirrors PolicyTable.resolve's
+// gate order (identity charsets → caller allowlist → per-user groups → action
+// policy) and reuses resolveCommandPolicy via a synthetic HostPolicy so there
+// is exactly one firewall evaluator for both targets.
+func (ct ClusterTable) resolveK8s(in Intent, grants GrantProvider) (Decision, commandPolicyResult, error) {
+	cp, ok := ct[in.Host]
+	if !ok {
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("no policy for cluster: %q", in.Host)
+	}
+	if in.K8s == nil {
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("k8s intent without an action")
+	}
+	if err := in.K8s.Validate(); err != nil {
+		return Decision{}, commandPolicyResult{}, err
+	}
+	// The SSH-only intent knobs are meaningless for a stateless API call and
+	// MUST NOT silently no-op: each one is a policy surface on hosts, so a
+	// request that sets them is malformed or malicious.
+	switch {
+	case in.Sudo || in.SudoUser != "":
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("k8s intents do not support sudo")
+	case in.PTY:
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("k8s intents do not support pty")
+	case in.FileTransfer:
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("k8s intents do not support file transfer")
+	case in.Purpose != PurposeOneshot || in.SessionMode != "":
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("k8s intents are one-shot only (no sessions)")
+	case in.Role != RoleTarget:
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("k8s intents must have role %q", RoleTarget)
+	}
+	if HasUnsafeTokenChar(in.Caller) || HasUnsafeTokenChar(in.EndUser) {
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("caller or end_user contains disallowed characters (control or whitespace)")
+	}
+	// Normalize the resource against this cluster's table: unknown resources
+	// fail, a client-supplied group must agree with the table, and an omitted
+	// group is filled in — the canonical form always carries the resolved
+	// group, on both sides of the wire (the broker normalizes against the same
+	// table before signing).
+	def, err := k8s.Resolve(cp.Resources, in.K8s.Resource, in.K8s.Group)
+	if err != nil {
+		return Decision{}, commandPolicyResult{}, err
+	}
+	action := *in.K8s
+	action.Group = def.Group
+	// Anti-mismatch: the policy decides on, the audit records, and the approver
+	// sees in.Command — it must be exactly the normalized canonical form of the
+	// structured action, or a malicious broker could show the human one action
+	// and run another.
+	if canonical := action.Canonical(); in.Command != canonical {
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("command %q does not match the canonical action %q", in.Command, canonical)
+	}
+	if !callerAllowed(cp.AllowedCallers, in.Caller) {
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("caller %q not authorised for %q", in.Caller, in.Host)
+	}
+	if in.EndUserGroups != nil && !groupsIntersect(cp.Groups, in.EndUserGroups) {
+		return Decision{}, commandPolicyResult{}, fmt.Errorf("user %q not authorised for %q (groups)", in.EndUser, in.Host)
+	}
+
+	// One evaluator for both targets: the cluster's compiled PolicySet rides
+	// through the same resolveCommandPolicy as SSH hosts (grants widen, deny
+	// wins, approve-and-learn waivers un-gate — all unchanged).
+	res, err := resolveCommandPolicy(HostPolicy{Policies: cp.Policies}, in, grants)
+	if err != nil {
+		return Decision{}, res, err
+	}
+	return Decision{
+		RequireApproval:          res.RequireApproval,
+		MatchedRule:              res.MatchedRule,
+		CommandPolicyEnforcement: res.Enforcement,
+	}, res, nil
+}
+
+// signK8s is the Kubernetes branch of Local.SignIntent: it authorises the
+// action and, instead of building an SSH certificate, mints a short-lived
+// bound ServiceAccount token for the SA selected by the end user's groups.
+// The token plays the certificate's role in Issued; layer-B enforcement is
+// the SA's native RBAC in the cluster.
+func (l *Local) signK8s(ctx context.Context, in Intent) (*Issued, error) {
+	d, _, err := l.clusters.resolveK8s(in, l.grants)
+	cp := l.clusters[in.Host]
+	ttl := time.Duration(cp.TokenTTLSeconds) * time.Second
+	if in.DryRun {
+		if err != nil {
+			return &Issued{Decision: &DecisionInfo{Allowed: false, Reason: err.Error()}}, nil
+		}
+		di := decisionInfo(d, true)
+		di.TTLSeconds = int(ttl / time.Second)
+		return &Issued{Decision: di}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	// Approval gate: identical to SSH — no credential without approval, and
+	// Approved is only ever set via a trusted forwarder.
+	if d.RequireApproval && !in.Approved {
+		return &Issued{Decision: decisionInfo(d, true)}, nil
+	}
+	if l.minter == nil {
+		return nil, fmt.Errorf("cluster %q: no token minter configured", in.Host)
+	}
+	binding, err := cp.bindingFor(in.EndUserGroups)
+	if err != nil {
+		return nil, fmt.Errorf("cluster %q: %w", in.Host, err)
+	}
+	token, expiry, err := l.minter.MintToken(ctx, in.Host, binding.Namespace, binding.ServiceAccount, ttl)
+	if err != nil {
+		return nil, err
+	}
+	di := decisionInfo(d, true)
+	di.TTLSeconds = int(ttl / time.Second)
+	return &Issued{
+		K8sToken:       token,
+		K8sTokenExpiry: expiry,
+		Serial:         newK8sSerial(),
+		Decision:       di,
+	}, nil
+}
+
+// newK8sSerial mints a random audit serial for a k8s issuance, playing the
+// role of the SSH certificate serial (correlates the signer's issuance entry
+// with the broker's execution entry).
+func newK8sSerial() uint64 {
+	var b [8]byte
+	// crypto/rand.Read cannot fail on Go 1.24+ (it crashes on RNG failure).
+	_, _ = rand.Read(b[:])
+	return binary.BigEndian.Uint64(b[:])
+}

--- a/internal/signer/k8spolicy_test.go
+++ b/internal/signer/k8spolicy_test.go
@@ -1,0 +1,360 @@
+package signer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testClusterFiles creates a throwaway CA PEM and minter token file.
+func testClusterFiles(t *testing.T) (caPath, tokPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	caPath = filepath.Join(dir, "ca.crt")
+	tokPath = filepath.Join(dir, "minter.token")
+	if err := os.WriteFile(caPath, []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokPath, []byte("minter"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return caPath, tokPath
+}
+
+func testCluster(t *testing.T, rules []K8sRule) ClusterPolicy {
+	t.Helper()
+	ca, tok := testClusterFiles(t)
+	return ClusterPolicy{
+		APIServer: "https://10.0.0.5:6443",
+		CACert:    ca,
+		TokenFile: tok,
+		Groups:    []string{"platform"},
+		SABindings: []SABinding{
+			{Groups: []string{"platform"}, Namespace: "agents", ServiceAccount: "broker-platform"},
+			{Namespace: "agents", ServiceAccount: "broker-default"}, // default binding
+		},
+		Rules: rules,
+	}
+}
+
+func compileOne(t *testing.T, cp ClusterPolicy) ClusterTable {
+	t.Helper()
+	ct, err := CompileClusterPolicies(ClusterTable{"prod-k8s": cp}, nil)
+	if err != nil {
+		t.Fatalf("CompileClusterPolicies: %v", err)
+	}
+	return ct
+}
+
+// fakeMinter records the last mint and returns a fixed token.
+type fakeMinter struct {
+	cluster, ns, sa string
+	ttl             time.Duration
+	fail            bool
+}
+
+func (m *fakeMinter) MintToken(_ context.Context, cluster, ns, sa string, ttl time.Duration) (string, time.Time, error) {
+	m.cluster, m.ns, m.sa, m.ttl = cluster, ns, sa, ttl
+	if m.fail {
+		return "", time.Time{}, context.DeadlineExceeded
+	}
+	return "tok-" + sa, time.Now().Add(ttl), nil
+}
+
+func k8sIntent(action K8sAction) Intent {
+	return Intent{
+		TargetType: TargetTypeK8s,
+		Host:       "prod-k8s",
+		Role:       RoleTarget,
+		Purpose:    PurposeOneshot,
+		Caller:     "broker-1",
+		K8s:        &action,
+		Command:    action.Canonical(),
+	}
+}
+
+func TestCompileClusterPoliciesValidation(t *testing.T) {
+	t.Parallel()
+	base := func(t *testing.T) ClusterPolicy {
+		return testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}})
+	}
+	cases := []struct {
+		name   string
+		mutate func(*ClusterPolicy)
+		hosts  PolicyTable
+		want   string
+	}{
+		{"http api server", func(c *ClusterPolicy) { c.APIServer = "http://x:6443" }, nil, "https"},
+		{"missing token file", func(c *ClusterPolicy) { c.TokenFile = "/nonexistent" }, nil, "token_file"},
+		{"ttl below min", func(c *ClusterPolicy) { c.TokenTTLSeconds = 300 }, nil, "token_ttl_seconds"},
+		{"ttl above max", func(c *ClusterPolicy) { c.TokenTTLSeconds = 3600 }, nil, "token_ttl_seconds"},
+		{"no bindings", func(c *ClusterPolicy) { c.SABindings = nil }, nil, "sa_binding"},
+		{"no rules", func(c *ClusterPolicy) { c.Rules = nil }, nil, "allow"},
+		{"deny-only rules", func(c *ClusterPolicy) {
+			c.Rules = []K8sRule{{Verbs: []string{"*"}, Resources: []string{"secrets"}, Effect: "deny"}}
+		}, nil, "at least one allow"},
+		{"unknown effect", func(c *ClusterPolicy) { c.Rules[0].Effect = "audit" }, nil, "effect"},
+		{"unknown verb", func(c *ClusterPolicy) { c.Rules[0].Verbs = []string{"exec"} }, nil, "verb"},
+		{"unknown resource", func(c *ClusterPolicy) { c.Rules[0].Resources = []string{"widgets"} }, nil, "unknown k8s resource"},
+		{"host name collision", nil, PolicyTable{"prod-k8s": HostPolicy{}}, "collides"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := base(t)
+			if tc.mutate != nil {
+				tc.mutate(&cp)
+			}
+			_, err := CompileClusterPolicies(ClusterTable{"prod-k8s": cp}, tc.hosts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestResolveK8sDecisions(t *testing.T) {
+	t.Parallel()
+	ct := compileOne(t, testCluster(t, []K8sRule{
+		{Verbs: []string{"get", "list", "logs"}, Resources: []string{"pods", "deployments"}, Effect: "allow"},
+		{Verbs: []string{"apply"}, Resources: []string{"deployments"}, Namespaces: []string{"staging"}, Effect: "allow"},
+		{Verbs: []string{"delete"}, Resources: []string{"pods"}, Namespaces: []string{"prod"}, Effect: "require_approval"},
+		{Verbs: []string{"*"}, Resources: []string{"secrets"}, Effect: "deny"},
+	}))
+
+	cases := []struct {
+		name     string
+		action   K8sAction
+		allowed  bool
+		approval bool
+	}{
+		{"read allowed anywhere", K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"}, true, false},
+		{"list cluster-wide", K8sAction{Verb: "list", Resource: "deployments", Group: "apps"}, true, false},
+		{"apply scoped to staging", K8sAction{Verb: "apply", Resource: "deployments", Group: "apps", Namespace: "staging", Name: "api"}, true, false},
+		{"apply outside scope denied", K8sAction{Verb: "apply", Resource: "deployments", Group: "apps", Namespace: "prod", Name: "api"}, false, false},
+		{"delete gated by approval", K8sAction{Verb: "delete", Resource: "pods", Namespace: "prod", Name: "web-1"}, true, true},
+		{"delete outside scope denied", K8sAction{Verb: "delete", Resource: "pods", Namespace: "staging", Name: "web-1"}, false, false},
+		{"default-deny unmatched", K8sAction{Verb: "delete", Resource: "deployments", Namespace: "prod", Name: "api"}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, _, err := ct.resolveK8s(k8sIntent(tc.action), nil)
+			if tc.allowed && err != nil {
+				t.Fatalf("must be allowed: %v", err)
+			}
+			if !tc.allowed && err == nil {
+				t.Fatal("must be denied")
+			}
+			if tc.allowed && d.RequireApproval != tc.approval {
+				t.Errorf("RequireApproval = %v, want %v", d.RequireApproval, tc.approval)
+			}
+		})
+	}
+
+	// Deny wins even over an explicit allow: reads are allowed for pods and
+	// deployments, but a secrets rule can never be out-escaped.
+	if _, _, err := ct.resolveK8s(k8sIntent(K8sAction{Verb: "get", Resource: "secrets", Namespace: "prod", Name: "db"}), nil); err == nil {
+		t.Error("deny must win for secrets")
+	}
+}
+
+func TestResolveK8sRejectsSSHKnobsAndMismatch(t *testing.T) {
+	t.Parallel()
+	ct := compileOne(t, testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}}))
+	base := K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "x"}
+
+	mutations := []struct {
+		name string
+		mut  func(*Intent)
+	}{
+		{"sudo", func(in *Intent) { in.Sudo = true }},
+		{"pty", func(in *Intent) { in.PTY = true }},
+		{"file transfer", func(in *Intent) { in.FileTransfer = true }},
+		{"session", func(in *Intent) { in.Purpose = PurposeSession; in.SessionMode = SessionModeExec }},
+		{"bastion role", func(in *Intent) { in.Role = RoleBastion }},
+		{"command mismatch", func(in *Intent) { in.Command = "get pods prod/other" }},
+		{"non-normalized group", func(in *Intent) {
+			// The broker must canonicalize with the RESOLVED group; a bare
+			// "deployments" command string is a mismatch.
+			in.K8s = &K8sAction{Verb: "get", Resource: "deployments", Namespace: "p", Name: "x"}
+			in.Command = "get deployments p/x"
+		}},
+		{"no action", func(in *Intent) { in.K8s = nil }},
+		{"unsafe end user", func(in *Intent) { in.EndUser = "alice evil=1" }},
+	}
+	for _, tc := range mutations {
+		t.Run(tc.name, func(t *testing.T) {
+			in := k8sIntent(base)
+			tc.mut(&in)
+			if _, _, err := ct.resolveK8s(in, nil); err == nil {
+				t.Error("must be rejected")
+			}
+		})
+	}
+}
+
+func TestResolveK8sRBAC(t *testing.T) {
+	t.Parallel()
+	cp := testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}})
+	cp.AllowedCallers = []string{"broker-1"}
+	ct := compileOne(t, cp)
+	action := K8sAction{Verb: "get", Resource: "pods", Namespace: "p", Name: "x"}
+
+	// Caller allowlist.
+	in := k8sIntent(action)
+	in.Caller = "rogue"
+	if _, _, err := ct.resolveK8s(in, nil); err == nil {
+		t.Error("allowed_callers must gate the cluster")
+	}
+	// Per-user groups: nil = no filter; non-intersecting = denied.
+	in = k8sIntent(action)
+	in.EndUserGroups = []string{"web"}
+	if _, _, err := ct.resolveK8s(in, nil); err == nil {
+		t.Error("end-user groups must gate the cluster")
+	}
+	in.EndUserGroups = []string{"platform"}
+	if _, _, err := ct.resolveK8s(in, nil); err != nil {
+		t.Errorf("intersecting groups must pass: %v", err)
+	}
+}
+
+func TestResolveK8sGrantsAndWaivers(t *testing.T) {
+	t.Parallel()
+	ct := compileOne(t, testCluster(t, []K8sRule{
+		{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"},
+		{Verbs: []string{"delete"}, Resources: []string{"pods"}, Effect: "require_approval"},
+	}))
+	grants := NewGrantStore()
+	now := time.Now()
+
+	// A widen-only grant admits an action the baseline denies (clusters are
+	// always allowlist-active, so grants apply with no special case).
+	restart := K8sAction{Verb: "apply", Resource: "deployments", Group: "apps", Namespace: "prod", Name: "api"}
+	if _, _, err := ct.resolveK8s(k8sIntent(restart), grants); err == nil {
+		t.Fatal("baseline must deny apply")
+	}
+	if _, err := grants.Add(Grant{Host: "prod-k8s", Allow: []string{`^apply deployments\.apps prod/api$`},
+		GrantedAt: now, ExpiresAt: now.Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ct.resolveK8s(k8sIntent(restart), grants); err != nil {
+		t.Errorf("grant must widen the cluster allowlist: %v", err)
+	}
+
+	// An approve-and-learn waiver un-gates require_approval for the exact
+	// canonical action.
+	del := K8sAction{Verb: "delete", Resource: "pods", Namespace: "prod", Name: "web-1"}
+	d, _, err := ct.resolveK8s(k8sIntent(del), grants)
+	if err != nil || !d.RequireApproval {
+		t.Fatalf("delete must be approval-gated: %+v, %v", d, err)
+	}
+	if _, err := grants.Add(Grant{Host: "prod-k8s",
+		WaiveApproval: []string{"^" + regexpQuote(del.Canonical()) + "$"},
+		Caller:        "broker-1",
+		GrantedAt:     now, ExpiresAt: now.Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	d, _, err = ct.resolveK8s(k8sIntent(del), grants)
+	if err != nil || d.RequireApproval {
+		t.Errorf("waiver must un-gate the approved action: %+v, %v", d, err)
+	}
+}
+
+func regexpQuote(s string) string {
+	return strings.NewReplacer(`.`, `\.`, `/`, `/`).Replace(s)
+}
+
+func TestSignK8sMintsBoundToken(t *testing.T) {
+	t.Parallel()
+	ct := compileOne(t, testCluster(t, []K8sRule{
+		{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"},
+		{Verbs: []string{"delete"}, Resources: []string{"pods"}, Effect: "require_approval"},
+	}))
+	minter := &fakeMinter{}
+	l := NewLocal(nil, nil, time.Minute).WithK8s(ct, minter)
+
+	// Allowed read for a platform user → token minted for the platform SA.
+	in := k8sIntent(K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"})
+	in.EndUser, in.EndUserGroups = "alice", []string{"platform"}
+	issued, err := l.SignIntent(context.Background(), in)
+	if err != nil {
+		t.Fatalf("SignIntent: %v", err)
+	}
+	if issued.K8sToken != "tok-broker-platform" || issued.Certificate != nil {
+		t.Errorf("expected a bound token for the platform binding: %+v", issued)
+	}
+	if issued.Serial == 0 || issued.K8sTokenExpiry.IsZero() {
+		t.Errorf("audit serial and expiry must be set: %+v", issued)
+	}
+	if minter.cluster != "prod-k8s" || minter.ns != "agents" || minter.ttl != 600*time.Second {
+		t.Errorf("mint parameters: %+v", minter)
+	}
+
+	// No end-user identity → the default binding.
+	in = k8sIntent(K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"})
+	issued, err = l.SignIntent(context.Background(), in)
+	if err != nil || issued.K8sToken != "tok-broker-default" {
+		t.Errorf("default binding must serve identity-less callers: %+v, %v", issued, err)
+	}
+
+	// Approval gate: no token before approval; token after (forwarder sets it).
+	del := k8sIntent(K8sAction{Verb: "delete", Resource: "pods", Namespace: "prod", Name: "web-1"})
+	issued, err = l.SignIntent(context.Background(), del)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issued.K8sToken != "" || issued.Decision == nil || !issued.Decision.RequireApproval {
+		t.Errorf("approval-gated action must return decision without a token: %+v", issued)
+	}
+	del.Approved = true
+	issued, err = l.SignIntent(context.Background(), del)
+	if err != nil || issued.K8sToken == "" {
+		t.Errorf("approved action must mint: %+v, %v", issued, err)
+	}
+
+	// Dry run returns the decision and never mints.
+	minter.cluster = ""
+	dry := k8sIntent(K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"})
+	dry.DryRun = true
+	issued, err = l.SignIntent(context.Background(), dry)
+	if err != nil || issued.K8sToken != "" || issued.Decision == nil || !issued.Decision.Allowed {
+		t.Errorf("dry-run: %+v, %v", issued, err)
+	}
+	if minter.cluster != "" {
+		t.Error("dry-run must not mint a token")
+	}
+	// Dry-run denial is a result, not an error (same contract as SSH).
+	dry.K8s = &K8sAction{Verb: "apply", Resource: "configmaps", Namespace: "p", Name: "x"}
+	dry.Command = dry.K8s.Canonical()
+	issued, err = l.SignIntent(context.Background(), dry)
+	if err != nil || issued.Decision == nil || issued.Decision.Allowed {
+		t.Errorf("dry-run denial: %+v, %v", issued, err)
+	}
+}
+
+func TestSignK8sBindingSelection(t *testing.T) {
+	t.Parallel()
+	cp := testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}})
+	cp.SABindings = []SABinding{{Groups: []string{"platform"}, Namespace: "agents", ServiceAccount: "sa-platform"}}
+	l := NewLocal(nil, nil, time.Minute).WithK8s(compileOne(t, cp), &fakeMinter{})
+
+	// The cluster group gate passes (nil groups = unrestricted), but no binding
+	// matches an identity-less caller when there is no default binding.
+	in := k8sIntent(K8sAction{Verb: "get", Resource: "pods", Namespace: "p", Name: "x"})
+	if _, err := l.SignIntent(context.Background(), in); err == nil || !strings.Contains(err.Error(), "sa_binding") {
+		t.Errorf("no matching binding must fail closed: %v", err)
+	}
+}
+
+func TestHostAllowlistActiveCoversClusters(t *testing.T) {
+	t.Parallel()
+	ct := compileOne(t, testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}}))
+	l := NewLocal(nil, PolicyTable{}, time.Minute).WithK8s(ct, &fakeMinter{})
+
+	exists, allowlist := l.HostAllowlistActive("prod-k8s")
+	if !exists || !allowlist {
+		t.Errorf("clusters must be grant-eligible (allowlist-active): exists=%v allowlist=%v", exists, allowlist)
+	}
+}

--- a/internal/signer/remote.go
+++ b/internal/signer/remote.go
@@ -31,7 +31,18 @@ type WireRequest struct {
 	SessionMode string `json:"session_mode,omitempty"` // exec|shell|pty for session intents
 	Command     string `json:"command,omitempty"`
 	TTLSeconds  int    `json:"ttl_seconds,omitempty"`
-	PublicKey   string `json:"public_key"` // authorized_keys line of the ephemeral pubkey
+	PublicKey   string `json:"public_key,omitempty"` // authorized_keys line of the ephemeral pubkey (SSH only)
+
+	// Kubernetes target. TargetType "k8s" selects the cluster path; the action
+	// fields are flat (no nested struct) to keep the wire simple, and Command
+	// carries the action's canonical string form (the signer recomputes it and
+	// rejects a mismatch). Absent/"ssh" = the SSH path (public_key required).
+	TargetType   string `json:"target_type,omitempty"`
+	K8sVerb      string `json:"k8s_verb,omitempty"`
+	K8sResource  string `json:"k8s_resource,omitempty"`
+	K8sGroup     string `json:"k8s_group,omitempty"`
+	K8sNamespace string `json:"k8s_namespace,omitempty"`
+	K8sName      string `json:"k8s_name,omitempty"`
 
 	// Elevation (sudo NOPASSWD).
 	Sudo     bool   `json:"sudo,omitempty"`
@@ -94,9 +105,47 @@ type WireResponse struct {
 	// ElevationPrefix is the prefix to prepend in persistent sessions.
 	// Empty in one-shot (the prefix is already in the cert's force-command).
 	ElevationPrefix string `json:"elevation_prefix,omitempty"`
+	// K8sToken is the short-lived bound ServiceAccount token minted for a
+	// Kubernetes intent (the k8s analogue of Certificate). K8sTokenExpiry is
+	// its RFC 3339 expiry.
+	K8sToken       string    `json:"k8s_token,omitempty"`
+	K8sTokenExpiry time.Time `json:"k8s_token_expiry,omitempty"`
 	// Decision is populated in dry-run (empty Certificate) and optionally in
 	// normal issuance for traceability.
 	Decision *DecisionInfo `json:"decision,omitempty"`
+}
+
+// WireClusterInfo is the connectivity data for a Kubernetes cluster returned
+// by GET /v1/clusters. Like WireHostInfo it carries only what the broker needs
+// to reach the API server (all public material — the CA PEM inlined from the
+// signer's ca_cert path); the token_file, SA bindings, and rules stay in the
+// signer.
+type WireClusterInfo struct {
+	APIServer      string        `json:"api_server"`
+	CACertPEM      string        `json:"ca_cert_pem"`
+	Groups         []string      `json:"groups,omitempty"`
+	ExtraResources []ResourceDef `json:"extra_resources,omitempty"`
+}
+
+// ResourceDef is the wire alias for a k8s resource definition, so the broker
+// can normalize an action's group against the same table the signer uses
+// without importing internal/k8s from the wire layer. Mirror of
+// k8s.ResourceDef.
+type ResourceDef struct {
+	Resource   string `json:"resource"`
+	Group      string `json:"group,omitempty"`
+	Version    string `json:"version"`
+	Kind       string `json:"kind"`
+	Namespaced bool   `json:"namespaced"`
+}
+
+// ClusterInfo is the broker's internal representation of a cluster's
+// connectivity data received from the signer.
+type ClusterInfo struct {
+	APIServer      string
+	CACertPEM      string
+	Groups         []string
+	ExtraResources []ResourceDef
 }
 
 // WireHostInfo contains the connectivity and capability data for a host as
@@ -160,14 +209,13 @@ func (r *Remote) SetApprovalWait(d time.Duration) { r.approvalWait = d }
 
 // SignIntent implements Signer against the remote service.
 func (r *Remote) SignIntent(ctx context.Context, in Intent) (*Issued, error) {
-	body, err := json.Marshal(WireRequest{
+	wr := WireRequest{
 		Host:          in.Host,
 		Role:          in.Role,
 		Purpose:       in.Purpose,
 		SessionMode:   in.SessionMode,
 		Command:       in.Command,
 		TTLSeconds:    int(in.RequestedTTL / time.Second),
-		PublicKey:     string(ssh.MarshalAuthorizedKey(in.PublicKey)),
 		Sudo:          in.Sudo,
 		SudoUser:      in.SudoUser,
 		PTY:           in.PTY,
@@ -182,7 +230,18 @@ func (r *Remote) SignIntent(ctx context.Context, in Intent) (*Issued, error) {
 		LearnTTLSeconds: in.LearnTTLSeconds,
 		LearnApprover:   in.LearnApprover,
 		LearnApprovalID: in.LearnApprovalID,
-	})
+	}
+	if in.TargetType == TargetTypeK8s && in.K8s != nil {
+		wr.TargetType = TargetTypeK8s
+		wr.K8sVerb = in.K8s.Verb
+		wr.K8sResource = in.K8s.Resource
+		wr.K8sGroup = in.K8s.Group
+		wr.K8sNamespace = in.K8s.Namespace
+		wr.K8sName = in.K8s.Name
+	} else if in.PublicKey != nil {
+		wr.PublicKey = string(ssh.MarshalAuthorizedKey(in.PublicKey))
+	}
+	body, err := json.Marshal(wr)
 	if err != nil {
 		return nil, err
 	}
@@ -219,9 +278,22 @@ func (r *Remote) SignIntent(ctx context.Context, in Intent) (*Issued, error) {
 		return nil, fmt.Errorf("signing rejected (%d): %s", resp.StatusCode, bytes.TrimSpace(rb))
 	}
 
-	var wr WireResponse
-	if err := json.Unmarshal(rb, &wr); err != nil {
+	var wresp WireResponse
+	if err := json.Unmarshal(rb, &wresp); err != nil {
 		return nil, fmt.Errorf("invalid response: %w", err)
+	}
+	return issuedFromWire(in, wresp)
+}
+
+// issuedFromWire builds an Issued from a WireResponse, handling the SSH
+// (certificate) and k8s (bound token) branches plus the decision-only cases
+// (dry-run and approval-required).
+func issuedFromWire(in Intent, wr WireResponse) (*Issued, error) {
+	if in.TargetType == TargetTypeK8s {
+		if in.DryRun || wr.K8sToken == "" {
+			return &Issued{Decision: wr.Decision}, nil
+		}
+		return &Issued{K8sToken: wr.K8sToken, K8sTokenExpiry: wr.K8sTokenExpiry, Serial: wr.Serial, Decision: wr.Decision}, nil
 	}
 	// Dry-run, or response without certificate (requires approval): decision only.
 	if in.DryRun || wr.Certificate == "" {
@@ -273,6 +345,11 @@ func (r *Remote) pollApproval(ctx context.Context, approvalID string) (*Issued, 
 			var wr WireResponse
 			if err := json.Unmarshal(rb, &wr); err != nil {
 				return nil, fmt.Errorf("invalid approval response: %w", err)
+			}
+			// The approval result carries whichever credential the target needs;
+			// dispatch on the response content (never a dry-run here).
+			if wr.K8sToken != "" {
+				return &Issued{K8sToken: wr.K8sToken, K8sTokenExpiry: wr.K8sTokenExpiry, Serial: wr.Serial, Decision: wr.Decision}, nil
 			}
 			if wr.Certificate == "" {
 				return &Issued{Decision: wr.Decision}, nil
@@ -336,6 +413,46 @@ func (r *Remote) FetchHosts(ctx context.Context, onBehalfOf string) (map[string]
 		}
 	}
 	return hosts, nil
+}
+
+// FetchClusters calls GET /v1/clusters on the signer and returns the
+// connectivity data for the Kubernetes clusters the caller may reach. Like
+// FetchHosts, onBehalfOf (when non-empty) is sent in X-On-Behalf-Of so the
+// signer filters by the original broker's groups (control plane use case).
+func (r *Remote) FetchClusters(ctx context.Context, onBehalfOf string) (map[string]ClusterInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.url+"/v1/clusters", nil)
+	if err != nil {
+		return nil, fmt.Errorf("building /v1/clusters request: %w", err)
+	}
+	if onBehalfOf != "" {
+		req.Header.Set(HeaderOnBehalfOf, onBehalfOf)
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching cluster list: %w", err)
+	}
+	defer resp.Body.Close()
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading /v1/clusters response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("signer returned %d: %s", resp.StatusCode, bytes.TrimSpace(rb))
+	}
+	var wire map[string]WireClusterInfo
+	if err := json.Unmarshal(rb, &wire); err != nil {
+		return nil, fmt.Errorf("invalid /v1/clusters response: %w", err)
+	}
+	clusters := make(map[string]ClusterInfo, len(wire))
+	for name, c := range wire {
+		clusters[name] = ClusterInfo{
+			APIServer:      c.APIServer,
+			CACertPEM:      c.CACertPEM,
+			Groups:         c.Groups,
+			ExtraResources: c.ExtraResources,
+		}
+	}
+	return clusters, nil
 }
 
 // ParseCertificate converts an authorized_keys line into an *ssh.Certificate.

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -47,8 +47,19 @@ var reValidUser = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,31}$`)
 // Intent is what the broker requests to sign. It contains no security
 // constraints — those are derived by the signer's policy.
 type Intent struct {
-	Caller       string // requester identity (mTLS CN in remote mode; "local" in local mode)
-	Host         string // logical host name
+	Caller string // requester identity (mTLS CN in remote mode; "local" in local mode)
+	Host   string // logical host name (or cluster name when TargetType is k8s)
+
+	// TargetType selects the target family: "" or "ssh" is an SSH host
+	// (backward compatible — every pre-k8s client sends nothing); "k8s" is a
+	// Kubernetes cluster, whose action travels in K8s and whose Command is the
+	// action's canonical string form.
+	TargetType string
+	// K8s is the structured Kubernetes action (TargetType "k8s" only). Command
+	// must equal K8s.Canonical(); the signer rejects any mismatch so the
+	// audited/approved string is provably what runs.
+	K8s *K8sAction
+
 	Role         string // RoleTarget | RoleBastion
 	Purpose      string // PurposeOneshot | PurposeSession
 	SessionMode  string // for PurposeSession: exec | shell | pty
@@ -118,6 +129,12 @@ type Intent struct {
 type Issued struct {
 	Certificate *ssh.Certificate
 	Serial      uint64
+
+	// K8sToken is the short-lived bound ServiceAccount token minted for a
+	// Kubernetes intent — the k8s analogue of Certificate (exactly one of the
+	// two is set on a successful issuance). K8sTokenExpiry is its expiry.
+	K8sToken       string
+	K8sTokenExpiry time.Time
 	// ElevationPrefix is the exact prefix to prepend to each command in persistent
 	// sessions (e.g. "sudo -n" or "sudo -n -u deploy"). Empty when there is no
 	// elevation or the purpose is one-shot (the prefix is already in ForceCommand).
@@ -807,7 +824,24 @@ type Local struct {
 	policy     PolicyTable
 	defaultTTL time.Duration
 	grants     GrantProvider // runtime widen-only grants; nil = none (fail-safe)
+
+	// Kubernetes target (optional): the compiled cluster table and the bound
+	// ServiceAccount token minter. nil = no k8s clusters configured.
+	clusters ClusterTable
+	minter   TokenMinter
 }
+
+// WithK8s attaches the compiled Kubernetes cluster table and its token minter
+// to the signer. Returns l for chaining at construction.
+func (l *Local) WithK8s(clusters ClusterTable, minter TokenMinter) *Local {
+	l.clusters = clusters
+	l.minter = minter
+	return l
+}
+
+// Clusters returns the compiled cluster table (nil when no k8s target is
+// configured). Read-only; used by the HTTP handlers.
+func (l *Local) Clusters() ClusterTable { return l.clusters }
 
 // NewLocal creates a local signer with a single CA key (backward compatible).
 func NewLocal(caKey ssh.Signer, policy PolicyTable, defaultTTL time.Duration) *Local {
@@ -835,11 +869,16 @@ func NewLocalWithGrants(defaultCA ssh.Signer, groupCAs map[string]ssh.Signer, po
 // allowlist-active — there a grant would be a no-op and, if injected, would
 // invert the host to default-deny (see PolicySet.decideOne).
 func (l *Local) HostAllowlistActive(host string) (exists, allowlist bool) {
-	hp, ok := l.policy[host]
-	if !ok {
-		return false, false
+	if hp, ok := l.policy[host]; ok {
+		return true, hp.effectivePolicies().hasAllowlist()
 	}
-	return true, hp.effectivePolicies().hasAllowlist()
+	// Clusters share the grant namespace with hosts (disjoint names, enforced
+	// at load) and are allowlist-active by construction (default-deny), so
+	// widen-only grants apply to them without a special case.
+	if cp, ok := l.clusters[host]; ok {
+		return true, cp.Policies.hasAllowlist()
+	}
+	return false, false
 }
 
 // caKeyFor returns the CA to use for the given host policy. The first group in
@@ -860,6 +899,9 @@ func (l *Local) caKeyFor(hp HostPolicy) ssh.Signer {
 // is returned. A policy denial in dry-run is a result (Allowed=false), not an
 // error; only configuration failures (invalid regex) return an error.
 func (l *Local) SignIntent(ctx context.Context, in Intent) (*Issued, error) {
+	if in.TargetType == TargetTypeK8s {
+		return l.signK8s(ctx, in)
+	}
 	d, err := l.policy.resolve(in, l.defaultTTL, l.grants)
 	if in.DryRun {
 		if err != nil {

--- a/lab/run_k8s_lab.sh
+++ b/lab/run_k8s_lab.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Laboratorio e2e del target Kubernetes (credential-broker). Sin cluster real:
+# un mock del API server en Go (TLS) responde TokenRequest, get/list/delete y
+# apply, registrando cada llamada. Verifica el flujo completo:
+#   1. get permitido → el broker acuña token (bound SA) y ejecuta la llamada.
+#   2. list con selector.
+#   3. delete gateado por aprobación → 202 → approve → ejecuta.
+#   4. verbo/recurso no permitido → denegado (default-deny).
+#   5. secrets denegado por regla deny aunque haya lectura permitida.
+#   6. la canónica aparece en la auditoría del signer y del broker; el manifest
+#      de apply NO aparece verbatim (solo body_sha256).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LAB="$ROOT/lab/work-k8s"
+SIGNER_PORT=9463
+CP_PORT=7463
+API_PORT=6443
+
+rm -rf "$LAB"; mkdir -p "$LAB/pki"
+P="$LAB/pki"
+
+echo "== 1. Mock del API server de Kubernetes (TLS) =="
+cat > "$LAB/mockapi.go" <<'GO'
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	logf, _ := os.Create(os.Args[3])
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		fmt.Fprintf(logf, "%s %s %s\n", r.Method, r.URL.Path, r.URL.RawQuery)
+		logf.Sync()
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/token") {
+			// TokenRequest response.
+			json.NewEncoder(w).Encode(map[string]any{
+				"status": map[string]any{
+					"token":               "bound-sa-token",
+					"expirationTimestamp": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339),
+				},
+			})
+			return
+		}
+		if len(body) > 0 {
+			fmt.Fprintf(logf, "  body-bytes=%d\n", len(body))
+			logf.Sync()
+		}
+		json.NewEncoder(w).Encode(map[string]any{"kind": "Result", "path": r.URL.Path})
+	})
+	srv := &http.Server{Addr: ":" + os.Args[1], Handler: mux}
+	if err := srv.ListenAndServeTLS(os.Args[2]+".crt", os.Args[2]+".key"); err != nil {
+		panic(err)
+	}
+}
+GO
+
+# TLS server cert for the mock API (SAN localhost/127.0.0.1).
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$P/api.key" -out "$P/api.crt" \
+  -days 1 -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
+printf 'minter-credential\n' > "$P/minter.token"
+
+echo "== 2. PKI mTLS (signer, control plane, broker-1, admin-1) =="
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$P/server_ca.key" -out "$P/server_ca.crt" \
+  -days 1 -subj "/CN=server-ca" >/dev/null 2>&1
+for srv in signer cp; do
+  openssl req -newkey rsa:2048 -nodes -keyout "$P/$srv.key" -out "$P/$srv.csr" -subj "/CN=localhost" >/dev/null 2>&1
+  openssl x509 -req -in "$P/$srv.csr" -CA "$P/server_ca.crt" -CAkey "$P/server_ca.key" \
+    -CAcreateserial -days 1 -out "$P/$srv.crt" \
+    -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1") >/dev/null 2>&1
+done
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$P/clients_ca.key" -out "$P/clients_ca.crt" \
+  -days 1 -subj "/CN=clients-ca" >/dev/null 2>&1
+for cn in broker-1 admin-1 cp-1; do
+  openssl req -newkey rsa:2048 -nodes -keyout "$P/$cn.key" -out "$P/$cn.csr" -subj "/CN=$cn" >/dev/null 2>&1
+  openssl x509 -req -in "$P/$cn.csr" -CA "$P/clients_ca.crt" -CAkey "$P/clients_ca.key" \
+    -CAcreateserial -days 1 -out "$P/$cn.crt" >/dev/null 2>&1
+done
+
+echo "== 3. signer.json con un cluster (default-deny; delete → require_approval) =="
+head -c 32 /dev/urandom > "$LAB/signer_audit.seed"
+# Minimal SSH CA so the signer starts (no hosts used in this lab).
+ssh-keygen -t ed25519 -N '' -f "$LAB/ssh_ca" >/dev/null
+cat > "$LAB/signer.json" <<EOF
+{
+  "listen": ":$SIGNER_PORT",
+  "server_cert": "$P/signer.crt", "server_key": "$P/signer.key", "client_ca": "$P/clients_ca.crt",
+  "ca_key": "$LAB/ssh_ca",
+  "audit_log": "$LAB/signer_audit.log", "audit_key": "$LAB/signer_audit.seed",
+  "max_ttl_seconds": 120,
+  "reload_callers": ["admin-1"],
+  "trusted_forwarders": ["cp-1"],
+  "hosts": {},
+  "kubernetes": {
+    "clusters": {
+      "lab-k8s": {
+        "api_server": "https://127.0.0.1:$API_PORT",
+        "ca_cert": "$P/api.crt",
+        "token_file": "$P/minter.token",
+        "token_ttl_seconds": 600,
+        "sa_bindings": [ { "namespace": "agents", "service_account": "broker-agent" } ],
+        "rules": [
+          { "verbs": ["get","list"], "resources": ["pods","deployments"], "effect": "allow" },
+          { "verbs": ["delete"], "resources": ["pods"], "namespaces": ["prod"], "effect": "require_approval" },
+          { "verbs": ["*"], "resources": ["secrets"], "effect": "deny" }
+        ]
+      }
+    }
+  }
+}
+EOF
+cat > "$LAB/cp.json" <<EOF
+{
+  "listen": ":$CP_PORT",
+  "server_cert": "$P/cp.crt", "server_key": "$P/cp.key", "client_ca": "$P/clients_ca.crt",
+  "signer": { "url": "https://localhost:$SIGNER_PORT", "client_cert": "$P/cp-1.crt", "client_key": "$P/cp-1.key", "ca": "$P/server_ca.crt" },
+  "approval": { "timeout_seconds": 120, "callers": ["admin-1"] },
+  "audit_log": "$LAB/cp_audit.log", "audit_key": "$(head -c 32 /dev/urandom > "$LAB/cp_audit.seed"; echo "$LAB/cp_audit.seed")"
+}
+EOF
+
+echo "== 4. Binarios + arranque =="
+( cd "$ROOT" && go build -o "$LAB/signer" ./cmd/signer && go build -o "$LAB/control-plane" ./cmd/control-plane && go build -o "$LAB/broker-ctl" ./cmd/broker-ctl )
+( cd "$LAB" && go run mockapi.go "$API_PORT" "$P/api" "$LAB/api.log" ) >"$LAB/mock.out" 2>&1 &
+API_PID=$!
+"$LAB/signer" -config "$LAB/signer.json" >"$LAB/signer.out" 2>&1 & SIGNER_PID=$!
+"$LAB/control-plane" -config "$LAB/cp.json" >"$LAB/cp.out" 2>&1 & CP_PID=$!
+trap 'kill "$API_PID" "$SIGNER_PID" "$CP_PID" 2>/dev/null || true' EXIT
+sleep 3
+
+CURL_BROKER=(curl -s --cert "$P/broker-1.crt" --key "$P/broker-1.key" --cacert "$P/server_ca.crt")
+CTL_CP=(env BROKER_CTL_CP_URL="localhost:$CP_PORT" BROKER_CTL_CP_CERT="$P/admin-1.crt" \
+    BROKER_CTL_CP_KEY="$P/admin-1.key" BROKER_CTL_CP_CA="$P/server_ca.crt" "$LAB/broker-ctl")
+
+k8s_sign() { # verb resource namespace name  → posts a k8s sign request to the control plane
+  local canonical="$1 $2 $3/$4"
+  "${CURL_BROKER[@]}" -X POST "https://localhost:$CP_PORT/v1/sign" -H 'Content-Type: application/json' \
+    -d "$(printf '{"target_type":"k8s","host":"lab-k8s","role":"target","purpose":"oneshot","command":"%s","k8s_verb":"%s","k8s_resource":"%s","k8s_namespace":"%s","k8s_name":"%s"}' "$canonical" "$1" "$2" "$3" "$4")"
+}
+
+echo "== 5. get pod permitido → token acuñado + llamada al API =="
+RESP="$(k8s_sign get pods prod web-1)"
+echo "$RESP" | grep -q 'bound-sa-token' && echo "   OK: token bound emitido" || { echo "FAIL: sin token: $RESP"; exit 1; }
+grep -q 'POST /api/v1/namespaces/agents/serviceaccounts/broker-agent/token' "$LAB/api.log" \
+  && echo "   OK: TokenRequest llamado" || { echo "FAIL: no hubo TokenRequest"; exit 1; }
+
+echo "== 6. delete gateado → 202 → approve → token =="
+RESP="$(k8s_sign delete pods prod web-1)"
+APPROVAL_ID="$(echo "$RESP" | sed -n 's/.*"approval_id":"\([^"]*\)".*/\1/p')"
+[ -n "$APPROVAL_ID" ] && echo "   OK: 202 approval $APPROVAL_ID" || { echo "FAIL: delete no gateado: $RESP"; exit 1; }
+"${CTL_CP[@]}" approval list | grep -q 'delete pods prod/web-1' \
+  && echo "   OK: el aprobador ve la acción canónica" || { echo "FAIL: canónica no visible"; exit 1; }
+"${CTL_CP[@]}" approval allow "$APPROVAL_ID" >/dev/null
+RESULT="$("${CURL_BROKER[@]}" "https://localhost:$CP_PORT/v1/sign/result/$APPROVAL_ID")"
+echo "$RESULT" | grep -q 'bound-sa-token' && echo "   OK: token tras aprobar" || { echo "FAIL: sin token tras aprobar: $RESULT"; exit 1; }
+
+# NOTE: this helper builds the canonical string without resolving the API
+# group, so the deny tests use CORE resources (no group) to avoid a canonical
+# mismatch masking the policy decision. The real MCP path resolves the group in
+# the broker before signing.
+echo "== 7. default-deny y deny-wins =="
+k8s_sign delete configmaps prod cfg | grep -qi 'not allowed\|denied' && echo "   OK: acción no permitida rechazada (default-deny)" || { echo "FAIL: delete configmaps debería denegarse"; exit 1; }
+k8s_sign get secrets prod db | grep -qi 'not allowed\|denied' && echo "   OK: secrets denegado (deny gana)" || { echo "FAIL: secrets debería denegarse"; exit 1; }
+
+echo "== 8. auditoría: canónica presente en el signer =="
+grep -q 'target=k8s action=get pods prod/web-1' "$LAB/signer_audit.log" \
+  && echo "   OK: canónica en el audit del signer" || { echo "FAIL: canónica ausente en el signer"; exit 1; }
+
+rm -rf "$LAB"
+echo "Lab k8s OK."

--- a/signer.example.json
+++ b/signer.example.json
@@ -119,5 +119,36 @@
       "max_ttl_seconds": 120,
       "groups": ["databases"]
     }
+  },
+
+  "_kubernetes_comment": "OPTIONAL Kubernetes target (credential-broker). Each cluster is DEFAULT-DENY: at least one allow/require_approval rule is required, and anything unmatched is refused. The broker never sees a cluster credential — the signer mints a short-lived bound ServiceAccount token per action and the cluster's native RBAC (layer B) enforces it. Setup: create a minter ServiceAccount whose ENTIRE RBAC is `create` on serviceaccounts/token for the SAs in sa_bindings, and put its token in token_file; create the agent SAs (broker-*) with the least-privilege Roles the agent needs. Cluster names must be DISJOINT from host names above (grants and audit are indexed by that shared name). Absent = SSH-only signer.",
+  "kubernetes": {
+    "clusters": {
+      "prod-k8s": {
+        "api_server": "https://10.0.0.5:6443",
+        "ca_cert": "pki/prod-k8s-ca.crt",
+        "_token_file_comment": "The minter credential: a ServiceAccount token whose only RBAC is create on serviceaccounts/token for the SAs below. Rotate it out-of-band; the signer re-reads it per mint.",
+        "token_file": "pki/prod-k8s-minter.token",
+        "_token_ttl_comment": "Bound-token lifetime in seconds. Range [600, 900] (TokenRequest refuses less than 600); default 600.",
+        "token_ttl_seconds": 600,
+        "groups": ["platform"],
+        "_sa_bindings_comment": "Map end-user groups → the ServiceAccount whose bound token is minted for them (layer-B RBAC). Evaluated in order; the first group-intersecting binding wins; a binding with empty groups is the default and matches any caller (including identity-less stdio/mTLS).",
+        "sa_bindings": [
+          { "groups": ["platform"], "namespace": "agents", "service_account": "broker-platform" },
+          { "namespace": "agents", "service_account": "broker-readonly" }
+        ],
+        "_rules_comment": "Structured ActionPolicy, compiled to the same firewall machinery as command_policy (deny wins; grants/approve-and-learn/recommend all apply). Each rule matches on verbs/resources/namespaces/names (omitted or '*' = any). effect: allow | deny | require_approval (require_approval implies allow, gated behind human approval). NOTE: leaving 'secrets' out of every allow rule keeps it default-denied — recommended.",
+        "rules": [
+          { "verbs": ["get", "list", "logs"], "resources": ["pods", "deployments", "services", "configmaps", "events"], "effect": "allow" },
+          { "verbs": ["apply"], "resources": ["deployments"], "namespaces": ["staging"], "effect": "allow" },
+          { "verbs": ["delete", "apply"], "resources": ["deployments", "pods"], "namespaces": ["prod"], "effect": "require_approval" },
+          { "verbs": ["*"], "resources": ["secrets"], "effect": "deny" }
+        ],
+        "_extra_resources_comment": "OPTIONAL: extend the curated core resource table with CRDs (no API discovery — explicit and reviewable). Each needs resource (plural), group, version, kind, namespaced.",
+        "extra_resources": [
+          { "resource": "certificates", "group": "cert-manager.io", "version": "v1", "kind": "Certificate", "namespaced": true }
+        ]
+      }
+    }
   }
 }

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -162,7 +162,8 @@ func genMCPTools() string {
 
 	ctx := context.Background()
 	srv := mcp.NewServer(&mcp.Implementation{Name: "ssh-broker", Version: "docgen"}, nil)
-	mcpserver.Register(srv, nil, nil) // handlers are not invoked during registration
+	mcpserver.Register(srv, nil, nil)    // handlers are not invoked during registration
+	mcpserver.RegisterK8s(srv, nil, nil) // document the k8s family unconditionally
 	st, ct := mcp.NewInMemoryTransports()
 	if _, err := srv.Connect(ctx, st, nil); err != nil {
 		fatal(fmt.Errorf("server connect: %w", err))
@@ -240,6 +241,10 @@ var configStructs = []struct{ file, name, title string }{
 	{"internal/signer/cmdpolicy.go", "CommandPolicy", "Command policy (`command_policy`)"},
 	{"internal/redact/redact.go", "Config", "Secret redaction (`redact`, all three services)"},
 	{"internal/redact/redact.go", "Pattern", "Redaction pattern (`redact.patterns[]`)"},
+	{"internal/signer/k8spolicy.go", "ClusterPolicy", "Kubernetes cluster policy (`kubernetes.clusters.<name>`)"},
+	{"internal/signer/k8spolicy.go", "SABinding", "Kubernetes SA binding (`kubernetes.clusters.<name>.sa_bindings[]`)"},
+	{"internal/signer/k8spolicy.go", "K8sRule", "Kubernetes action rule (`kubernetes.clusters.<name>.rules[]`)"},
+	{"internal/k8s/resources.go", "ResourceDef", "Kubernetes resource (`kubernetes.clusters.<name>.extra_resources[]`)"},
 }
 
 var enumDecls = []struct{ file, title string }{


### PR DESCRIPTION
Adds a **Kubernetes target** to the broker, reusing the entire control plane (identity, RBAC, approval, grants, signed audit) with a structured action grammar instead of the shell one. Posture is **credential-broker**, same as SSH: the signer mints a short-lived, scoped credential and steps out of the data path — the agent never holds a cluster credential.

## What
- **Canonical action grammar** (`internal/signer/k8saction.go`): `<verb> <resource[.group]> <namespace>/<name>`, built from charset-validated fields (never parsed → injection-free). It feeds the policy, the audit `command`, the approval flow, and grants/waivers — all grammar-neutral string matchers.
- **Per-cluster default-deny ActionPolicy** (`internal/signer/k8spolicy.go`): structured `{verbs, resources, namespaces, names, effect}` rules compile at load into the **same `PolicySet`** as `command_policy`, so deny-wins composition, runtime grants, approve-and-learn waivers, and `policy recommend` apply to k8s **unchanged**. The broker sends the structured fields **and** the canonical string; the signer recomputes it and rejects a mismatch (anti-mismatch: approver/audit see what runs).
- **Bound ServiceAccount tokens**: the signer holds one minimal-privilege minter per cluster (`token_file`; RBAC = `create` on `serviceaccounts/token`), calls TokenRequest to mint a bound token (TTL 600–900s) for the SA chosen by the end user's groups (`sa_bindings`), and returns it over the existing mTLS channel like an SSH cert.
- **Dependency-free client** (`internal/k8s`): five verbs + TokenRequest as plain REST over `net/http` (no client-go), CA-pinned, curated core resource table + per-cluster `extra_resources`.
- **6 curated MCP tools** registered only when a cluster is visible: `k8s_list_clusters`, `k8s_get`, `k8s_list`, `k8s_logs` (read), `k8s_apply`, `k8s_delete` (mutating, policy/approval-gated). No pod-exec/port-forward/sessions in this phase.
- **Config/endpoints**: `kubernetes.clusters.<name>` in `signer.json` (names disjoint from hosts — grants/audit share the name), `GET /v1/clusters` (forwarded by the control plane), `broker-ctl cluster list --remote`. `audit.Entry` += `target_type`/`body_sha256` (a k8s_apply manifest is never logged verbatim).

## Security
THREAT_MODEL gap #10 documents the structural trade: a bound token grants the SA's whole RBAC for its TTL, not one call (no `force-command` equivalent). Layer A (broker action policy) bounds what the broker *requests*; layer B (the SA's native RBAC) is what the token *grants* — scope agent SAs to least privilege. The minter credential is deliberately minimal.

## Verification
- Unit/integration: canonical grammar (incl. injection-rejection), REST client paths/auth/TLS-pinning + minter, cluster policy (default-deny, deny-wins, require_approval, grants/waivers, RBAC, SSH-knob rejection, canonical mismatch), broker K8sExecute (happy path, group normalization, denied, approval gate, dry-run, apply body-hash audit), control-plane forward + k8s approval flow + `/v1/clusters` forward.
- E2e: `lab/run_k8s_lab.sh` (mock API server, no cluster) — mints a bound token for an allowed action, gates a delete behind approval and issues the token after approval, enforces default-deny and deny-wins, and checks the canonical action in the audit log. All green.
- `go vet` + `go test -race ./...` clean; docs-check gate (docgen + example-config validation) passes. No new module dependencies (k8s uses only stdlib).