### PR TITLE
ci: align release.yml action versions to the Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       # fetch-depth: 0 fetches the full history and tags so `git describe --tags`
       # in `make dist` resolves the release version to inject into the binaries.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.4'
 
@@ -45,7 +45,7 @@ jobs:
           echo "CHECKSUMS=dist/checksums.txt" >> "$GITHUB_ENV"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
The `v1.35.0` Release run emitted a Node.js 20 deprecation annotation: `release.yml` used `actions/checkout@v4`, `actions/setup-go@v4` and `softprops/action-gh-release@v2`, which declare the (deprecated) Node 20 runtime. `go.yml` and `docs.yml` were already on `checkout@v5` / `setup-go@v6`.

Aligned `release.yml` to the same Node 24 majors:

| Action | Before | After | Runtime |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24 |
| actions/setup-go | v4 | v6 | node24 |
| softprops/action-gh-release | v2 | v3 | node24 |

`go-version` (`1.26.4`) was already identical across all three workflows — no change there. No functional change; the next release run will not emit the deprecation warning.