### PR TITLE
fix: redact env-assignment no longer masks the bare shell PWD variable

### DIFF
--- a/internal/redact/defaults.go
+++ b/internal/redact/defaults.go
@@ -12,6 +12,9 @@ package redact
 //   - The env-assignment rule requires the sensitive keyword to be a full
 //     "_"-delimited component of the variable name, so AUTH matches AUTH= and
 //     BASIC_AUTH= but not AUTHOR= or XAUTHORITY= (real-world false positives).
+//     PWD is the exception: it demands a leading component (MYSQL_PWD=, DB_PWD=)
+//     so the ubiquitous shell working-directory variable (bare PWD=) is not
+//     masked out of every recording and env dump.
 //   - The mysql rule covers the attached short form (mysql -psecret) — the
 //     canonical example of threat-model gap #8 — and is scoped to the mysql
 //     client family because a bare "-p<value>" is far too ambiguous (ports,
@@ -27,7 +30,7 @@ var Defaults = []Pattern{
 	},
 	{
 		Name:  "env-assignment",
-		Regex: `(?i)\b(?:[A-Z0-9]+_)*(?:PASSWORD|PASSWD|PWD|PASSPHRASE|SECRET|TOKEN|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIALS?|AUTH)(?:_[A-Z0-9]+)*=(?P<secret>"[^"]+"|'[^']+'|[^\s"']+)`,
+		Regex: `(?i)\b(?:(?:[A-Z0-9]+_)*(?:PASSWORD|PASSWD|PASSPHRASE|SECRET|TOKEN|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|CREDENTIALS?|AUTH)|(?:[A-Z0-9]+_)+PWD)(?:_[A-Z0-9]+)*=(?P<secret>"[^"]+"|'[^']+'|[^\s"']+)`,
 	},
 	{
 		Name:  "uri-userinfo",

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -46,6 +46,12 @@ func TestDefaultsRedact(t *testing.T) {
 		{"env auth alone", "AUTH=abc cmd", "AUTH=[REDACTED:env-assignment] cmd"},
 		{"env author untouched", "AUTHOR=luis git commit", "AUTHOR=luis git commit"},
 		{"env xauthority untouched", "XAUTHORITY=/home/x/.Xauthority startx", "XAUTHORITY=/home/x/.Xauthority startx"},
+		// PWD demands a leading component: prefixed forms are secrets, the bare
+		// shell working-directory variable is not.
+		{"env mysql_pwd masked", "MYSQL_PWD=hunter2 mysql -e x", "MYSQL_PWD=[REDACTED:env-assignment] mysql -e x"},
+		{"env db_pwd masked", "DB_PWD=s3cr3t app", "DB_PWD=[REDACTED:env-assignment] app"},
+		{"env bare pwd untouched", "PWD=/home/luis make build", "PWD=/home/luis make build"},
+		{"env passwd bare still masked", "PASSWD=hunter2 cmd", "PASSWD=[REDACTED:env-assignment] cmd"},
 
 		// uri-userinfo: only the password component is masked.
 		{"uri", "curl https://user:hunter2@example.com/x", "curl https://user:[REDACTED:uri-userinfo]@example.com/x"},


### PR DESCRIPTION
Fixes #86 — logic (low).

The `env-assignment` default redaction rule listed `PWD` alongside `PASSWORD`/`PASSWD` with an optional leading component, so bare `PWD=/home/x` — the ubiquitous shell working-directory variable (every `env` dump, `PWD=/tmp make`, etc.) — was masked as a secret in audit logs and recordings, degrading their forensic value. The rule's own design note says the `_`-delimited-component requirement exists precisely to kill this false-positive class (`AUTHOR`, `XAUTHORITY`); bare `PWD` was a bigger offender than either.

**Fix:** restructured the alternation so `PWD` demands a leading component — `MYSQL_PWD=` and `DB_PWD=` (real password vars, e.g. the one MySQL reads) still mask; bare `PWD=` does not. `PASSWD`/`PASSWORD`/`PASSPHRASE` and every other keyword keep matching bare, so no secret coverage is lost.

**Verified:** `gofmt`, `go vet`, `go test -race ./internal/redact/ ./internal/audit/`; docgen idempotent. New table cases lock in bare-`PWD` untouched, `*_PWD` masked, bare `PASSWD` still masked.