### PR TITLE
fix: k8s ActionPolicy deny rules were dead code (deny silently ignored)

### DIFF
--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -84,8 +84,18 @@ func (cp CommandPolicy) Validate() error {
 		}
 	}
 	switch cp.Mode {
-	case "", CmdPolicyOff, CmdPolicyAllowlist, CmdPolicyDenylist:
+	case "", CmdPolicyOff:
 		// ok
+	case CmdPolicyAllowlist:
+		// decideOne consults Deny only for denylist members; a Deny parked on an
+		// allowlist policy is silently ignored. Fail closed rather than drop it.
+		if len(cp.Deny) > 0 {
+			return fmt.Errorf("command_policy mode %q must not carry deny patterns (they are only evaluated in denylist mode)", cp.Mode)
+		}
+	case CmdPolicyDenylist:
+		if len(cp.Allow) > 0 {
+			return fmt.Errorf("command_policy mode %q must not carry allow patterns (they are only evaluated in allowlist mode)", cp.Mode)
+		}
 	default:
 		return fmt.Errorf("unknown command_policy mode: %q", cp.Mode)
 	}

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -457,6 +457,10 @@ func TestCommandPolicyValidate(t *testing.T) {
 		{"bad allow regex", CommandPolicy{Mode: CmdPolicyAllowlist, Allow: []string{"("}}, true},
 		{"bad deny regex", CommandPolicy{Mode: CmdPolicyDenylist, Deny: []string{"[z-a]"}}, true},
 		{"bad require_approval regex", CommandPolicy{RequireApproval: []string{"*"}}, true},
+		// A pattern that its mode never evaluates is a silently-dropped control:
+		// reject rather than ignore (regression guard for the k8s deny bug).
+		{"deny on allowlist rejected", CommandPolicy{Mode: CmdPolicyAllowlist, Allow: []string{"^ps$"}, Deny: []string{"^rm "}}, true},
+		{"allow on denylist rejected", CommandPolicy{Mode: CmdPolicyDenylist, Deny: []string{"^rm "}, Allow: []string{"^ps$"}}, true},
 		{"unknown mode", CommandPolicy{Mode: "blocklist"}, true},
 		{"unknown enforcement", CommandPolicy{Enforcement: "shadow"}, true},
 	}

--- a/internal/signer/k8spolicy.go
+++ b/internal/signer/k8spolicy.go
@@ -213,43 +213,52 @@ func compileCluster(name string, cp ClusterPolicy) (ClusterPolicy, error) {
 		return cp, fmt.Errorf("cluster %q: %w", name, err)
 	}
 
-	policy, err := compileK8sRules(name, cp.Rules, cp.Resources)
+	policies, err := compileK8sRules(name, cp.Rules, cp.Resources)
 	if err != nil {
 		return cp, err
 	}
-	cp.Policies = PolicySet{policy}
+	cp.Policies = policies
 	return cp, nil
 }
 
-// compileK8sRules materialises the structured rules as one allowlist
-// CommandPolicy over the canonical action grammar.
-func compileK8sRules(cluster string, rules []K8sRule, table map[string]k8s.ResourceDef) (CommandPolicy, error) {
-	cp := CommandPolicy{Mode: CmdPolicyAllowlist, Enforcement: CmdPolicyEnforce}
+// compileK8sRules materialises the structured rules as an allowlist
+// CommandPolicy (allow + require_approval) plus, when any deny rule is present,
+// a companion denylist CommandPolicy. Deny MUST land in a denylist-mode member:
+// PolicySet.decideOne only consults a member's Deny slice when that member's
+// Mode is denylist, so a deny pattern parked on the allowlist policy would be
+// silently ignored and "deny wins" would not hold.
+func compileK8sRules(cluster string, rules []K8sRule, table map[string]k8s.ResourceDef) (PolicySet, error) {
+	allow := CommandPolicy{Mode: CmdPolicyAllowlist, Enforcement: CmdPolicyEnforce}
+	deny := CommandPolicy{Mode: CmdPolicyDenylist, Enforcement: CmdPolicyEnforce}
 	for i, r := range rules {
 		re, err := compileK8sRule(r, table)
 		if err != nil {
-			return cp, fmt.Errorf("cluster %q: rules[%d]: %w", cluster, i, err)
+			return nil, fmt.Errorf("cluster %q: rules[%d]: %w", cluster, i, err)
 		}
 		switch r.Effect {
 		case K8sEffectAllow:
-			cp.Allow = append(cp.Allow, re)
+			allow.Allow = append(allow.Allow, re)
 		case K8sEffectDeny:
-			cp.Deny = append(cp.Deny, re)
+			deny.Deny = append(deny.Deny, re)
 		case K8sEffectRequireApproval:
 			// require_approval implies allow: the action is permitted but gated.
-			cp.Allow = append(cp.Allow, re)
-			cp.RequireApproval = append(cp.RequireApproval, re)
+			allow.Allow = append(allow.Allow, re)
+			allow.RequireApproval = append(allow.RequireApproval, re)
 		default:
-			return cp, fmt.Errorf("cluster %q: rules[%d]: unknown effect %q (allow, deny, or require_approval)", cluster, i, r.Effect)
+			return nil, fmt.Errorf("cluster %q: rules[%d]: unknown effect %q (allow, deny, or require_approval)", cluster, i, r.Effect)
 		}
 	}
-	if len(cp.Allow) == 0 {
-		return cp, fmt.Errorf("cluster %q: default-deny requires at least one allow or require_approval rule", cluster)
+	if len(allow.Allow) == 0 {
+		return nil, fmt.Errorf("cluster %q: default-deny requires at least one allow or require_approval rule", cluster)
 	}
-	if err := cp.Validate(); err != nil { // compiles the generated regexes
-		return cp, fmt.Errorf("cluster %q: %w", cluster, err)
+	ps := PolicySet{allow}
+	if len(deny.Deny) > 0 {
+		ps = append(ps, deny)
 	}
-	return cp, nil
+	if err := ps.Validate(); err != nil { // compiles the generated regexes
+		return nil, fmt.Errorf("cluster %q: %w", cluster, err)
+	}
+	return ps, nil
 }
 
 // compileK8sRule turns one structured rule into an anchored regex over the

--- a/internal/signer/k8spolicy_test.go
+++ b/internal/signer/k8spolicy_test.go
@@ -153,10 +153,19 @@ func TestResolveK8sDecisions(t *testing.T) {
 		})
 	}
 
-	// Deny wins even over an explicit allow: reads are allowed for pods and
-	// deployments, but a secrets rule can never be out-escaped.
-	if _, _, err := ct.resolveK8s(k8sIntent(K8sAction{Verb: "get", Resource: "secrets", Namespace: "prod", Name: "db"}), nil); err == nil {
-		t.Error("deny must win for secrets")
+	// Deny must win over an OVERLAPPING allow — not merely be masked by
+	// default-deny. Here "get secrets" is EXPLICITLY allowed by the read rule,
+	// yet the secrets deny rule must still block it. Without a dedicated
+	// denylist member (deny parked on the allowlist policy) the allow would win.
+	overlap := compileOne(t, testCluster(t, []K8sRule{
+		{Verbs: []string{"get", "list"}, Resources: []string{"pods", "secrets"}, Effect: "allow"},
+		{Verbs: []string{"*"}, Resources: []string{"secrets"}, Effect: "deny"},
+	}))
+	if _, _, err := overlap.resolveK8s(k8sIntent(K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"}), nil); err != nil {
+		t.Fatalf("get pods must be allowed by the read rule: %v", err)
+	}
+	if _, _, err := overlap.resolveK8s(k8sIntent(K8sAction{Verb: "get", Resource: "secrets", Namespace: "prod", Name: "db"}), nil); err == nil {
+		t.Error("deny must win over the overlapping allow for secrets")
 	}
 }
 


### PR DESCRIPTION
Fixes #82 — security (high).

## The bug

`compileK8sRules` built ONE `CommandPolicy{Mode: allowlist}` and appended deny-effect rules to that policy's `Deny` slice. But `PolicySet.decideOne` only consults a member's `Deny` patterns when the member's `Mode == denylist` — it `continue`s past every non-denylist member in the deny-wins pass. So **k8s `deny` rules were never evaluated**. A `deny` overlapping a broad `allow` was silently ignored and the allow won — the exact carve-out (`allow get *` + `deny get secrets`) that is the only reason `deny` exists.

The shipped `signer.example.json` ships `{ "verbs": ["*"], "resources": ["secrets"], "effect": "deny" }` and the docs promise "deny wins" — both were wrong at runtime. Runtime allow-grants on the cluster were likewise un-blockable by a deny rule.

The existing `TestResolveK8sDecisions` "deny must win for secrets" passed **for the wrong reason**: its allow rules never covered `secrets`, so default-deny (not the deny rule) blocked it, masking the dead code.

## The fix

- Compile deny-effect rules into a **separate `CommandPolicy{Mode: denylist}`** appended to the cluster's `PolicySet`, so `decideOne`'s deny-wins pass evaluates them — inheriting the SSH path's correct "deny beats allow, and beats grants" ordering.
- **Defense in depth**: `CommandPolicy.Validate` now rejects `Deny` patterns on an allowlist policy and `Allow` patterns on a denylist policy — a pattern its mode never evaluates is a silently-dropped security control, so it now fails closed at config load. Verified no existing config or test mixes modes.
- **Strengthened the test**: an allow rule that explicitly overlaps the deny (`get secrets` is now allowed by a read rule) proves the deny still wins — not merely masked by default-deny. Confirmed it fails without the fix.

## Verified

`gofmt` clean · `go vet` · `go build` · `go test -race ./...` all pass · docgen idempotent (no config-struct change).