### PR TITLE
fix: k8s signer audit token forgery via unvalidated req.Command (#67)

### DIFF
--- a/cmd/signer/k8s.go
+++ b/cmd/signer/k8s.go
@@ -89,8 +89,12 @@ func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer
 	})
 }
 
-// auditK8s records a k8s issuance decision. The canonical action is the
-// Command; the api_server is the audited Host. A k8s_apply manifest is never
+// auditK8s records a k8s issuance decision. The api_server is the audited
+// Host. The action is written from the STRUCTURED, token-safe req.K8s* fields
+// (validated in handleSign) rather than the free-form req.Command, so a
+// crafted command cannot splice forged key=value tokens into the signed,
+// space-separated token stream on the denial paths (where req.Command has not
+// yet been checked against the canonical). A k8s_apply manifest is never
 // logged verbatim (it can carry a Secret) — its sha256 rides in body_sha256,
 // added by the broker's execution entry, not here.
 func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, outcome string, dec *signer.DecisionInfo, err error) {
@@ -99,7 +103,18 @@ func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, 
 	if cp, ok := s.currentClusters()[req.Host]; ok {
 		host = cp.APIServer
 	}
-	cmd := "target=k8s action=" + req.Command
+	resource := req.K8sResource
+	if req.K8sGroup != "" {
+		resource += "." + req.K8sGroup
+	}
+	ns, name := req.K8sNamespace, req.K8sName
+	if ns == "" {
+		ns = "-"
+	}
+	if name == "" {
+		name = "-"
+	}
+	cmd := "target=k8s verb=" + req.K8sVerb + " resource=" + resource + " ns=" + ns + " name=" + name
 	if req.EndUser != "" {
 		cmd += " user=" + req.EndUser
 	}

--- a/cmd/signer/k8s_audit_test.go
+++ b/cmd/signer/k8s_audit_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luisgf/ssh-broker/internal/audit"
+	"github.com/luisgf/ssh-broker/internal/signer"
+)
+
+// auditSeed is the fixed all-zero seed used by the signer audit tests.
+func auditSeed() ed25519.PrivateKey { return ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize)) }
+
+// TestAuditK8sKeepsCraftedCommandOutOfTokenStream is the regression test for
+// the k8s audit token-forgery gap: auditK8s must build the signed, space-
+// separated key=value stream from the STRUCTURED k8s fields, never from the
+// free-form req.Command (which a broker can craft with forged tokens and which,
+// on the denial paths, has not been checked against the canonical).
+func TestAuditK8sKeepsCraftedCommandOutOfTokenStream(t *testing.T) {
+	t.Parallel()
+	auditPath := filepath.Join(t.TempDir(), "audit.log")
+	al, err := audit.Open(auditPath, auditSeed())
+	if err != nil {
+		t.Fatalf("audit.Open: %v", err)
+	}
+	// A captureLocalSigner has no clusters, so the request hits the unknown-
+	// cluster denial path — where req.Command is unvalidated. The k8s fields are
+	// clean, so the token-char gate lets the request reach that path.
+	srv := &server{local: &captureLocalSigner{}, audit: al}
+
+	rec := httptest.NewRecorder()
+	srv.handleSign(rec, signRequestAs(t, "broker-1", signer.WireRequest{
+		TargetType:   signer.TargetTypeK8s,
+		Host:         "ghost",
+		Role:         signer.RoleTarget,
+		Purpose:      signer.PurposeOneshot,
+		K8sVerb:      "get",
+		K8sResource:  "pods",
+		K8sNamespace: "p",
+		K8sName:      "x",
+		// Crafted: legitimate canonical spaces plus forged key=value tokens.
+		Command: "get pods p/x user=victim elev=sudo:root pty=1",
+	}))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unknown cluster must be 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	al.Close()
+
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var e audit.Entry
+	if err := json.Unmarshal(bytes.TrimSpace(data), &e); err != nil {
+		t.Fatalf("parse audit line: %v", err)
+	}
+	if e.Command != "target=k8s verb=get resource=pods ns=p name=x" {
+		t.Errorf("Command = %q, want the structured token stream", e.Command)
+	}
+	for _, forged := range []string{"user=victim", "elev=sudo:root", "pty=1"} {
+		if strings.Contains(e.Command, forged) {
+			t.Errorf("forged token %q leaked into the audit Command: %q", forged, e.Command)
+		}
+	}
+}
+
+// TestHandleSignRejectsUnsafeK8sFields verifies the token-char gate now covers
+// the k8s_* fields, so a crafted field cannot reach any auditK8s call.
+func TestHandleSignRejectsUnsafeK8sFields(t *testing.T) {
+	t.Parallel()
+	fields := []struct {
+		name string
+		mut  func(*signer.WireRequest)
+	}{
+		{"k8s_verb", func(r *signer.WireRequest) { r.K8sVerb = "get x=1" }},
+		{"k8s_resource", func(r *signer.WireRequest) { r.K8sResource = "pods y=2" }},
+		{"k8s_group", func(r *signer.WireRequest) { r.K8sGroup = "apps z=3" }},
+		{"k8s_namespace", func(r *signer.WireRequest) { r.K8sNamespace = "p q=4" }},
+		{"k8s_name", func(r *signer.WireRequest) { r.K8sName = "x\nelev=sudo" }},
+	}
+	for _, f := range fields {
+		t.Run(f.name, func(t *testing.T) {
+			t.Parallel()
+			al, err := audit.Open(filepath.Join(t.TempDir(), "audit.log"), auditSeed())
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { al.Close() })
+			srv := &server{local: &captureLocalSigner{}, audit: al}
+			req := signer.WireRequest{
+				TargetType: signer.TargetTypeK8s, Host: "ghost",
+				Role: signer.RoleTarget, Purpose: signer.PurposeOneshot,
+				K8sVerb: "get", K8sResource: "pods", K8sNamespace: "p", K8sName: "x",
+			}
+			f.mut(&req)
+			rec := httptest.NewRecorder()
+			srv.handleSign(rec, signRequestAs(t, "broker-1", req))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("unsafe %s must be rejected 400, got %d: %s", f.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -518,9 +518,16 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// error, or issued paths — including session_mode, which authorizeIntent does
 	// not whitespace-check on the one-shot issued path. Uses the same predicate as
 	// authorizeIntent's KeyID gate so the two cannot drift.
+	// The k8s_* fields are added here too: auditK8s builds the k8s audit record
+	// as a space-separated key=value stream from these structured fields (never
+	// from the free-form req.Command, which the client can craft with forged
+	// tokens). Validating them here, before any auditK8s on the k8s denial
+	// paths, keeps the stream unambiguous and unforgeable.
 	for _, f := range []struct{ name, val string }{
 		{"end_user", req.EndUser}, {"role", req.Role}, {"purpose", req.Purpose},
 		{"session_mode", req.SessionMode}, {"sudo_user", req.SudoUser},
+		{"k8s_verb", req.K8sVerb}, {"k8s_resource", req.K8sResource}, {"k8s_group", req.K8sGroup},
+		{"k8s_namespace", req.K8sNamespace}, {"k8s_name", req.K8sName},
 	} {
 		if signer.HasUnsafeTokenChar(f.val) {
 			http.Error(w, "invalid "+f.name+": control or whitespace characters not allowed", http.StatusBadRequest)


### PR DESCRIPTION
Closes #67.

## Problem
`auditK8s` built the signed audit record's `Command` as a space-separated key=value token stream (`target=k8s action=<req.Command> user=<end_user>`). `req.Command` is broker-controlled and, on the k8s denial paths (unknown cluster, cluster-not-authorised, SignIntent error), had not yet been checked against the canonical action — so a compromised/semi-trusted broker could splice forged `user=`/`elev=`/`pty=` tokens into the tamper-evident signer log. Same class as the closed #13/#16 SSH-path forgeries.

## Fix
- Build the audit action from the structured, token-safe `req.K8s*` fields (`verb=.. resource=..[.group] ns=.. name=..`) instead of the free-form `req.Command`.
- Add `k8s_verb/k8s_resource/k8s_group/k8s_namespace/k8s_name` to the `handleSign` token-char gate, so they are validated (no whitespace/control chars) before any `auditK8s` call.

## Tests
- `TestAuditK8sKeepsCraftedCommandOutOfTokenStream`: a crafted `req.Command` with forged tokens hits the unknown-cluster denial path and does **not** appear in the audit line.
- `TestHandleSignRejectsUnsafeK8sFields`: an unsafe `k8s_*` field is rejected 400.

Verified: gofmt, go vet, go build, go test -race — all pass.