### PR TITLE
Distribution: prebuilt binaries, OCI image and containerized demo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -15,7 +16,8 @@ jobs:
 
     steps:
       # fetch-depth: 0 fetches the full history and tags so `git describe --tags`
-      # in `make dist` resolves the release version to inject into the binaries.
+      # in `make dist` resolves the release version to inject into the binaries,
+      # and so goreleaser can compute the changelog range.
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -31,23 +33,35 @@ jobs:
       # Build the SAME artifact as the documented install path (OPERATIONS §8):
       # `make dist` produces dist/infrabroker-<version>.tar.gz with all six
       # binaries (incl. control-plane, which the shipped systemd unit execs),
-      # version-injected, plus deploy/ and the example configs. Building a subset
-      # here would ship a release whose control-plane unit has nothing to run.
-      - name: Build release tarball
+      # version-injected, plus deploy/ and the example configs. goreleaser
+      # attaches it to the release via release.extra_files; its own archives
+      # live in dist-goreleaser/ so `release --clean` never wipes this one.
+      - name: Build installer tarball
         run: make dist
 
-      - name: Checksum
-        run: |
-          cd dist
-          ARCHIVE=$(ls infrabroker-*.tar.gz)
-          sha256sum "$ARCHIVE" > checksums.txt
-          echo "ARCHIVE=dist/$ARCHIVE" >> "$GITHUB_ENV"
-          echo "CHECKSUMS=dist/checksums.txt" >> "$GITHUB_ENV"
+      # checksums.txt is goreleaser's (covers the per-platform archives); the
+      # installer tarball gets its own sidecar to avoid the name collision.
+      - name: Checksum installer tarball
+        run: cd dist && sha256sum infrabroker-*.tar.gz > installer.sha256
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
         with:
-          generate_release_notes: true
-          files: |
-            ${{ env.ARCHIVE }}
-            ${{ env.CHECKSUMS }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Single owner of the GitHub release: goreleaser creates it, uploads the
+      # per-platform archives + checksums.txt + the installer tarball, pushes
+      # the per-arch images to ghcr and stitches the multi-arch manifests.
+      - name: goreleaser release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ medium.txt
 # Configuración local de la sesión del agente (permisos por máquina, no versionar)
 .claude/settings.local.json
 /plans/
+/dist-goreleaser/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,117 @@
+# goreleaser v2 — prebuilt binaries + OCI image for each release tag.
+# The installer tarball (make dist) is NOT built here: release.yml runs
+# `make dist` first and this config attaches it via release.extra_files.
+version: 2
+
+project_name: infrabroker
+
+# The Makefile owns ./dist (installer tarball). goreleaser must never share
+# it: `release --clean` wipes its dist directory at startup.
+dist: dist-goreleaser
+
+builds:
+  - id: signer
+    main: ./cmd/signer
+    binary: signer
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    # {{ .Tag }} (v-prefixed) keeps parity with the Makefile's `git describe`.
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+  - id: broker
+    main: ./cmd/broker
+    binary: broker
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+  - id: broker-ctl
+    main: ./cmd/broker-ctl
+    binary: broker-ctl
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+  - id: mcp-broker
+    main: ./cmd/mcp-broker
+    binary: mcp-broker
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+  - id: mcp-broker-http
+    main: ./cmd/mcp-broker-http
+    binary: mcp-broker-http
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+  - id: control-plane
+    main: ./cmd/control-plane
+    binary: control-plane
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+
+# One archive per OS/arch with all six binaries (4 assets, not 24): whoever
+# downloads mcp-broker almost always wants broker-ctl too, and the systemd
+# path keeps using the installer tarball.
+archives:
+  - id: unified
+    ids: [signer, broker, broker-ctl, mcp-broker, mcp-broker-http, control-plane]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+      - config.example.json
+      - signer.example.json
+      - control-plane.example.json
+      - broker-ctl.example.json
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github-native
+
+release:
+  # Attach the installer tarball built by `make dist` (see release.yml).
+  extra_files:
+    - glob: dist/infrabroker-*.tar.gz
+    - glob: dist/installer.sha256
+
+# Image build is COPY-only from the prebuilt binaries above — a multi-stage
+# `go build` here would recompile under emulation and drift from the archives.
+# dockers_v2 builds the multi-arch manifest in one buildx invocation (in
+# snapshot mode it builds per-arch local tags instead of pushing).
+#
+# The io.modelcontextprotocol.server.name label is how the MCP Registry
+# validates ownership of the OCI package: it must equal server.json's "name".
+dockers_v2:
+  - id: infrabroker
+    images:
+      - ghcr.io/luisgf/infrabroker
+    tags:
+      - "{{ .Version }}"
+      - latest
+    dockerfile: Dockerfile
+    ids: [signer, broker, broker-ctl, mcp-broker, mcp-broker-http, control-plane]
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.title: infrabroker
+      org.opencontainers.image.description: "Infrastructure access broker for AI agents — SSH & Kubernetes. The model never touches a credential."
+      org.opencontainers.image.source: https://github.com/luisgf/infrabroker
+      org.opencontainers.image.url: https://luisgf.github.io/infrabroker/
+      org.opencontainers.image.licenses: GPL-3.0-only
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      io.modelcontextprotocol.server.name: io.github.luisgf/infrabroker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Built by goreleaser (see .goreleaser.yaml): the context already contains
+# the six prebuilt static binaries for the target platform — no compilation
+# happens here, so the image stays bit-identical to the release archives.
+#
+# distroless/static ships CA roots (outbound TLS to the signer / OIDC / Azure
+# Key Vault) and a nonroot user (uid 65532), and nothing else: no shell, no
+# package manager. The broker's SSH client is pure Go — no openssh needed.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# goreleaser (dockers_v2) lays the prebuilt binaries out per platform
+# (linux/amd64/..., linux/arm64/...) in the build context.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/signer $TARGETPLATFORM/broker $TARGETPLATFORM/broker-ctl \
+     $TARGETPLATFORM/mcp-broker $TARGETPLATFORM/mcp-broker-http \
+     $TARGETPLATFORM/control-plane /usr/local/bin/
+
+USER nonroot
+
+# stdio MCP frontend by default (what MCP clients launch); the other binaries
+# are selected with --entrypoint, e.g. --entrypoint /usr/local/bin/signer.
+ENTRYPOINT ["/usr/local/bin/mcp-broker"]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 #   make docs-gen      # regenerate docs/reference/ from code
 #   make docs-check    # gen + drift checks + strict site build (CI gate)
 #   make docs-serve    # live-preview the site at 127.0.0.1:8000
+#   make demo          # containerized demo: examples/compose up --build
 #   make verify        # full pre-push gate: fmt + vet + build + race tests + docs-check
 
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -21,7 +22,7 @@ CMDS    := signer broker broker-ctl mcp-broker mcp-broker-http control-plane
 # MkDocs runner: prefer a local mkdocs, else fall back to `python3 -m mkdocs`.
 MKDOCS  ?= $(shell command -v mkdocs 2>/dev/null || echo "python3 -m mkdocs")
 
-.PHONY: build install $(CMDS) test fmt vet version clean dist docs docs-gen docs-serve docs-check verify
+.PHONY: build install $(CMDS) test fmt vet version clean dist docs docs-gen docs-serve docs-check verify demo
 
 build: $(CMDS)
 install: build
@@ -91,6 +92,11 @@ docs-check: docs-gen
 # Live preview at http://127.0.0.1:8000 (regenerates first).
 docs-serve: docs-gen
 	$(MKDOCS) serve
+
+# Containerized demo (docs/CONTAINERS.md). INFRABROKER_TAG selects the image
+# tag (default: latest from ghcr; use a local snapshot tag while developing).
+demo:
+	docker compose -f examples/compose/compose.yaml up --build -d
 
 # ── Pre-push gate ──────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,28 @@ separate signer + ASCIIcast recording + chained audit, as a small set of Go
 binaries without a cluster. Enterprise features (web UI, multi-region HA) are on
 the roadmap (see [HANDOFF.md](docs/HANDOFF.md)).
 
+## Install
+
+- **Prebuilt binaries** — each [release](https://github.com/luisgf/infrabroker/releases)
+  ships `infrabroker_<ver>_{linux,darwin}_{amd64,arm64}.tar.gz` with all six
+  binaries, plus the installer tarball (`infrabroker-v<ver>.tar.gz`) that
+  `deploy/install.sh` consumes for the systemd production path.
+- **go install** — `go install github.com/luisgf/infrabroker/cmd/mcp-broker@latest`
+  (pure Go, no CGO; same for the other `cmd/` binaries).
+- **Container** — `ghcr.io/luisgf/infrabroker` (docker or podman, multi-arch;
+  entrypoint is the stdio MCP frontend). See [CONTAINERS.md](docs/CONTAINERS.md),
+  including a compose demo that runs the full stack against a toy host:
+  `cd examples/compose && docker compose up --build -d` (or `make demo`).
+- **From source** — the Quickstart below.
+
+Register with Claude Code in one line — native binary or container:
+
+```bash
+claude mcp add infrabroker -- ~/bin/mcp-broker -config /secure/path/config.json
+claude mcp add infrabroker -- docker run -i --rm -v /secure/path:/config \
+  ghcr.io/luisgf/infrabroker -config /config/config.json
+```
+
 ## Quickstart
 
 ```bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [v1.37.0] - 2026-07-04
+
+Distribution release: prebuilt binaries, an official OCI image and a
+containerized demo. Installing no longer requires a Go toolchain.
+
+### Added
+- **Prebuilt release binaries** (goreleaser): one archive per platform
+  (`linux`/`darwin` × `amd64`/`arm64`) with all six binaries and the example
+  configs, plus `checksums.txt`. The installer tarball for the systemd path
+  (`infrabroker-v<ver>.tar.gz`, consumed by `deploy/install.sh`) is unchanged
+  and still attached to every release.
+- **Official OCI image** `ghcr.io/luisgf/infrabroker` (multi-arch
+  linux/amd64+arm64, distroless/static, nonroot): the six binaries with
+  `mcp-broker` as entrypoint. Carries the `io.modelcontextprotocol.server.name`
+  label the MCP Registry uses to validate package ownership (`server.json`
+  bumped to reference `ghcr.io/luisgf/infrabroker:1.37.0`).
+- **Compose demo** (`examples/compose/`, `make demo`): signer + toy sshd
+  target + broker with auto-provisioned PKI — run a policied command through
+  the full remote-signing topology in 5 minutes, then `down -v` and it is
+  gone. Works with docker compose and podman compose (rootless).
+- **docs/CONTAINERS.md**: image usage (stdio MCP in a container, other
+  binaries via `--entrypoint`), the demo walkthrough, podman notes, and the
+  explicit demo≠production and k8s-target≠k8s-runtime boundaries.
+- README **Install** section: release binaries, `go install`, container and
+  one-click `claude mcp add` lines.
+
+### Changed
+- `release.yml`: goreleaser now owns the GitHub release (archives, checksums,
+  image push to ghcr and multi-arch manifests); `make dist` still builds the
+  installer tarball, attached via `release.extra_files`. Workflow gains
+  `packages: write`.
+
 ## [v1.36.0] - 2026-07-04
 
 The project is renamed **ssh-broker → infrabroker**: the broker outgrew SSH

--- a/docs/CONTAINERS.md
+++ b/docs/CONTAINERS.md
@@ -76,6 +76,8 @@ topology against a **toy target** — nothing touches real servers:
 ```bash
 git clone https://github.com/luisgf/infrabroker && cd infrabroker/examples/compose
 docker compose up --build -d        # or: podman compose up --build -d
+# health via each service's monitor endpoint (plain HTTP, demo-only — the
+# real listeners are the mTLS APIs; monitor is bound to 127.0.0.1 here):
 curl -s http://127.0.0.1:9160/healthz && curl -s http://127.0.0.1:9180/healthz
 ```
 
@@ -100,7 +102,8 @@ docker compose exec sshd sh -c 'tail -1 /demo/state/signer_audit.log'   # outcom
 docker compose exec sshd sh -c 'tail -1 /demo/state/broker_audit.log'   # outcome: executed
 ```
 
-Policy is default-deny — an undeclared host is refused:
+Access is scoped by host and caller — an undeclared host is refused (`404`),
+and the signer only mints certs for host `demo` to caller `broker-1`:
 
 ```bash
 docker compose exec sshd curl -s --cacert /demo/pki/agents_ca.crt \
@@ -108,6 +111,12 @@ docker compose exec sshd curl -s --cacert /demo/pki/agents_ca.crt \
   https://broker:8443/v1/ssh_run -d '{"host":"prod-db","command":"id"}'
 # unknown host: "prod-db"  (404)
 ```
+
+This shows host/caller scoping, **not** the per-command firewall: the demo host
+declares no `command_policy`, so any command runs on `demo`. The command
+allow/deny/`require_approval` engine (with a `403` on denial) is a separate
+layer — see [Architecture: AI-action firewall](ARCHITECTURE.md#ai-action-firewall)
+and [Tool usage](USAGE.md).
 
 Connect Claude Code to the demo over stdio (the provisioner also wrote an
 `mcp.json` for this):

--- a/docs/CONTAINERS.md
+++ b/docs/CONTAINERS.md
@@ -1,0 +1,157 @@
+# Containers
+
+infrabroker ships an official OCI image and a self-contained compose demo.
+Containers are the fastest way to **evaluate** the broker and the vehicle for
+MCP-client installs from the registry; they are **not** the recommended
+production layout (see the warning at the end).
+
+## The official image
+
+```
+ghcr.io/luisgf/infrabroker:<X.Y.Z>     # matches each release tag
+ghcr.io/luisgf/infrabroker:latest
+```
+
+- **Contents:** the six release binaries (`signer`, `broker`, `broker-ctl`,
+  `mcp-broker`, `mcp-broker-http`, `control-plane`) under `/usr/local/bin/`,
+  bit-identical to the release archives (the image copies the prebuilt
+  binaries; nothing is compiled in the Dockerfile).
+- **Base:** `distroless/static` — CA roots for outbound TLS (signer, OIDC,
+  Azure Key Vault), a `nonroot` user (uid 65532), and **no shell or package
+  manager**. The SSH client is pure Go; no `openssh` inside.
+- **Entrypoint:** `mcp-broker` (the stdio MCP frontend — what an MCP client
+  launches). Arguments after the image name go to `mcp-broker`.
+- **Architectures:** `linux/amd64`, `linux/arm64`.
+
+```bash
+docker run --rm ghcr.io/luisgf/infrabroker -version
+```
+
+## stdio MCP frontend in a container
+
+Mount a directory with your `config.json` (and the PKI material it points to)
+and pass `-i` so the MCP client owns stdin/stdout:
+
+```bash
+docker run -i --rm -v /secure/path:/config \
+  ghcr.io/luisgf/infrabroker -config /config/config.json
+# podman is a drop-in replacement (rootless works):
+podman run -i --rm -v /secure/path:/config:Z \
+  ghcr.io/luisgf/infrabroker -config /config/config.json
+```
+
+Register it in Claude Code:
+
+```bash
+claude mcp add infrabroker -- docker run -i --rm \
+  -v /secure/path:/config ghcr.io/luisgf/infrabroker -config /config/config.json
+```
+
+Note that the container needs network reachability to your signer and to the
+managed hosts. For personal use the native binary is simpler (no mounts, no
+network namespace to think about) — see the [Quickstart](index.md).
+
+## Running the other binaries
+
+Everything else in the image is selected with `--entrypoint`:
+
+```bash
+docker run --rm --entrypoint /usr/local/bin/signer \
+  -v /secure/path:/config -p 9443:9443 \
+  ghcr.io/luisgf/infrabroker -config /config/signer.json
+```
+
+## Try it in 5 minutes (compose demo)
+
+`examples/compose/` in the repository spins up the full remote-signing
+topology against a **toy target** — nothing touches real servers:
+
+| Service | What it is |
+|---|---|
+| `pki-init` | One-shot provisioner: SSH CA, mTLS PKI, service configs into a volume |
+| `signer` | Holds the CA key and the policy (only `broker-1` may reach host `demo`) |
+| `sshd` | Toy target host trusting the demo CA (`TrustedUserCAKeys`), user `demo` |
+| `broker` | HTTP+mTLS frontend — runs **without** the CA key (remote signing) |
+
+```bash
+git clone https://github.com/luisgf/infrabroker && cd infrabroker/examples/compose
+docker compose up --build -d        # or: podman compose up --build -d
+curl -s http://127.0.0.1:9160/healthz && curl -s http://127.0.0.1:9180/healthz
+```
+
+Run a command through the broker (the `sshd` container carries `curl` and the
+demo agent's client certificate, so it doubles as the "agent" for testing):
+
+```bash
+docker compose exec sshd curl -s \
+  --cacert /demo/pki/agents_ca.crt \
+  --cert /demo/pki/agent.crt --key /demo/pki/agent.key \
+  https://broker:8443/v1/ssh_run -d '{"host":"demo","command":"id"}'
+# {"stdout":"uid=1000(demo) ...","stderr":"","exit_code":0,"serial":...}
+```
+
+What just happened: the broker generated an ephemeral Ed25519 key in RAM,
+asked the signer for a certificate scoped to `host:demo` with a TTL of
+minutes, opened the SSH connection itself and returned only the output. See
+the same `serial` on both sides of the trust boundary:
+
+```bash
+docker compose exec sshd sh -c 'tail -1 /demo/state/signer_audit.log'   # outcome: issued
+docker compose exec sshd sh -c 'tail -1 /demo/state/broker_audit.log'   # outcome: executed
+```
+
+Policy is default-deny — an undeclared host is refused:
+
+```bash
+docker compose exec sshd curl -s --cacert /demo/pki/agents_ca.crt \
+  --cert /demo/pki/agent.crt --key /demo/pki/agent.key \
+  https://broker:8443/v1/ssh_run -d '{"host":"prod-db","command":"id"}'
+# unknown host: "prod-db"  (404)
+```
+
+Connect Claude Code to the demo over stdio (the provisioner also wrote an
+`mcp.json` for this):
+
+```bash
+claude mcp add infrabroker-demo -- docker run -i --rm \
+  --network infrabroker-demo -v infrabroker-demo-state:/demo \
+  ghcr.io/luisgf/infrabroker -config /demo/mcp.json
+```
+
+Then ask the model to run something on `demo` (`ssh_execute`) — and watch the
+audit log grow. Tear everything down (PKI and state included):
+
+```bash
+docker compose down -v
+```
+
+Re-running `up` re-provisions from scratch; `up` over a live volume is a no-op
+(the provisioner is idempotent).
+
+## Podman notes
+
+The demo avoids Docker-only features on purpose: explicit project, network and
+volume names (`infrabroker-demo`, `infrabroker-demo-state`) so the stdio
+one-liner works identically, and healthcheck/`depends_on` conditions from the
+compose spec. It requires either `podman compose` delegating to the
+docker-compose provider or `podman-compose` recent enough to support
+`depends_on: condition:`. Rootless podman works — nothing in the demo needs
+privileged ports on the host.
+
+!!! warning "Demo ≠ production"
+    The demo trades away everything the hardened deployment is about: all
+    material lives in one volume, services share it, TTLs and cert lifetimes
+    are short but the PKI is self-signed and disposable. Production runs each
+    service as its own system user via `deploy/install.sh` (systemd), with
+    per-service PKI directories and optionally the CA key in Azure Key Vault —
+    see [Operations](OPERATIONS.md) and the
+    [deploy README](https://github.com/luisgf/infrabroker/tree/main/deploy).
+
+!!! note "Kubernetes: target vs runtime"
+    infrabroker already **brokers access to** Kubernetes clusters (the `k8s_*`
+    tools: per-operation bound ServiceAccount tokens, default-deny policy —
+    see [Tool usage §10](USAGE.md#10-kubernetes-tools-k8s_)). Running the
+    broker itself **inside** a cluster (manifests/Helm) is deliberately not
+    shipped yet; it is on the roadmap and needs its own answer for CA-key
+    custody in-cluster. The image works fine as a building block if you roll
+    your own.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,20 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-04 (v1.36.0, renombrado ssh-broker → infrabroker).
+> actualización: 2026-07-04 (v1.37.0, distribución: binarios + OCI + demo).
 >
 > Estado reciente:
+> - **v1.37.0**: release de distribución. goreleaser (archives por plataforma
+>   con los 6 binarios; el tarball del installer se conserva vía
+>   `release.extra_files`), imagen OCI multi-arch `ghcr.io/luisgf/infrabroker`
+>   (distroless/static, nonroot, entrypoint `mcp-broker`, label
+>   `io.modelcontextprotocol.server.name` para el MCP Registry), demo compose
+>   en `examples/compose/` (`make demo`; signer + sshd de juguete + broker,
+>   PKI autoprovisionada, verificada e2e con auditoría correlada) y
+>   `docs/CONTAINERS.md`. k8s como runtime del broker: APLAZADO a propósito
+>   (decisión 2026-07-04; solo k8s como target). Homebrew tap: descartado por
+>   ahora. Post-release manual: hacer público el package en ghcr (one-time) y
+>   publicar en el MCP Registry con `mcp-publisher` (server.json ya en 1.37.0).
 > - **v1.36.0**: renombrado del proyecto **ssh-broker → infrabroker** (module
 >   path, dist, CI, docs site, unidades systemd, usuarios de sistema y rutas
 >   de instalación; el repo de GitHub redirige). Sin cambios funcionales. Se

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -1,0 +1,17 @@
+# infrabroker demo (docker/podman compose)
+
+Self-contained demo: a signer holding an ephemeral SSH CA, a toy sshd target
+and a broker that executes commands with per-operation certificates — no real
+servers touched, everything discarded with `compose down -v`.
+
+```bash
+docker compose up --build -d      # or: podman compose up --build -d
+```
+
+The full walkthrough (verification curl, audit-chain inspection, connecting
+Claude Code over stdio, cleanup) lives in the documentation:
+[Containers](../../docs/CONTAINERS.md) · https://luisgf.github.io/infrabroker/CONTAINERS/
+
+**This is a demo, not a production layout** — production deployment is
+`deploy/install.sh` (systemd, one system user per service, optional Azure Key
+Vault CA custody). See [deploy/README.md](../../deploy/README.md).

--- a/examples/compose/compose.yaml
+++ b/examples/compose/compose.yaml
@@ -1,0 +1,69 @@
+# infrabroker demo — try it in 5 minutes without touching real servers.
+# See docs/CONTAINERS.md for the walkthrough. THIS IS A DEMO, NOT A
+# PRODUCTION LAYOUT: production runs the signer and broker as separate
+# system users via deploy/install.sh (systemd), ideally with the CA in
+# Azure Key Vault.
+#
+# Explicit project/network/volume names keep docker compose and podman
+# compose in sync, and make the stdio one-liner in the docs copy-pasteable.
+name: infrabroker-demo
+
+networks:
+  default:
+    name: infrabroker-demo
+
+volumes:
+  demo:
+    name: infrabroker-demo-state
+
+services:
+  # One-shot: generates the SSH CA, mTLS PKI and configs into the volume.
+  pki-init:
+    build: ./pki-init
+    volumes:
+      - demo:/demo
+
+  # Holds the CA key and the issuance policy. Only "broker-1" may request
+  # certificates, and only for host "demo".
+  signer:
+    image: ghcr.io/luisgf/infrabroker:${INFRABROKER_TAG:-latest}
+    entrypoint: ["/usr/local/bin/signer", "-config", "/demo/signer.json"]
+    volumes:
+      - demo:/demo
+    depends_on:
+      pki-init:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1:9160:9160"   # plain-HTTP /healthz + /metrics (demo only)
+
+  # Toy target host: sshd trusting the demo CA, user "demo".
+  sshd:
+    build: ./sshd
+    volumes:
+      - demo:/demo
+    depends_on:
+      pki-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "22"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  # HTTP+mTLS frontend (POST /v1/ssh_run). Runs WITHOUT the CA key: it asks
+  # the signer for a scoped ephemeral certificate per operation.
+  broker:
+    image: ghcr.io/luisgf/infrabroker:${INFRABROKER_TAG:-latest}
+    entrypoint: ["/usr/local/bin/broker", "-config", "/demo/broker.json"]
+    volumes:
+      - demo:/demo
+    depends_on:
+      pki-init:
+        condition: service_completed_successfully
+      signer:
+        condition: service_started
+      sshd:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8443:8443"   # mTLS API (client cert: /demo/pki/agent.*)
+      - "127.0.0.1:9180:9180"   # plain-HTTP /healthz + /metrics (demo only)

--- a/examples/compose/pki-init/Dockerfile
+++ b/examples/compose/pki-init/Dockerfile
@@ -1,0 +1,10 @@
+# One-shot provisioner for the demo: generates the SSH CA, the mTLS PKI and
+# the service configs into the shared /demo volume, then exits.
+FROM alpine:3.22
+
+RUN apk add --no-cache openssh-keygen openssl
+
+COPY pki-init.sh /usr/local/bin/pki-init.sh
+RUN chmod 0755 /usr/local/bin/pki-init.sh
+
+ENTRYPOINT ["/usr/local/bin/pki-init.sh"]

--- a/examples/compose/pki-init/pki-init.sh
+++ b/examples/compose/pki-init/pki-init.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Provision the infrabroker demo volume (/demo): SSH CA, demo sshd material,
+# mTLS PKI (signer<->broker and agent->broker) and the three service configs.
+# Idempotent: a marker file makes repeated `compose up` runs a no-op, so the
+# pinned host key and issued material stay stable until `compose down -v`.
+#
+# Ownership model (the trap of this demo): this container runs as root, but
+# signer/broker run as distroless nonroot (uid 65532) and the sshd container
+# runs as root with StrictModes. PKI/state/configs are chowned to 65532;
+# everything under /demo/sshd stays root-owned.
+set -eu
+
+DEMO=/demo
+MARKER="$DEMO/.provisioned"
+
+if [ -f "$MARKER" ]; then
+    echo "pki-init: $MARKER exists, nothing to do"
+    exit 0
+fi
+
+mkdir -p "$DEMO/pki" "$DEMO/sshd" "$DEMO/state"
+
+echo "== 1. SSH CA + demo host key + sshd config =="
+ssh-keygen -t ed25519 -N '' -C infrabroker-demo-ca -f "$DEMO/pki/ssh_ca" >/dev/null
+ssh-keygen -t ed25519 -N '' -f "$DEMO/sshd/host" >/dev/null
+printf 'host:demo\n' > "$DEMO/sshd/principals"
+
+cat > "$DEMO/sshd/sshd_config" <<EOF
+Port 22
+ListenAddress 0.0.0.0
+HostKey $DEMO/sshd/host
+TrustedUserCAKeys $DEMO/pki/ssh_ca.pub
+AuthorizedPrincipalsFile $DEMO/sshd/principals
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+AllowUsers demo
+LogLevel VERBOSE
+EOF
+
+echo "== 2. mTLS PKI (SANs are compose service names) =="
+P="$DEMO/pki"
+san() { printf "subjectAltName=DNS:%s" "$1" > /tmp/san.cnf; }
+
+# signer server CA + cert (validates the signer towards the broker)
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$P/signer_ca.key" \
+    -out "$P/signer_ca.crt" -days 7 -subj "/CN=demo-signer-ca" 2>/dev/null
+openssl req -newkey rsa:2048 -nodes -keyout "$P/signer.key" \
+    -out /tmp/signer.csr -subj "/CN=signer" 2>/dev/null
+san signer
+openssl x509 -req -in /tmp/signer.csr -CA "$P/signer_ca.crt" \
+    -CAkey "$P/signer_ca.key" -CAcreateserial -days 7 \
+    -out "$P/signer.crt" -extfile /tmp/san.cnf 2>/dev/null
+
+# brokers CA + broker client cert (CN=broker-1 identifies the broker to the signer)
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$P/brokers_ca.key" \
+    -out "$P/brokers_ca.crt" -days 7 -subj "/CN=demo-brokers-ca" 2>/dev/null
+openssl req -newkey rsa:2048 -nodes -keyout "$P/broker_client.key" \
+    -out /tmp/broker_client.csr -subj "/CN=broker-1" 2>/dev/null
+openssl x509 -req -in /tmp/broker_client.csr -CA "$P/brokers_ca.crt" \
+    -CAkey "$P/brokers_ca.key" -CAcreateserial -days 7 \
+    -out "$P/broker_client.crt" 2>/dev/null
+
+# agents CA + broker HTTP server cert + demo agent client cert
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$P/agents_ca.key" \
+    -out "$P/agents_ca.crt" -days 7 -subj "/CN=demo-agents-ca" 2>/dev/null
+openssl req -newkey rsa:2048 -nodes -keyout "$P/broker_server.key" \
+    -out /tmp/broker_server.csr -subj "/CN=broker" 2>/dev/null
+san broker
+openssl x509 -req -in /tmp/broker_server.csr -CA "$P/agents_ca.crt" \
+    -CAkey "$P/agents_ca.key" -CAcreateserial -days 7 \
+    -out "$P/broker_server.crt" -extfile /tmp/san.cnf 2>/dev/null
+openssl req -newkey rsa:2048 -nodes -keyout "$P/agent.key" \
+    -out /tmp/agent.csr -subj "/CN=demo-agent" 2>/dev/null
+openssl x509 -req -in /tmp/agent.csr -CA "$P/agents_ca.crt" \
+    -CAkey "$P/agents_ca.key" -CAcreateserial -days 7 \
+    -out "$P/agent.crt" 2>/dev/null
+
+echo "== 3. audit seeds + service configs =="
+head -c 32 /dev/urandom > "$DEMO/state/signer_audit.seed"
+head -c 32 /dev/urandom > "$DEMO/state/broker_audit.seed"
+head -c 32 /dev/urandom > "$DEMO/state/mcp_audit.seed"
+
+HOST_PUB="$(cat "$DEMO/sshd/host.pub")"
+
+# Signer: CA custody + policy, and the single source of truth for hosts —
+# in remote mode the broker takes its host table from GET /v1/hosts, so the
+# full definition (addr, user, host_key) lives here. Only broker-1 may
+# request certs for "demo". No source_address pin: container IPs are
+# dynamic in the demo network.
+cat > "$DEMO/signer.json" <<EOF
+{
+  "listen": ":9443",
+  "server_cert": "$P/signer.crt",
+  "server_key": "$P/signer.key",
+  "client_ca": "$P/brokers_ca.crt",
+  "ca_key": "$P/ssh_ca",
+  "audit_log": "$DEMO/state/signer_audit.log",
+  "audit_key": "$DEMO/state/signer_audit.seed",
+  "monitor_listen": "0.0.0.0:9160",
+  "max_ttl_seconds": 120,
+  "hosts": {
+    "demo": {
+      "addr": "sshd:22",
+      "user": "demo",
+      "host_key": "$HOST_PUB",
+      "principal": "host:demo",
+      "max_ttl_seconds": 120,
+      "allowed_callers": ["broker-1"]
+    }
+  }
+}
+EOF
+
+# Broker (HTTP+mTLS frontend): no ca_key and no hosts — remote signing, and
+# the host table comes from the signer.
+cat > "$DEMO/broker.json" <<EOF
+{
+  "listen": ":8443",
+  "server_cert": "$P/broker_server.crt",
+  "server_key": "$P/broker_server.key",
+  "client_ca": "$P/agents_ca.crt",
+  "audit_log": "$DEMO/state/broker_audit.log",
+  "audit_key": "$DEMO/state/broker_audit.seed",
+  "monitor_listen": "0.0.0.0:9180",
+  "max_ttl_seconds": 120,
+  "signer": {
+    "url": "https://signer:9443",
+    "client_cert": "$P/broker_client.crt",
+    "client_key": "$P/broker_client.key",
+    "ca": "$P/signer_ca.crt"
+  }
+}
+EOF
+
+# stdio MCP config (for `docker run -i ... mcp-broker` joined to this network).
+cat > "$DEMO/mcp.json" <<EOF
+{
+  "audit_log": "$DEMO/state/mcp_audit.log",
+  "audit_key": "$DEMO/state/mcp_audit.seed",
+  "max_ttl_seconds": 120,
+  "signer": {
+    "url": "https://signer:9443",
+    "client_cert": "$P/broker_client.crt",
+    "client_key": "$P/broker_client.key",
+    "ca": "$P/signer_ca.crt"
+  }
+}
+EOF
+
+echo "== 4. ownership: 65532 (distroless nonroot) except sshd material =="
+chown -R 65532:65532 "$DEMO/pki" "$DEMO/state" \
+    "$DEMO/signer.json" "$DEMO/broker.json" "$DEMO/mcp.json"
+chmod 600 "$P"/*.key "$P/ssh_ca" "$DEMO/state/"*.seed
+chmod 644 "$P"/*.crt "$P/ssh_ca.pub"
+chown root:root "$DEMO/sshd" "$DEMO/sshd/host" "$DEMO/sshd/host.pub" \
+    "$DEMO/sshd/principals" "$DEMO/sshd/sshd_config"
+chmod 600 "$DEMO/sshd/host"
+chmod 644 "$DEMO/sshd/host.pub" "$DEMO/sshd/principals" "$DEMO/sshd/sshd_config"
+
+touch "$MARKER"
+echo "pki-init: demo volume provisioned"

--- a/examples/compose/pki-init/pki-init.sh
+++ b/examples/compose/pki-init/pki-init.sh
@@ -6,8 +6,9 @@
 #
 # Ownership model (the trap of this demo): this container runs as root, but
 # signer/broker run as distroless nonroot (uid 65532) and the sshd container
-# runs as root with StrictModes. PKI/state/configs are chowned to 65532;
-# everything under /demo/sshd stays root-owned.
+# runs as root. OpenSSH's default StrictModes then requires the host key to be
+# owned by root and not group/world-writable, so PKI/state/configs are chowned
+# to 65532 while everything under /demo/sshd stays root-owned 0600.
 set -eu
 
 DEMO=/demo

--- a/examples/compose/sshd/Dockerfile
+++ b/examples/compose/sshd/Dockerfile
@@ -1,0 +1,14 @@
+# Toy SSH target for the demo: trusts the demo CA via TrustedUserCAKeys and
+# accepts certificate logins as user "demo". It also carries curl so the
+# docs' verification commands (mTLS curl against the broker, reading the
+# audit logs) can run from inside the demo network.
+FROM alpine:3.22
+
+RUN apk add --no-cache openssh-server curl \
+    && adduser -D -s /bin/sh demo \
+    # adduser -D leaves the account locked ("!"); sshd refuses logins for
+    # locked accounts even with certificate auth. "*" = no password, unlocked.
+    && sed -i 's/^demo:!/demo:*/' /etc/shadow
+
+# Config and host key live in the shared /demo volume (written by pki-init).
+ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e", "-f", "/demo/sshd/sshd_config"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: infrabroker
-site_description: SSH access broker with an ephemeral CA for AI agents
+site_description: Infrastructure access broker for AI agents — SSH & Kubernetes, ephemeral credentials
 site_url: https://luisgf.github.io/infrabroker/
 repo_url: https://github.com/luisgf/infrabroker
 repo_name: luisgf/infrabroker
@@ -75,6 +75,7 @@ nav:
   - Architecture: ARCHITECTURE.md
   - Threat model: THREAT_MODEL.md
   - Operations: OPERATIONS.md
+  - Containers: CONTAINERS.md
   - API reference: API.md
   - Tool usage: USAGE.md
   - Security: SECURITY.md

--- a/server.json
+++ b/server.json
@@ -6,13 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "1.36.0",
+  "version": "1.37.0",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker",
-      "version": "1.36.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:1.37.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

Phase 2 of the visibility plan — kill the install friction:

- **goreleaser** (`.goreleaser.yaml`): 4 per-platform archives (linux/darwin × amd64/arm64) with the six binaries + example configs, `checksums.txt`, github-native changelog. It is now the single owner of the GitHub release; `make dist` still produces the installer tarball (same asset name, `deploy/install.sh` contract untouched) attached via `release.extra_files`. `dist: dist-goreleaser` so `--clean` never wipes the Makefile's `dist/`.
- **OCI image** `ghcr.io/luisgf/infrabroker` (`Dockerfile` + `dockers_v2`): multi-arch (amd64/arm64), distroless/static, nonroot, all six binaries, entrypoint `mcp-broker`, other binaries via `--entrypoint`. Carries the `io.modelcontextprotocol.server.name` label — the MCP Registry validates OCI package ownership against it. `server.json` bumped to `ghcr.io/luisgf/infrabroker:1.37.0` (version embedded in the identifier — the registry's OCI validator rejects a separate `version` field).
- **Compose demo** (`examples/compose/`, `make demo`): pki-init (one-shot, idempotent) + signer + toy sshd + broker in remote-signing mode. mTLS SANs are compose service names; the full host definition lives in `signer.json` (single source of truth — in remote mode the broker's host table comes from `GET /v1/hosts`). Ownership split handled (uid 65532 for services, root for sshd StrictModes material).
- **Docs**: new `docs/CONTAINERS.md` (image, stdio in a container, demo walkthrough, podman/rootless notes, demo≠production and k8s-target≠k8s-runtime admonitions) + README Install section + changelog v1.37.0.

Deliberately out of scope (decided 2026-07-04): k8s-as-runtime manifests/Helm (roadmap note only) and Homebrew tap.

## Verification (all run locally)

- `goreleaser check` + `goreleaser release --snapshot --clean`: 4 archives with 6 binaries each, images built; `docker run --rm <img> -version` (entrypoint) and each binary via `--entrypoint` OK; MCP label present in image config; `make dist` + goreleaser coexistence confirmed.
- Compose e2e (snapshot image): `/healthz` on 9160/9180; `POST /v1/ssh_run {"host":"demo","command":"id"}` → `uid=1000(demo)`, exit 0, same serial in `signer_audit.log` (issued) and `broker_audit.log` (executed); undeclared host → 404; stdio `mcp-broker` joined the demo network and loaded hosts from the signer; re-up idempotent; `down -v && up` reprovisions.
- Not verified locally: podman (not installed here) — the compose file sticks to spec features and documents the minimum podman-compose requirement; and the actual ghcr push/multi-arch manifest, which first runs on the v1.37.0 tag.
- `make verify` green (gofmt, vet, build, race tests, docs drift gate, strict mkdocs).

## After merge

1. Tag `v1.37.0` (changelog ready) and watch the release workflow (first goreleaser run).
2. One-time manual: make the ghcr package public (Settings → Packages) — anonymous pulls and registry validation need it.
3. `docker buildx imagetools inspect ghcr.io/luisgf/infrabroker:1.37.0` (manifest list + labels).
4. Then the MCP Registry publish (`mcp-publisher login github && mcp-publisher publish`) unblocks.