### PR TITLE
docs: regenerate config reference — fix stale config.md / red Docs CI (#74)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -267,7 +267,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `resource` | `string` | Resource is the lowercase plural name used in tool calls, policy rules, and REST paths (e.g. "deployments"). |
 | `group` | `string` | Group is the API group; empty = core ("" → /api/v1, else /apis/<group>). |
 | `version` | `string` | Version is the served API version (e.g. "v1"). |
-| `kind` | `string` | Kind is the manifest kind (e.g. "Deployment"), used to resolve a k8s_apply manifest to its resource. |
+| `kind` | `string` | Kind is the manifest kind (e.g. "Deployment") — descriptive metadata for the resource entry; required so an extra_resources declaration is self-documenting. |
 | `namespaced` | `bool` | Namespaced marks namespace-scoped resources. |
 
 ## Vocabulary (enumerated constants)


### PR DESCRIPTION
Closes #74.

The ResolveKind removal (#68 / PR #71) edited the `internal/k8s` `ResourceDef.Kind` doc comment **without** running `make docs-gen`, leaving `docs/reference/config.md` stale. The anti-drift gate in `.github/workflows/docs.yml` (job `check`) has been **failing on every push/PR since PR #71** — the docs `check` is non-blocking, so #71/#72/#73 merged over a red Docs workflow. The stale line also made a factually wrong claim (Kind is *not* used to resolve a manifest; resolution uses the resource name via `k8s.Resolve`).

Regenerated `docs/reference/config.md` (one-line change) → Docs workflow green again.

Verified: `go run ./tools/docgen` (idempotent, no residual drift), ExampleConfig tests, `mkdocs build --strict`.