### PR TITLE
fix: close the untracked-file hole in the docs anti-drift gate, add make verify

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -153,14 +153,14 @@ cluster RBAC. Audit these with the same rigor as the SSH path:
 
 - **STEP 5 — VERIFY (all must pass before committing):**
   ```
-  gofmt -l .        # must print nothing
-  go vet ./...
-  go build ./...
-  go test -race ./...
-  make docs-gen     # FIRST when routes/tools/config/CLI changed — docs-check only DETECTS drift
-  make docs-check   # only when docs/config/routes/tools changed
+  make verify       # gofmt + vet + build + race tests + docs gate (docs-gen,
+                    # drift incl. untracked files, example configs, strict site)
   ```
-  On failure, fix forward; never commit a red tree.
+  `verify` regenerates `docs/reference/` first: if that changes files, COMMIT
+  the regenerated files with the fix (the gate only DETECTS drift). On failure,
+  fix forward; never commit a red tree. `build`/`govulncheck`/`check` are
+  required status checks on `main` — a red gate blocks the merge; NEVER use
+  `gh pr merge --admin` to bypass it for an audit fix.
 
 - **STEP 6 — COMMIT (linked):** one logical fix per commit. Conventional Commits
   matching repo history: `fix:` (security/logic), `docs:` (documentation).

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,11 @@ jobs:
       - name: Regenerate reference and check for drift
         run: |
           go run ./tools/docgen
-          if ! git diff --exit-code docs/reference; then
+          # git status --porcelain (not git diff): a NEW generated file that was
+          # never committed is drift too — git diff only reports tracked changes.
+          if [ -n "$(git status --porcelain docs/reference)" ]; then
+            git status --porcelain docs/reference
+            git --no-pager diff docs/reference
             echo "::error::docs/reference is stale — run 'make docs-gen' and commit the result."
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@
 #   make version       # print the version that would be embedded
 #   make dist          # release tarball: binaries + deploy/ + example configs
 #   make docs-gen      # regenerate docs/reference/ from code
-#   make docs-check    # gen + drift checks + strict site build (CI gate, run before pushing)
+#   make docs-check    # gen + drift checks + strict site build (CI gate)
 #   make docs-serve    # live-preview the site at 127.0.0.1:8000
+#   make verify        # full pre-push gate: fmt + vet + build + race tests + docs-check
 
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 PKG     := github.com/luisgf/ssh-broker/internal/version
@@ -20,7 +21,7 @@ CMDS    := signer broker broker-ctl mcp-broker mcp-broker-http control-plane
 # MkDocs runner: prefer a local mkdocs, else fall back to `python3 -m mkdocs`.
 MKDOCS  ?= $(shell command -v mkdocs 2>/dev/null || echo "python3 -m mkdocs")
 
-.PHONY: build install $(CMDS) test fmt vet version clean dist docs docs-gen docs-serve docs-check
+.PHONY: build install $(CMDS) test fmt vet version clean dist docs docs-gen docs-serve docs-check verify
 
 build: $(CMDS)
 install: build
@@ -72,13 +73,33 @@ docs: docs-gen
 
 # Full anti-drift gate (what CI runs): regenerate the reference and fail if it
 # differs from what's committed; validate the example configs against the structs;
-# build the site strictly.
+# build the site strictly. `git status --porcelain` (not `git diff`) so a NEW
+# generated file that was never committed is drift too, not a silent pass.
 docs-check: docs-gen
-	@git diff --exit-code docs/reference \
-	  || { echo "docs/reference is stale — commit the regenerated files (make docs-gen)"; exit 1; }
+	@stale="$$(git status --porcelain docs/reference)"; \
+	  if [ -n "$$stale" ]; then \
+	    echo "docs/reference is stale — commit the regenerated files (make docs-gen):"; \
+	    echo "$$stale"; \
+	    git --no-pager diff docs/reference; \
+	    exit 1; \
+	  fi
 	go test ./cmd/signer/ ./cmd/control-plane/ ./cmd/broker-ctl/ ./internal/broker/ -run ExampleConfig
 	$(MKDOCS) build --strict
 
 # Live preview at http://127.0.0.1:8000 (regenerates first).
 docs-serve: docs-gen
 	$(MKDOCS) serve
+
+# ── Pre-push gate ──────────────────────────────────────────────────────────────
+
+# Everything the required CI checks run (go.yml build + docs.yml check), in one
+# shot. Green here means the PR merges; a red tree never leaves the machine.
+verify:
+	@unformatted="$$(gofmt -l .)"; \
+	  if [ -n "$$unformatted" ]; then \
+	    echo "These files are not gofmt-clean:"; echo "$$unformatted"; exit 1; \
+	  fi
+	go vet ./...
+	go build ./...
+	go test -race ./...
+	$(MAKE) docs-check

--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -295,7 +295,8 @@ in the same commit.
 
 ## Quick reference checklist
 
-Before opening a PR or pushing to `main`:
+Before opening a PR or pushing to `main` — `make verify` runs the mechanical
+checks (fmt, vet, build, race tests, and the docs anti-drift gate) in one shot:
 
 ```
 [ ] gofmt -l . → no output

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,8 +67,15 @@ code. Two layers keep them honest:
 - **Strict build** — `mkdocs build --strict` fails on a broken internal link or a
   renamed anchor, and the example configs are validated against the Go structs.
 
-Run **`make docs-check`** before pushing (it runs the whole gate locally), or
-`make docs-serve` to preview.
+Run **`make verify`** before pushing — it runs the whole mechanical gate locally
+(gofmt, vet, build, race tests, and this docs gate; the site build needs
+`pip install -r requirements-docs.txt` once). `make docs-check` runs the docs
+gate alone; `make docs-serve` previews the site.
+
+These are not advisory: the `build`, `govulncheck` and `check` workflow jobs are
+**required status checks** on the protected `main` branch, so a red gate blocks
+the merge. (`gh pr merge --admin` exists as an explicit emergency bypass — do
+not use it to skip a failing gate.)
 
 ### Mandatory pre-commit checklist (living docs)
 
@@ -118,7 +125,8 @@ commit.
 
 ## Plan of work for each commit
 
-Quick checklist (from [CODING_STYLE.md](CODING_STYLE.md)):
+Quick checklist (from [CODING_STYLE.md](CODING_STYLE.md)); `make verify` runs
+the mechanical ones — fmt, vet, build, race tests, docs gate — in one shot:
 
 ```
 [ ] gofmt -l . → no output


### PR DESCRIPTION
## Why

The docs anti-drift mechanism detected drift fine but nothing **enforced** it — the failure mode behind #74, where three PRs merged over a red Docs workflow. And the detection itself had a hole: `git diff --exit-code docs/reference` only reports changes to tracked files, so a NEW generated reference page that was never committed would pass the gate silently.

## What

- **docs.yml `check` + `make docs-check`**: drift detection switched to `git status --porcelain docs/reference`, which also flags untracked files; on failure both print the offending paths and the diff.
- **`make verify`**: one-shot local pre-push gate mirroring the required CI checks — gofmt-clean, `go vet`, build, `go test -race`, full docs gate.
- **CONTRIBUTING.md / CODING_STYLE.md / audit skill STEP 5**: point at `make verify`; document that a red gate now blocks the merge.
- **Repo settings (already applied, not in this diff)**: `build`, `govulncheck` and `check` are now **required status checks** on the protected `main` branch (`enforce_admins=false`, so `gh pr merge --admin` remains as an explicit emergency bypass).

No runtime behavior change (Makefile/CI/docs/skill only), hence no CHANGELOG entry.

## Verified

- Negative test: an untracked `docs/reference/phantom.md` now fails `make docs-check` with the `??` path printed — it passed silently before.
- `make verify` green end to end (docs-gen idempotent, example configs validated, `mkdocs build --strict` OK).
- This PR itself merges under the new required checks.