### PR TITLE
fix: audit follow-ups — OPERATIONS drift, install.sh hardening, docgen prune, verify honesty

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,8 @@ jobs:
           go run ./tools/docgen
           # git status --porcelain (not git diff): a NEW generated file that was
           # never committed is drift too — git diff only reports tracked changes.
+          # docgen also prunes orphaned pages, so a removed generator shows up
+          # here as a tracked deletion instead of silently shipping a stale page.
           if [ -n "$(git status --porcelain docs/reference)" ]; then
             git status --porcelain docs/reference
             git --no-pager diff docs/reference

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,11 @@ docs-serve: docs-gen
 
 # ── Pre-push gate ──────────────────────────────────────────────────────────────
 
-# Everything the required CI checks run (go.yml build + docs.yml check), in one
-# shot. Green here means the PR merges; a red tree never leaves the machine.
+# The local pre-push gate: gofmt, vet, build, race tests and the docs anti-drift
+# gate — mirroring the go.yml `build` job and the docs.yml `check` job. The third
+# required check, `govulncheck`, needs a network install, so it runs here only
+# when the tool is already on PATH; otherwise the CI govulncheck job is the
+# backstop. A clean run means those two gates pass — not that govulncheck will.
 verify:
 	@unformatted="$$(gofmt -l .)"; \
 	  if [ -n "$$unformatted" ]; then \
@@ -104,4 +107,9 @@ verify:
 	go vet ./...
 	go build ./...
 	go test -race ./...
+	@if command -v govulncheck >/dev/null 2>&1; then \
+	    echo "govulncheck ./..."; govulncheck ./...; \
+	  else \
+	    echo "verify: govulncheck not on PATH — CI runs it (install: go install golang.org/x/vuln/cmd/govulncheck@latest)"; \
+	  fi
 	$(MAKE) docs-check

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,9 @@ docs: docs-gen
 # Full anti-drift gate (what CI runs): regenerate the reference and fail if it
 # differs from what's committed; validate the example configs against the structs;
 # build the site strictly. `git status --porcelain` (not `git diff`) so a NEW
-# generated file that was never committed is drift too, not a silent pass.
+# generated file that was never committed is drift too, not a silent pass;
+# docgen prunes orphaned pages, so a removed/renamed generator surfaces as a
+# tracked deletion here rather than shipping a stale page.
 docs-check: docs-gen
 	@stale="$$(git status --porcelain docs/reference)"; \
 	  if [ -n "$$stale" ]; then \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -186,7 +186,14 @@ each one and update the config paths before restarting:
 sudo mv /etc/ssh-broker/pki/signer.key /etc/ssh-broker/pki/signer.crt /etc/ssh-broker/pki/signer/
 sudo chown root:ssh-broker-signer /etc/ssh-broker/pki/signer/*
 # ... same for control-plane/ and mcp-http/; broker-ctl material → pki/admin/
-sudo userdel ssh-broker            # optional: retire the legacy shared user
+```
+
+Then restart the units (§Upgrades). Only **after** the services are running as
+their new per-service users can the legacy shared account be retired — while
+the old units are still up they hold it open and `userdel` refuses:
+
+```bash
+sudo userdel ssh-broker            # optional; fails if any process still uses it
 ```
 
 With `state_db` configured, runtime grants/waivers (signer) and pending or

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -186,10 +186,17 @@ fi
 # <= v1.34 single-user layout) is readable by every service via the shared
 # group — the exact exposure the per-service split removes. The installer
 # cannot know which key belongs to which service, so it warns instead of
-# moving files.
-stray_keys="$(find "${ETCDIR}/pki" -maxdepth 1 -type f \
-    -exec grep -l "PRIVATE KEY" {} + 2>/dev/null || true)"
-if [[ -n "${stray_keys}" ]]; then
+# moving files. NUL-safe collection so a key filename with spaces cannot mangle
+# the checklist; symlinks are followed; grep's per-file boolean is tested
+# directly (no blanket 2>/dev/null that would hide a real find/grep failure as
+# a silently-absent security warning).
+stray_keys=()
+while IFS= read -r -d '' f; do
+    if grep -Iqs "PRIVATE KEY" "${f}"; then
+        stray_keys+=("${f}")
+    fi
+done < <(find "${ETCDIR}/pki" -maxdepth 1 \( -type f -o -type l \) -print0)
+if (( ${#stray_keys[@]} > 0 )); then
     cat >&2 <<EOF
 
 WARNING: private keys found directly under ${ETCDIR}/pki — every service can
@@ -201,9 +208,9 @@ paths, e.g.:
     # admin CLI material (broker-ctl) goes to ${ETCDIR}/pki/admin/ (root-only)
 
 Affected files:
-$(printf '    %s\n' ${stray_keys})
-
 EOF
+    printf '    %s\n' "${stray_keys[@]}" >&2
+    echo >&2
 fi
 
 # 5. systemd units.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -165,15 +165,20 @@ metadata: { name: broker-platform, namespace: agents }
 # ...bind it to Roles/ClusterRoles for the resources your rules allow.
 ```
 
-Mint the minter's own token and store it where `token_file` points (0600,
-owned by the service user); the signer re-reads it per mint, so you can rotate
-it out-of-band:
+Mint the minter's own token and store it where `token_file` points; the signer
+re-reads it per mint, so you can rotate it out-of-band. It is a **standing
+cluster credential** — write it `0600` owned by the signer's service user
+(`ssh-broker-signer` in the production layout, §8) and never under the
+group-readable `/etc/ssh-broker/pki` root:
 
 ```bash
+umask 077
 kubectl -n agents create token ssh-broker-minter --duration=8760h \
   > /var/lib/ssh-broker/signer/pki/prod-k8s-minter.token
 kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' \
   | base64 -d > /var/lib/ssh-broker/signer/pki/prod-k8s-ca.crt
+chown ssh-broker-signer:ssh-broker-signer /var/lib/ssh-broker/signer/pki/prod-k8s-minter.token
+chmod 0600 /var/lib/ssh-broker/signer/pki/prod-k8s-minter.token
 ```
 
 **In `signer.json`:** add the cluster under `kubernetes.clusters` (see
@@ -259,6 +264,12 @@ policy stays in `signer.json`):
   "control_plane": { "url": "127.0.0.1:7443", "cert": "pki/broker-admin.crt", "key": "pki/broker-admin.key", "ca": "pki/mtls_ca.crt" }
 }
 ```
+
+The relative `pki/*` paths above are the **lab** layout. In the production
+per-service install (§8) the admin CLI material is root-only under
+`/etc/ssh-broker/pki/admin/`, and the seeded `/etc/ssh-broker/broker-ctl.json`
+points both sections at `pki/admin/admin.{crt,key}` with the shared
+`pki/mtls_ca.crt` — no service user can read it and impersonate the admin.
 
 Search order: `--client-config` → `$BROKER_CTL_CONFIG` →
 `~/.config/broker-ctl/config.json` → `/etc/ssh-broker/broker-ctl.json`
@@ -706,7 +717,7 @@ an idempotent installer and a release target:
 ```bash
 make dist                        # dist/ssh-broker-<version>.tar.gz
 # on the target host, as root:
-./deploy/install.sh              # user, dirs, binaries, units, seed configs
+./deploy/install.sh              # per-service users, dirs, binaries, units, seed configs
 systemctl enable --now ssh-broker-signer   # always the signer first
 ```
 
@@ -717,6 +728,16 @@ lives in `/var/lib/ssh-broker/signer/signer.json`** (service-owned): the durable
 policy-mutation API rewrites it in place, so it cannot sit in the read-only
 `/etc` tree. Policy hot-reload maps to `systemctl reload ssh-broker-signer`
 (SIGHUP).
+
+**Privilege separation (v1.35.0+):** each daemon runs as its own system user
+(`ssh-broker-signer`, `ssh-broker-control-plane`, `ssh-broker-mcp-http`); the
+shared `ssh-broker` group only grants traversal of `/etc/ssh-broker` and read
+of the shared mTLS CA cert. Each service's mTLS key lives in its own
+`/etc/ssh-broker/pki/<svc>/` (`0750 root:ssh-broker-<svc>`), the admin CLI
+material in `pki/admin/` (root-only), and only the CA **cert** sits at the
+`pki/` root. A compromised broker frontend therefore cannot read the signer's
+CA key, policy, state, or another service's key. See `deploy/README.md` for the
+full layout and the upgrade steps from a single-user install.
 The installer also seeds `/etc/ssh-broker/broker-ctl.json` (client parameters,
 see §4) so `broker-ctl host list --remote` works flag-less as the post-deploy
 end-to-end check.

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -36,11 +36,42 @@ func main() {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		fatal(err)
 	}
-	write(filepath.Join(outDir, "endpoints.md"), genEndpoints())
-	write(filepath.Join(outDir, "mcp-tools.md"), genMCPTools())
-	write(filepath.Join(outDir, "config.md"), genConfig())
-	write(filepath.Join(outDir, "cli.md"), genCLI())
+	generated := map[string]string{
+		"endpoints.md": genEndpoints(),
+		"mcp-tools.md": genMCPTools(),
+		"config.md":    genConfig(),
+		"cli.md":       genCLI(),
+	}
+	for name, content := range generated {
+		write(filepath.Join(outDir, name), content)
+	}
+	// Prune any stale .md left from a generator that was renamed or removed: the
+	// drift gate compares the worktree against HEAD, so an orphan that docgen no
+	// longer emits would otherwise stay byte-identical forever and ship a stale
+	// page. Deleting it here surfaces the removal as a tracked deletion.
+	pruneStale(outDir, generated)
 	fmt.Println("docgen: wrote docs/reference/{endpoints,mcp-tools,config,cli}.md")
+}
+
+// pruneStale removes every *.md in dir that docgen did not just write.
+func pruneStale(dir string, keep map[string]string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || filepath.Ext(name) != ".md" {
+			continue
+		}
+		if _, ok := keep[name]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, name)); err != nil {
+			fatal(err)
+		}
+		fmt.Printf("docgen: pruned stale %s\n", filepath.Join(dir, name))
+	}
 }
 
 // ── endpoints ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Five audit-loop fixes that were authored on the #80 and #81 branches but did not reach `main` (those PRs merged before these commits landed). Rebased onto current `main` (post-#80/#81). One commit per issue.

| Issue | Sev | Fix |
|---|---|---|
| #83 | medium | `OPERATIONS.md` updated for the per-service deploy layout (§8), admin CLI material in `pki/admin/` (§4), and the k8s minter token minted `0600 ssh-broker-signer` instead of `0644 root:root` (§2.1) |
| #84 | low | `deploy/README.md`: `userdel ssh-broker` moved out of the pre-restart block (it fails while the old units still hold the account) |
| #85 | low | `install.sh` stray-key migration warning made NUL-safe (spaced filenames intact) and non-swallowing (a real find/grep failure no longer hides the security warning) |
| #87 | low | `docgen` prunes orphaned reference pages, so a removed/renamed generator surfaces as a tracked deletion in the drift gate (the #74 blind spot in the deletion direction) |
| #88 | low | `make verify` comment made honest about the govulncheck gap; it now also runs govulncheck when the tool is on PATH |

## Verified

`make verify` green end to end on this branch (gofmt, vet, build, `go test -race ./...`, docgen idempotent + prune, example configs, `mkdocs build --strict`). Container e2e for the install.sh change (spaced key filename listed intact, non-key cert not flagged) and docgen prune (planted `phantom.md` removed) were run on the source branches.