### PR TITLE
fix: drop the dead force parameter from k8s Client.Apply (#75)

### DIFF
--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -158,7 +158,7 @@ func runK8sAction(ctx context.Context, client *k8s.Client, def k8s.ResourceDef, 
 		if len(manifest) == 0 {
 			return "", fmt.Errorf("k8s apply requires a manifest")
 		}
-		return client.Apply(ctx, def, a.Namespace, a.Name, manifest, false)
+		return client.Apply(ctx, def, a.Namespace, a.Name, manifest)
 	default:
 		return "", fmt.Errorf("unsupported k8s verb %q", a.Verb)
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -201,16 +201,13 @@ func (c *Client) Delete(ctx context.Context, def ResourceDef, namespace, name st
 	return out, err
 }
 
-// Apply performs a server-side apply (create-or-update) of a JSON manifest.
-// The API server enforces that the manifest's metadata matches the path, and
-// conflicts with other field managers fail unless the operator opted into
-// force at the tool level.
-func (c *Client) Apply(ctx context.Context, def ResourceDef, namespace, name string, manifest []byte, force bool) (string, error) {
+// Apply performs a server-side apply (create-or-update) of a JSON manifest as
+// fieldManager=ssh-broker. The API server enforces that the manifest's
+// metadata matches the path; a field-manager conflict fails the apply (there
+// is no force override — the broker never overwrites another manager's fields).
+func (c *Client) Apply(ctx context.Context, def ResourceDef, namespace, name string, manifest []byte) (string, error) {
 	q := url.Values{}
 	q.Set("fieldManager", FieldManager)
-	if force {
-		q.Set("force", "true")
-	}
 	out, _, err := c.do(ctx, http.MethodPatch, resourcePath(def, namespace, name), q,
 		"application/apply-patch+yaml", manifest, apiMaxBytes)
 	return out, err

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -135,7 +135,7 @@ func TestClientApply(t *testing.T) {
 	c := f.client(t)
 	manifest := []byte(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","namespace":"prod"}}`)
 
-	if _, err := c.Apply(context.Background(), mustDef(t, "deployments"), "prod", "api", manifest, false); err != nil {
+	if _, err := c.Apply(context.Background(), mustDef(t, "deployments"), "prod", "api", manifest); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if f.lastReq.Method != http.MethodPatch {


### PR DESCRIPTION
Closes #75.

`Client.Apply` took a `force bool` the only caller (`runK8sAction`) always passed as `false`; no MCP tool or `K8sExecuteOpts` exposed it, and the comment described a non-existent 'force at the tool level' override. Removed the dead parameter + query wiring, corrected the comment (fieldManager=ssh-broker; a field-manager conflict fails the apply, no force override), and updated the two call sites.

Verified: gofmt, go vet, go build, go test -race (k8s, broker).