### PR TITLE
feat: privilege separation in deploy — one system user per service

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -65,8 +65,9 @@ Run from the repo:
     (`host list --remote`) gets 403 — only local SIGHUP remains.
   - `sign_rate_limit_per_min` set (> 0).
   - `monitor_listen` bound to localhost/private interface, never public.
-  - Cert/key paths are ABSOLUTE (`/etc/ssh-broker/pki/...`); a relative
-    `audit_log` is fine (lands in `/var/lib/ssh-broker/<svc>/`).
+  - Cert/key paths are ABSOLUTE and point into the service's OWN pki subdir
+    (`/etc/ssh-broker/pki/<svc>/...`); a relative `audit_log` is fine (lands
+    in `/var/lib/ssh-broker/<svc>/`).
   - Every host with `"jump"` shares a group with its bastion.
   - `/etc/ssh-broker/broker-ctl.json` (client parameters) points `signer.url`
     at the real signer and cert/key/ca at the real PKI, with a cert whose CN
@@ -89,10 +90,19 @@ sudo ./deploy/install.sh [--services "..."]
 
 Idempotent; never overwrites an existing real config. On a fresh install, edit
 the seeded configs (`/var/lib/ssh-broker/signer/signer.json` for the signer,
-`/etc/ssh-broker/*.json` for the rest) and place the mTLS PKI before starting. That
-includes the seeded `/etc/ssh-broker/broker-ctl.json`: point its `signer` /
+`/etc/ssh-broker/*.json` for the rest) and place the mTLS PKI before starting:
+each service's cert+key in ITS subdir `/etc/ssh-broker/pki/<svc>/`
+(`0640 root:ssh-broker-<svc>`), the shared `mtls_ca.crt` at the `pki/` root,
+admin CLI material in `pki/admin/` (root-only). Services run as per-service
+users (`ssh-broker-<svc>`) — privilege separation, see `deploy/README.md`.
+That includes the seeded `/etc/ssh-broker/broker-ctl.json`: point its `signer` /
 `control_plane` sections at the installed PKI so the admin CLI needs no
 flags (precedence: flag > `BROKER_CTL_*` env > file > default).
+
+**Upgrade from ≤ v1.34 (single-user layout):** the installer converges users,
+state-dir and config ownership automatically, and WARNS about private keys
+still flat under `pki/` — those must be moved into the per-service subdirs and
+the config paths updated before restarting (see `deploy/README.md` §Upgrades).
 
 ## 4. Start / apply
 

--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -46,12 +46,27 @@ override). Backends supported by the code (`internal/ca/loader.go`):
 If the user hasn't stated a preference, ask which backend to use, presenting
 exactly this trade-off.
 
+## 1b. Kubernetes target (only if `kubernetes.clusters` is configured)
+
+The per-cluster minter credential (`token_file`) is the signer's **only
+standing cluster credential** — treat it like the CA key:
+
+- Lives under the signer's state dir (e.g.
+  `/var/lib/ssh-broker/signer/pki/<cluster>-minter.token`), `0600`, owned by
+  `ssh-broker-signer`. Never under the shared `/etc/ssh-broker/pki` root.
+- Its RBAC in the cluster must be minimal: `create` on
+  `serviceaccounts/token` for the bound SAs only. If the user hands you a
+  broader credential, flag it before deploying.
+- Cluster names must stay disjoint from host names (the signer refuses
+  otherwise); every cluster is default-deny until it has ≥1 allow rule and an
+  `sa_bindings` entry.
+
 ## 2. Preflight (before touching the target)
 
 Run from the repo:
 
-- `make test` and `make docs-check` pass (docs-check also validates the
-  example configs against the structs).
+- `make verify` passes (gofmt, vet, build, race tests, and the full docs gate
+  including the example-config validation).
 - `make version` — confirm the tag you are about to ship; a `-dirty` suffix
   means uncommitted changes: stop and ask.
 - Review the real config that will run for production posture (the signer
@@ -65,6 +80,12 @@ Run from the repo:
     (`host list --remote`) gets 403 — only local SIGHUP remains.
   - `sign_rate_limit_per_min` set (> 0).
   - `monitor_listen` bound to localhost/private interface, never public.
+  - `state_db` set in `signer.json` and `control-plane.json`
+    (`/var/lib/ssh-broker/<svc>/state.db`) so grants/waivers and pending
+    approvals survive restarts. Its absence is not an error, but changes the
+    restart trade-offs in step 4 — say so.
+  - `redact` block present in the three configs (secrets in commands masked in
+    audit logs, recordings, notifications).
   - Cert/key paths are ABSOLUTE and point into the service's OWN pki subdir
     (`/etc/ssh-broker/pki/<svc>/...`); a relative `audit_log` is fine (lands
     in `/var/lib/ssh-broker/<svc>/`).
@@ -77,7 +98,9 @@ Run from the repo:
   `broker-ctl host list --remote > /tmp/policy-before.txt` — and diff it
   against the same command after the upgrade. An unexpected delta means the
   config file that shipped does not match what was really running (e.g.
-  un-persisted mutations or a stale file).
+  un-persisted mutations or a stale file). If `state_db` is configured, back
+  up each `state.db` **with its `-wal`/`-shm` sidecars** before replacing
+  binaries.
 
 ## 3. Install
 
@@ -113,13 +136,25 @@ the config paths updated before restarting (see `deploy/README.md` §Upgrades).
   `systemctl reload ssh-broker-signer` (SIGHUP) or `broker-ctl reload`
   (flag-less via the client config; works from another machine), no
   downtime. New binaries, `listen`, TLS material or `audit_log` → restart.
-  Warn before restarting: control-plane restart drops pending approvals and
-  the behaviour baseline; mcp-http restart drops live MCP sessions.
+  Warn before restarting, scaled to whether `state_db` is configured:
+  **with** it, runtime grants/waivers and pending approvals survive and only
+  the behaviour baseline (re-learns) and live MCP sessions are lost;
+  **without** it, a control-plane restart also drops pending approvals and a
+  signer restart drops runtime grants/waivers.
 
 ## 5. Verify
 
 - `systemctl status` on each installed unit; `journalctl -u <unit> -n 20`
   clean of errors. With `pem` custody a CA warning line is expected.
+- **Privilege separation holds** — each unit runs as ITS user, and the
+  isolation is real, not assumed:
+
+  ```bash
+  systemctl show -p User ssh-broker-signer ssh-broker-control-plane ssh-broker-mcp-http
+  # expect ssh-broker-signer / ssh-broker-control-plane / ssh-broker-mcp-http
+  runuser -u ssh-broker-mcp-http -- cat /var/lib/ssh-broker/signer/signer.json
+  # MUST fail (Permission denied) — if it reads, the layout regressed to shared
+  ```
 - `curl -s http://127.0.0.1:9160/healthz` (signer monitor) and the
   control-plane equivalent (`:9170` by default).
 - End-to-end — proves mTLS, `reload_callers` authorization and full policy
@@ -146,6 +181,10 @@ the config paths updated before restarting (see `deploy/README.md` §Upgrades).
   ```
 
   Expect `{}` when `callers._default` is default-deny.
+- **Kubernetes target only:** `broker-ctl cluster list --remote` returns the
+  configured clusters (proves the signer loaded them and the mTLS path); the
+  minter `token_file` is `0600 ssh-broker-signer` and NOT readable by the
+  other service users.
 - `signer --version` matches the tag shipped in step 2.
 
 Report what was deployed (services, host, version, custody backend) and any

--- a/broker-ctl.example.json
+++ b/broker-ctl.example.json
@@ -1,19 +1,19 @@
 {
   "_comment": "broker-ctl CLIENT parameters (optional). Where to reach the services and which mTLS identity to present, so the remote commands (reload, policy add/remove/grant/grants/revoke, approval, host list --remote) do not need --url/--cert/--key/--ca on every call. This is client-side config — the service policy lives in signer.json. Per-parameter precedence: explicit flag > BROKER_CTL_* env var > this file > built-in default. Search order: --client-config, $BROKER_CTL_CONFIG, ~/.config/broker-ctl/config.json, /etc/ssh-broker/broker-ctl.json (the current working directory is NOT searched — use --client-config for a local file, to avoid a planted ./broker-ctl.json redirecting the mTLS endpoint/CA). Env vars: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and BROKER_CTL_CP_{URL,CERT,KEY,CA}.",
 
-  "_signer_comment": "Signer-facing commands (reload, policy *, host list --remote). The cert CN must be in the signer's reload_callers for the policy/read APIs. If url is empty everywhere, it is derived from the listen field of --config.",
+  "_signer_comment": "Signer-facing commands (reload, policy *, host list --remote). The cert CN must be in the signer's reload_callers for the policy/read APIs. If url is empty everywhere, it is derived from the listen field of --config. The admin CLI material lives in pki/admin/ (root-only): no service user must be able to read it and impersonate the admin.",
   "signer": {
     "url": "127.0.0.1:9443",
-    "cert": "/etc/ssh-broker/pki/broker.crt",
-    "key": "/etc/ssh-broker/pki/broker.key",
+    "cert": "/etc/ssh-broker/pki/admin/admin.crt",
+    "key": "/etc/ssh-broker/pki/admin/admin.key",
     "ca": "/etc/ssh-broker/pki/mtls_ca.crt"
   },
 
   "_control_plane_comment": "Control-plane-facing commands (approval list/allow/deny). The cert CN must be in the control plane's approval.callers.",
   "control_plane": {
     "url": "127.0.0.1:7443",
-    "cert": "/etc/ssh-broker/pki/broker-admin.crt",
-    "key": "/etc/ssh-broker/pki/broker-admin.key",
+    "cert": "/etc/ssh-broker/pki/admin/admin.crt",
+    "key": "/etc/ssh-broker/pki/admin/admin.key",
     "ca": "/etc/ssh-broker/pki/mtls_ca.crt"
   }
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,27 +28,51 @@ tar xzf ssh-broker-<version>.tar.gz && cd ssh-broker-<version>
 sudo ./deploy/install.sh                   # everything; or --services "signer"
 ```
 
-The installer creates the `ssh-broker` system user, installs binaries to
+The installer creates **one system user per service**, installs binaries to
 `/usr/local/bin`, configs to `/etc/ssh-broker/` (never overwriting an
 existing one) and the units to `/etc/systemd/system`. It does **not** start
 anything: a fresh config still points at example values.
+
+## Privilege separation — one user per service
+
+Each service runs as its own system user: `ssh-broker-signer`,
+`ssh-broker-control-plane`, `ssh-broker-mcp-http`. The shared `ssh-broker`
+group exists **only** to traverse `/etc/ssh-broker` and read the shared mTLS
+CA certificate; everything sensitive carries the per-service user/group.
+
+Why: the broker frontends are the exposed surface. Under a single shared user,
+a compromised mcp-http process could **read** the signer's config (the whole
+policy), its `state.db` (grants), its audit seed, the k8s minter token, the
+local CA key under `pem` custody — and every other service's mTLS key, i.e.
+impersonate the signer. With per-service users none of that is readable; the
+systemd sandbox (`ProtectSystem=strict` + per-unit `StateDirectory`) already
+contained writes. Running the signer on a **separate host** remains the
+stronger posture (see `THREAT_MODEL.md`); this hardens the colocated layout.
 
 ## Reference layout
 
 ```
 /usr/local/bin/{signer,control-plane,mcp-broker-http,broker-ctl}
-/etc/ssh-broker/{control-plane.json,config.json,broker-ctl.json}  root:ssh-broker 0640
-/etc/ssh-broker/pki/                                              mTLS certs/keys
-/etc/ssh-broker/signer.env                                        optional AZURE_* creds (0600 root)
-/var/lib/ssh-broker/signer/signer.json                           ssh-broker:ssh-broker 0640
-/var/lib/ssh-broker/<svc>/                                        audit logs (StateDirectory)
+/etc/ssh-broker/control-plane.json      root:ssh-broker-control-plane 0640
+/etc/ssh-broker/config.json             root:ssh-broker-mcp-http 0640
+/etc/ssh-broker/broker-ctl.json         root:ssh-broker 0640 (admin CLI params)
+/etc/ssh-broker/pki/mtls_ca.crt         root:ssh-broker 0640 (shared, public)
+/etc/ssh-broker/pki/<svc>/              root:ssh-broker-<svc> 0750, keys 0640
+/etc/ssh-broker/pki/admin/              root 0700 (broker-ctl admin cert+key)
+/etc/ssh-broker/signer.env              optional AZURE_* creds (0600 root)
+/var/lib/ssh-broker/signer/signer.json  ssh-broker-signer 0640
+/var/lib/ssh-broker/<svc>/              state + audit logs (ssh-broker-<svc>)
 ```
 
 The **signer config lives under `/var/lib/ssh-broker/signer/`**, owned by the
 service, not under `/etc` — the durable policy-mutation API (`broker-ctl policy
 add/remove`) rewrites it in place, which the read-only `/etc` tree would block.
-The PKI and the other services' configs stay root-owned in `/etc`; the services
-only read them.
+The other services' configs stay root-owned in `/etc` with the per-service
+group (they can carry secrets — OIDC client, webhook tokens — so no service
+reads another's). Each private key goes in its service's `pki/<svc>/`
+subdirectory: a key dropped there is protected by the directory ownership
+alone. The admin CLI material in `pki/admin/` is root-only — no service can
+impersonate the admin.
 
 Configs must use **absolute** paths for certs/keys; a relative `audit_log`
 resolves under `/var/lib/ssh-broker/<svc>/` (the unit's WorkingDirectory),
@@ -101,7 +125,10 @@ AZURE_CLIENT_SECRET=...
 - [ ] `signer.json` `callers` has `"_default": {"allowed_groups": []}` — default-deny for unknown broker CNs.
 - [ ] `sign_rate_limit_per_min` set (size to the busiest legitimate broker).
 - [ ] CA custody is `akv` (or another KMS); `pem` only in a lab.
-- [ ] mTLS PKI in `/etc/ssh-broker/pki`, keys `0640 root:ssh-broker`.
+- [ ] mTLS PKI split per service: each key in `/etc/ssh-broker/pki/<svc>/`
+  (`0640 root:ssh-broker-<svc>`), admin CLI material in `pki/admin/` (root-only),
+  only the shared CA **cert** at the `pki/` root. No private key readable by
+  more than its own service.
 - [ ] `monitor_listen` bound to localhost or a private scrape interface — never public.
 - [ ] Signer ideally on a separate host from the broker (see THREAT_MODEL.md).
 - [ ] Single instance per service (live sessions and the behaviour baseline are in-memory).
@@ -146,6 +173,20 @@ and `audit_log` require a restart.
 sudo ./deploy/install.sh          # replaces binaries + units, keeps configs
 sudo systemctl restart ssh-broker-signer ssh-broker-control-plane ssh-broker-mcp-http
 signer --version                  # verify the embedded version
+```
+
+**Upgrading from a single-user install (≤ v1.34)**: the installer creates the
+per-service users, re-owns the state directories and configs, and installs the
+new units automatically. What it can **not** do is guess which mTLS key belongs
+to which service — it warns about private keys still sitting flat under
+`pki/` (readable by every service, the exposure this layout removes). Move
+each one and update the config paths before restarting:
+
+```bash
+sudo mv /etc/ssh-broker/pki/signer.key /etc/ssh-broker/pki/signer.crt /etc/ssh-broker/pki/signer/
+sudo chown root:ssh-broker-signer /etc/ssh-broker/pki/signer/*
+# ... same for control-plane/ and mcp-http/; broker-ctl material → pki/admin/
+sudo userdel ssh-broker            # optional: retire the legacy shared user
 ```
 
 With `state_db` configured, runtime grants/waivers (signer) and pending or

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -5,9 +5,17 @@
 # units in deploy/systemd/:
 #
 #   /usr/local/bin/{signer,control-plane,mcp-broker-http,broker-ctl}
-#   /etc/ssh-broker/            configs (0750 root:ssh-broker)
-#   /etc/ssh-broker/pki/        mTLS certs and keys (0750; keys 0640)
-#   /var/lib/ssh-broker/<svc>/  state and audit logs (created by systemd)
+#   /etc/ssh-broker/            configs (0750 root:ssh-broker; files per-service group)
+#   /etc/ssh-broker/pki/        shared mTLS CA cert (public material only)
+#   /etc/ssh-broker/pki/<svc>/  that service's cert+key (0750 root:ssh-broker-<svc>)
+#   /etc/ssh-broker/pki/admin/  broker-ctl admin CLI material (0700 root)
+#   /var/lib/ssh-broker/<svc>/  state and audit logs (owned by ssh-broker-<svc>)
+#
+# Each service runs as its OWN system user (ssh-broker-signer,
+# ssh-broker-control-plane, ssh-broker-mcp-http): a compromised broker cannot
+# read the signer's CA key, policy, state, or mTLS key. Re-running the
+# installer on a <= v1.34 single-user install converges ownership and warns
+# about keys that must be moved into the per-service pki subdirectories.
 #
 # Existing real configs are NEVER overwritten; *.example.json references are
 # refreshed on every run. Re-running after an upgrade replaces binaries and
@@ -57,37 +65,71 @@ ROOT="${SRC:-$(dirname "${SCRIPT_DIR}")}"
     exit 1
 }
 
-# Map service name -> binary : config-basename : unit.
+# Map service name -> binary : config-basename : unit : system user.
 svc_binary()  { case "$1" in signer) echo signer ;; control-plane) echo control-plane ;; mcp-http) echo mcp-broker-http ;; esac; }
 svc_config()  { case "$1" in signer) echo signer.json ;; control-plane) echo control-plane.json ;; mcp-http) echo config.json ;; esac; }
 svc_unit()    { case "$1" in signer) echo ssh-broker-signer.service ;; control-plane) echo ssh-broker-control-plane.service ;; mcp-http) echo ssh-broker-mcp-http.service ;; esac; }
+svc_user()    { echo "ssh-broker-$1"; }
 
 for svc in ${SERVICES}; do
     [[ -n "$(svc_binary "${svc}")" ]] || { echo "unknown service '${svc}' (valid: signer control-plane mcp-http)" >&2; exit 2; }
 done
 
-# 1. System user (no shell, no home login).
+# 1. System users — ONE PER SERVICE (privilege separation): a compromised
+# broker frontend must not be able to read the signer's CA key, policy, state,
+# or mTLS key. The shared "ssh-broker" group exists only to traverse
+# /etc/ssh-broker and read the shared mTLS CA certificate; each service's own
+# files carry its per-service group. (The legacy single "ssh-broker" user from
+# installs <= v1.34 is no longer created or used; it may be removed once the
+# new units are running: userdel ssh-broker.)
 if ! getent group ssh-broker >/dev/null; then
     groupadd --system ssh-broker
     echo "created group ssh-broker"
 fi
-if ! getent passwd ssh-broker >/dev/null; then
-    useradd --system --gid ssh-broker --home-dir /var/lib/ssh-broker \
-            --no-create-home --shell /usr/sbin/nologin ssh-broker
-    echo "created user ssh-broker"
-fi
+for svc in ${SERVICES}; do
+    u="$(svc_user "${svc}")"
+    if ! getent group "${u}" >/dev/null; then
+        groupadd --system "${u}"
+        echo "created group ${u}"
+    fi
+    if ! getent passwd "${u}" >/dev/null; then
+        useradd --system --gid "${u}" --groups ssh-broker \
+                --home-dir "/var/lib/ssh-broker" \
+                --no-create-home --shell /usr/sbin/nologin "${u}"
+        echo "created user ${u}"
+    else
+        usermod -aG ssh-broker "${u}"   # idempotent; heals a partial install
+    fi
+done
 
 # 2. Directories.
 # /etc/ssh-broker holds the read-only material the services never rewrite: the
-# mTLS PKI and the control-plane / mcp-http configs (root-owned, group-readable).
+# mTLS PKI and the control-plane / mcp-http configs. The pki/ root carries only
+# the SHARED mTLS CA certificate (public); each PRIVATE key lives in the
+# per-service subdirectory pki/<svc>/, readable by that service alone — a key
+# dropped in the right subdir is protected without any per-file chgrp.
+# pki/admin/ holds the broker-ctl admin CLI material, root-only: no service
+# must be able to impersonate the admin CLI.
 install -d -m 0750 -o root -g ssh-broker "${ETCDIR}" "${ETCDIR}/pki"
+install -d -m 0700 -o root -g root "${ETCDIR}/pki/admin"
+for svc in ${SERVICES}; do
+    install -d -m 0750 -o root -g "$(svc_user "${svc}")" "${ETCDIR}/pki/${svc}"
+done
 # The signer REWRITES its own config on a durable policy mutation
 # (broker-ctl policy add/remove -> temp-file+rename), so its config lives in the
 # service-owned state directory it can write, not under the read-only /etc tree.
 STATEDIR="/var/lib/ssh-broker"
+install -d -m 0750 -o root -g ssh-broker "${STATEDIR}"
 if [[ " ${SERVICES} " == *" signer "* ]]; then
-    install -d -m 0750 -o ssh-broker -g ssh-broker "${STATEDIR}" "${STATEDIR}/signer"
+    install -d -m 0750 -o ssh-broker-signer -g ssh-broker-signer "${STATEDIR}/signer"
 fi
+# Upgrades from the single-user layout (<= v1.34): re-own each service's state
+# (audit logs, state.db, the signer's config) to its new per-service user.
+for svc in ${SERVICES}; do
+    if [[ -d "${STATEDIR}/${svc}" ]]; then
+        chown -R "$(svc_user "${svc}"):$(svc_user "${svc}")" "${STATEDIR}/${svc}"
+    fi
+done
 
 # 3. Binaries (broker-ctl always: it is the admin CLI).
 install -d "${BINDIR}"
@@ -101,22 +143,31 @@ if [[ -f "${ROOT}/bin/broker-ctl" ]]; then
     echo "installed ${BINDIR}/broker-ctl"
 fi
 
-# 4. Configs: refresh the .example reference, never touch a real config. The
-# signer config goes to its writable state dir (step 2), owned by the service so
-# the durable policy-mutation API can rewrite it; the others stay root-owned
-# under /etc, read-only for their services.
+# 4. Configs: refresh the .example reference, never touch a real config's
+# CONTENT — but always converge its ownership (idempotent; migrates a
+# single-user install to the per-service layout). The signer config goes to its
+# writable state dir (step 2), owned by its service so the durable
+# policy-mutation API can rewrite it; the others stay root-owned under /etc
+# with the per-service GROUP, so each service reads only its own config (they
+# can carry secrets: OIDC client, webhook tokens).
 for svc in ${SERVICES}; do
     cfg="$(svc_config "${svc}")"
-    example="${ROOT}/${cfg%.json}.example.json"
-    [[ -f "${example}" ]] || continue
+    u="$(svc_user "${svc}")"
     case "${svc}" in
-        signer) confdir="${STATEDIR}/signer"; cowner="ssh-broker" ;;
+        signer) confdir="${STATEDIR}/signer"; cowner="${u}" ;;
         *)      confdir="${ETCDIR}";          cowner="root" ;;
     esac
-    install -m 0640 -o "${cowner}" -g ssh-broker "${example}" "${confdir}/${cfg}.example"
-    if [[ ! -f "${confdir}/${cfg}" ]]; then
-        install -m 0640 -o "${cowner}" -g ssh-broker "${example}" "${confdir}/${cfg}"
-        echo "installed ${confdir}/${cfg} (from example — EDIT BEFORE STARTING)"
+    example="${ROOT}/${cfg%.json}.example.json"
+    if [[ -f "${example}" ]]; then
+        install -m 0640 -o "${cowner}" -g "${u}" "${example}" "${confdir}/${cfg}.example"
+        if [[ ! -f "${confdir}/${cfg}" ]]; then
+            install -m 0640 -o "${cowner}" -g "${u}" "${example}" "${confdir}/${cfg}"
+            echo "installed ${confdir}/${cfg} (from example — EDIT BEFORE STARTING)"
+        fi
+    fi
+    if [[ -f "${confdir}/${cfg}" ]]; then
+        chown "${cowner}:${u}" "${confdir}/${cfg}"
+        chmod 0640 "${confdir}/${cfg}"
     fi
 done
 
@@ -129,6 +180,30 @@ if [[ -f "${ROOT}/broker-ctl.example.json" ]]; then
         install -m 0640 -o root -g ssh-broker "${ROOT}/broker-ctl.example.json" "${ETCDIR}/broker-ctl.json"
         echo "installed ${ETCDIR}/broker-ctl.json (from example — EDIT BEFORE USING)"
     fi
+fi
+
+# 4c. Migration check: a private key still sitting FLAT under pki/ (the
+# <= v1.34 single-user layout) is readable by every service via the shared
+# group — the exact exposure the per-service split removes. The installer
+# cannot know which key belongs to which service, so it warns instead of
+# moving files.
+stray_keys="$(find "${ETCDIR}/pki" -maxdepth 1 -type f \
+    -exec grep -l "PRIVATE KEY" {} + 2>/dev/null || true)"
+if [[ -n "${stray_keys}" ]]; then
+    cat >&2 <<EOF
+
+WARNING: private keys found directly under ${ETCDIR}/pki — every service can
+read them. Move each one into its service's subdirectory and update the config
+paths, e.g.:
+
+    mv ${ETCDIR}/pki/signer.key ${ETCDIR}/pki/signer/
+    chown root:ssh-broker-signer ${ETCDIR}/pki/signer/signer.key
+    # admin CLI material (broker-ctl) goes to ${ETCDIR}/pki/admin/ (root-only)
+
+Affected files:
+$(printf '    %s\n' ${stray_keys})
+
+EOF
 fi
 
 # 5. systemd units.
@@ -160,7 +235,11 @@ Done. Before starting (see deploy/README.md for the full checklist):
       "akv"  Azure Key Vault (production; credentials via managed identity or
              ${ETCDIR}/signer.env with AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET)
       "pem"  local key file (lab/dev only)
- 3. Place the mTLS PKI under ${ETCDIR}/pki (keys 0640 root:ssh-broker).
+ 3. Place the mTLS PKI:
+      shared CA cert     ${ETCDIR}/pki/mtls_ca.crt        (0640 root:ssh-broker)
+      per-service keys   ${ETCDIR}/pki/<svc>/             (0640 root:ssh-broker-<svc>)
+      admin CLI material ${ETCDIR}/pki/admin/             (root-only)
+    Each service can read ONLY its own subdirectory (privilege separation).
  4. Production hardening: callers should contain "_default": {"allowed_groups": []}
     (default-deny) and sign_rate_limit_per_min should be set.
  5. systemctl enable --now ssh-broker-signer   # signer first, then the rest

--- a/deploy/systemd/ssh-broker-control-plane.service
+++ b/deploy/systemd/ssh-broker-control-plane.service
@@ -5,9 +5,11 @@
 # per-agent behaviour guardrails. Does NOT hold the CA key. Reference layout:
 #
 #   binary   /usr/local/bin/control-plane
-#   config   /etc/ssh-broker/control-plane.json (root:ssh-broker 0640)
-#   mTLS/PKI /etc/ssh-broker/pki/               (root:ssh-broker 0750, keys 0640)
+#   config   /etc/ssh-broker/control-plane.json (root:ssh-broker-control-plane 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/control-plane/ (root:ssh-broker-control-plane 0750, keys 0640)
 #   state    /var/lib/ssh-broker/control-plane/ (audit log; created via StateDirectory)
+#
+# Runs as its own system user (privilege separation — see the signer unit).
 #
 # Use ABSOLUTE paths in control-plane.json for certs/keys. Relative paths (the
 # default audit_log) resolve under WorkingDirectory. Approval/behaviour state
@@ -23,8 +25,10 @@ After=ssh-broker-signer.service
 
 [Service]
 Type=simple
-User=ssh-broker
-Group=ssh-broker
+User=ssh-broker-control-plane
+Group=ssh-broker-control-plane
+# Shared group: traverse /etc/ssh-broker and read the shared mTLS CA cert only.
+SupplementaryGroups=ssh-broker
 ExecStart=/usr/local/bin/control-plane -config /etc/ssh-broker/control-plane.json
 WorkingDirectory=/var/lib/ssh-broker/control-plane
 StateDirectory=ssh-broker/control-plane

--- a/deploy/systemd/ssh-broker-mcp-http.service
+++ b/deploy/systemd/ssh-broker-mcp-http.service
@@ -6,9 +6,13 @@
 # no unit. Reference layout:
 #
 #   binary   /usr/local/bin/mcp-broker-http
-#   config   /etc/ssh-broker/config.json       (root:ssh-broker 0640)
-#   mTLS/PKI /etc/ssh-broker/pki/               (root:ssh-broker 0750, keys 0640)
+#   config   /etc/ssh-broker/config.json       (root:ssh-broker-mcp-http 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/mcp-http/      (root:ssh-broker-mcp-http 0750, keys 0640)
 #   state    /var/lib/ssh-broker/mcp-http/      (audit log; created via StateDirectory)
+#
+# Runs as its own system user (privilege separation — see the signer unit): a
+# compromise of this internet-facing frontend must not reach the signer's CA
+# key, policy, or state, nor the other services' mTLS keys.
 #
 # Use ABSOLUTE paths in config.json for certs/keys. Relative paths (the
 # default audit_log) resolve under WorkingDirectory. Session state is
@@ -24,8 +28,10 @@ After=ssh-broker-signer.service
 
 [Service]
 Type=simple
-User=ssh-broker
-Group=ssh-broker
+User=ssh-broker-mcp-http
+Group=ssh-broker-mcp-http
+# Shared group: traverse /etc/ssh-broker and read the shared mTLS CA cert only.
+SupplementaryGroups=ssh-broker
 ExecStart=/usr/local/bin/mcp-broker-http -config /etc/ssh-broker/config.json
 WorkingDirectory=/var/lib/ssh-broker/mcp-http
 StateDirectory=ssh-broker/mcp-http

--- a/deploy/systemd/ssh-broker-signer.service
+++ b/deploy/systemd/ssh-broker-signer.service
@@ -4,9 +4,16 @@
 # issuance policy. In the reference layout:
 #
 #   binary   /usr/local/bin/signer
-#   config   /var/lib/ssh-broker/signer/signer.json   (ssh-broker:ssh-broker 0640)
-#   mTLS/PKI /etc/ssh-broker/pki/                      (root:ssh-broker 0750, keys 0640)
-#   state    /var/lib/ssh-broker/signer/               (config + audit log; StateDirectory)
+#   config   /var/lib/ssh-broker/signer/signer.json (ssh-broker-signer:ssh-broker-signer 0640)
+#   mTLS/PKI /etc/ssh-broker/pki/signer/            (root:ssh-broker-signer 0750, keys 0640)
+#   state    /var/lib/ssh-broker/signer/             (config + audit log; StateDirectory)
+#
+# Privilege separation: each service runs as its OWN system user
+# (ssh-broker-signer / ssh-broker-control-plane / ssh-broker-mcp-http), with the
+# shared "ssh-broker" group only for traversing /etc/ssh-broker and reading the
+# shared mTLS CA certificate. A compromised broker frontend therefore cannot
+# read this service's CA key (pem custody), policy, grant state, audit seed, or
+# mTLS key — nor impersonate it.
 #
 # The signer config lives in the service-owned state directory, NOT under the
 # read-only /etc tree, because the durable policy-mutation API rewrites it in
@@ -31,8 +38,10 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=ssh-broker
-Group=ssh-broker
+User=ssh-broker-signer
+Group=ssh-broker-signer
+# Shared group: traverse /etc/ssh-broker and read the shared mTLS CA cert only.
+SupplementaryGroups=ssh-broker
 ExecStart=/usr/local/bin/signer -config /var/lib/ssh-broker/signer/signer.json
 # Hot-reload of policy/CA (same validated path as POST /v1/reload).
 ExecReload=/bin/kill -HUP $MAINPID

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [v1.35.0] - 2026-07-03
+
+Privilege separation in the reference deployment: each service now runs as its
+own system user, so a compromised broker frontend can no longer read the
+signer's CA key, policy, grant state, audit seed, or mTLS key — nor
+impersonate another service or the admin CLI.
+
+### Security
+- **One system user per service** (`ssh-broker-signer`,
+  `ssh-broker-control-plane`, `ssh-broker-mcp-http`) in the systemd units and
+  the installer. The shared `ssh-broker` group remains only for traversing
+  `/etc/ssh-broker` and reading the shared mTLS CA certificate. The legacy
+  single `ssh-broker` user is no longer created or used.
+- **Per-service PKI subdirectories**: each private key lives in
+  `/etc/ssh-broker/pki/<svc>/` (`0750 root:ssh-broker-<svc>`), readable by that
+  service alone; only the shared CA cert stays at the `pki/` root. Admin CLI
+  material moves to `pki/admin/` (root-only) so no service can impersonate the
+  admin (`broker-ctl.example.json` updated accordingly).
+- **Per-service config groups**: `/etc/ssh-broker/{control-plane,config}.json`
+  are readable only by their own service (they can carry secrets — OIDC
+  client, webhook tokens).
+
+### Changed
+- `deploy/install.sh` creates the per-service users/groups, converges ownership
+  of state directories and configs on upgrade (idempotent), and warns about
+  private keys still flat under `pki/` that must be moved into the per-service
+  subdirectories. Migration steps from the ≤ v1.34 single-user layout are in
+  `deploy/README.md` §Upgrades.
+- `THREAT_MODEL.md` documents the colocated-host process-isolation posture;
+  the deploy skill preflight checks the per-service key placement.
+
 ## [v1.34.0] - 2026-07-03
 
 Kubernetes target (credential-broker): the signer can now broker access to

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,21 @@
 # Handoff: SSH Broker con CA Efímera para Agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-03 (v1.34.0, target Kubernetes).
+> actualización: 2026-07-03 (v1.35.0, separación de privilegios en deploy).
 >
 > Estado reciente:
+> - **v1.35.0**: separación de privilegios en el deploy de referencia: un
+>   usuario de sistema por servicio (`ssh-broker-signer` /
+>   `ssh-broker-control-plane` / `ssh-broker-mcp-http`; el grupo compartido
+>   `ssh-broker` queda solo para atravesar `/etc/ssh-broker` y leer la CA mTLS
+>   pública). PKI por subdirectorio de servicio (`pki/<svc>/`, clave legible
+>   solo por su servicio), material del CLI admin en `pki/admin/` (solo root),
+>   configs de /etc con grupo por servicio. `install.sh` migra installs
+>   ≤ v1.34 (re-own idempotente + aviso de claves planas en `pki/`). Un broker
+>   comprometido ya no puede leer la clave CA `pem`, la policy, `state.db`, la
+>   semilla de audit ni suplantar a otro servicio. Además: protección de rama
+>   en main (build/govulncheck/check requeridos), gate anti-drift cierra el
+>   hueco de ficheros no trackeados, y `make verify` como gate local completo.
 > - **v1.34.0**: target Kubernetes (credential-broker). El signer acuña bound
 >   ServiceAccount tokens (TokenRequest) para acciones autorizadas; el agente
 >   nunca ve credencial de cluster. ActionPolicy estructurada por cluster

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -121,6 +121,15 @@ A single malicious one-shot command must pass, in order:
 
 Layers 4–7 are what make this more than a credential vault.
 
+**Process isolation on a colocated host.** The reference deployment
+(`deploy/`) runs each service as its **own system user** with a per-service
+PKI subdirectory and per-service config group. A compromised broker frontend
+therefore cannot read the signer's CA key (`pem` custody), policy, grant
+state, audit seed, or mTLS key — nor impersonate the signer, the control
+plane, or the admin CLI (whose material is root-only). Writes were already
+contained by the systemd sandbox; the user split contains reads. Running the
+signer on a separate host remains the stronger posture.
+
 ---
 
 ## Explicit non-goals & gaps


### PR DESCRIPTION
## Why

All three systemd units ran as the same `ssh-broker` user, with PKI keys `0640 root:ssh-broker`. A compromised broker frontend (the exposed surface) could therefore **read** the signer's config (the whole policy), its `state.db` (grants), its audit seed, the k8s minter token, the local CA key under `pem` custody — and every other service's mTLS key, i.e. impersonate the signer, the control plane, or the admin CLI. The systemd sandbox (`ProtectSystem=strict` + per-unit `StateDirectory`) contained writes, but not same-UID/GID reads.

## What

- **One system user per service**: `ssh-broker-signer`, `ssh-broker-control-plane`, `ssh-broker-mcp-http` (units + installer). The shared `ssh-broker` group remains **only** to traverse `/etc/ssh-broker` and read the shared mTLS CA cert (`SupplementaryGroups=`). The legacy single user is no longer created.
- **Per-service PKI subdirectories** (fail-closed contract): each key in `/etc/ssh-broker/pki/<svc>/` (`0750 root:ssh-broker-<svc>`) is protected by directory ownership alone; only the shared CA **cert** stays at the `pki/` root; admin CLI material moves to `pki/admin/` (root-only) so no service can impersonate the admin.
- **Per-service config groups** in `/etc` (configs can carry secrets: OIDC client, webhook tokens).
- **Migration** (≤ v1.34 single-user installs): `install.sh` converges users and ownership idempotently and **warns by name** about private keys still flat under `pki/`; manual steps documented in `deploy/README.md` §Upgrades.
- Docs: `THREAT_MODEL.md` (colocated process-isolation posture), deploy skill preflight, CHANGELOG v1.35.0, HANDOFF.

## Verified

- `gofmt` / `go vet` / `go build` / `go test -race ./...` clean; `make docs-check` green (docgen idempotent, example configs validate against structs, strict site build).
- **E2E in an `ubuntu:24.04` container**: fresh install (users, supplementary groups, every dir/config ownership asserted), cross-service isolation (`runuser -u ssh-broker-mcp-http` cannot read the signer's config nor list its pki dir; each service reads its own config and traverses the shared pki root), idempotent re-run, and migration from a simulated single-user layout (state re-owned to `ssh-broker-signer`, stray flat key warned about by name).