### PR TITLE
fix: audit pass — 5 verified low/medium findings (#96–#100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pki/
 config.json
 signer.json
 broker-ctl.json
+control-plane.json
 
 # Logs de auditoría (datos operativos)
 *.log

--- a/cmd/signer/buildstate_test.go
+++ b/cmd/signer/buildstate_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestBuildStateRejectsExcessiveGlobalMaxTTL is the regression test for the gap
+// where the global max_ttl_seconds (unlike the per-host one, validated in
+// CompileHostPolicies) was not checked at load, so a value above the 900s
+// certificate cap made every issuance for an uncapped host fail at request
+// time. buildState now rejects it up front.
+func TestBuildStateRejectsExcessiveGlobalMaxTTL(t *testing.T) {
+	t.Parallel()
+
+	// 901s is over the 15m certificate cap: rejected at load with a clear error.
+	if _, err := buildState(context.Background(), &Config{MaxTTLSeconds: 901}, nil); err == nil {
+		t.Fatal("buildState accepted max_ttl_seconds=901 (over the 900s cap)")
+	} else if !strings.Contains(err.Error(), "exceeds the 900s") {
+		t.Fatalf("wrong rejection error: %v", err)
+	}
+
+	// 900s is exactly the cap and must pass the TTL gate — the build then fails
+	// later (no CA key configured), which must NOT be the TTL error.
+	if _, err := buildState(context.Background(), &Config{MaxTTLSeconds: 900}, nil); err == nil {
+		t.Fatal("expected a later build error (missing CA key) for max_ttl_seconds=900")
+	} else if strings.Contains(err.Error(), "exceeds the 900s") {
+		t.Fatalf("max_ttl_seconds=900 must pass the TTL gate, got: %v", err)
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -337,6 +337,14 @@ func configModTime(path string) time.Time {
 // shared, stable GrantStore (created once in main and threaded through every
 // rebuild) so runtime grants survive config reloads; pass nil for none.
 func buildState(ctx context.Context, cfg *Config, grants signer.GrantProvider) (*signer.Local, error) {
+	// The CA hard-rejects any certificate TTL over 15m (ca.BuildAndSign), so a
+	// global max_ttl_seconds above that cap would make every issuance for a host
+	// with no per-host max_ttl_seconds fail at request time. Reject it at load,
+	// mirroring the per-host check in CompileHostPolicies (#45), instead of
+	// surfacing a silent per-request denial.
+	if cfg.MaxTTLSeconds > 900 {
+		return nil, fmt.Errorf("max_ttl_seconds %d exceeds the 900s (15m) certificate cap", cfg.MaxTTLSeconds)
+	}
 	// Compile + validate the host policies before touching anything so an invalid
 	// reload (bad command_policy regex, unknown mode, dangling jump, unknown group
 	// policy reference) is rejected up front and the previous good state is

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -179,35 +179,12 @@ func (m *sessionManager) add(s *liveSession) error {
 	return nil
 }
 
-func (m *sessionManager) get(id string) (*liveSession, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	s, ok := m.sessions[id]
-	if ok {
-		s.lastUsed = time.Now()
-	}
-	return s, ok
-}
-
-// checkout returns the session and marks one command as in flight, so the
-// reaper will not close the connection while the command runs. Every
-// successful checkout must be paired with a checkin when the command ends.
-func (m *sessionManager) checkout(id string) (*liveSession, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	s, ok := m.sessions[id]
-	if ok {
-		s.lastUsed = time.Now()
-		s.busy++
-	}
-	return s, ok
-}
-
-// checkoutOwned is checkout with an ownership gate. It returns found=false for
-// an unknown id, owned=false (WITHOUT mutating any state) when caller does not
-// own the session, and otherwise marks one command in flight (busy++,
-// lastUsed=now) and returns owned=true. Performing the C1 check under the lock
-// before mutating prevents a non-owner from refreshing another caller's
+// checkoutOwned looks up a session and, if caller owns it, marks one command in
+// flight (busy++, lastUsed=now) and returns owned=true. It returns found=false
+// for an unknown id and owned=false (WITHOUT mutating any state) when caller
+// does not own the session. Every successful checkout must be paired with a
+// checkin when the command ends. Performing the C1 ownership check under the
+// lock before mutating prevents a non-owner from refreshing another caller's
 // lastUsed or holding busy>0 to keep the reaper from closing the session.
 func (m *sessionManager) checkoutOwned(id, caller string) (s *liveSession, found, owned bool) {
 	m.mu.Lock()
@@ -233,16 +210,6 @@ func (m *sessionManager) checkin(s *liveSession) {
 		s.busy--
 	}
 	s.lastUsed = time.Now()
-}
-
-func (m *sessionManager) remove(id string) (*liveSession, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	s, ok := m.sessions[id]
-	if ok {
-		delete(m.sessions, id)
-	}
-	return s, ok
 }
 
 // removeOwned deletes the session only if it belongs to caller, atomically and
@@ -640,24 +607,6 @@ func shellQuoteSession(s string) string {
 	}
 	b.WriteByte('\'')
 	return b.String()
-}
-
-// elevationLabelFromPrefix builds the audit label from the prefix stored in the
-// session (e.g. "sudo -n" → "sudo:root").
-func elevationLabelFromPrefix(prefix string) string {
-	// "sudo -n" → root; "sudo -n -u deploy" → deploy
-	if prefix == "sudo -n" {
-		return "sudo:root"
-	}
-	// Extract the user from the -u flag.
-	const flag = "-u "
-	if idx := len("sudo -n "); idx < len(prefix) {
-		rest := prefix[idx:]
-		if len(rest) > 3 && rest[:3] == "-u " {
-			return "sudo:" + rest[3:]
-		}
-	}
-	return "sudo:?"
 }
 
 func newSessionID() string {

--- a/internal/broker/session_test.go
+++ b/internal/broker/session_test.go
@@ -42,6 +42,16 @@ func dummySession(id, caller string) *liveSession {
 	}
 }
 
+// peek returns a session with NO side effects (no lastUsed refresh, no busy
+// change), for asserting manager state in tests. Production code reaches
+// sessions only through the ownership-gated checkoutOwned/removeOwned.
+func peek(m *sessionManager, id string) (*liveSession, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[id]
+	return s, ok
+}
+
 // testAuditLog abre un log de auditoría temporal para tests que necesitan un Engine.
 func testAuditLog(t *testing.T) *audit.Log {
 	t.Helper()
@@ -64,24 +74,23 @@ func TestSessionManagerAddGetRemove(t *testing.T) {
 		t.Fatalf("add: %v", err)
 	}
 
-	got, ok := m.get("s1")
+	got, ok := peek(m, "s1")
 	if !ok || got.id != "s1" {
-		t.Fatalf("get después de add: ok=%v, got=%v", ok, got)
+		t.Fatalf("peek después de add: ok=%v, got=%v", ok, got)
 	}
 
-	removed, ok := m.remove("s1")
-	if !ok || removed.id != "s1" {
-		t.Fatalf("remove: ok=%v", ok)
+	removed, _, owned := m.removeOwned("s1", "alice")
+	if !owned || removed.id != "s1" {
+		t.Fatalf("removeOwned: owned=%v", owned)
 	}
 
 	// Después del remove ya no debe existir.
-	_, ok = m.get("s1")
-	if ok {
-		t.Error("get después de remove debe devolver false")
+	if _, ok := peek(m, "s1"); ok {
+		t.Error("peek después de removeOwned debe devolver false")
 	}
 }
 
-func TestSessionManagerGetActualizaLastUsed(t *testing.T) {
+func TestSessionManagerCheckoutOwnedActualizaLastUsed(t *testing.T) {
 	m := newTestSessionManager(t)
 	s := dummySession("s2", "bob")
 	s.lastUsed = time.Now().Add(-10 * time.Minute)
@@ -89,25 +98,28 @@ func TestSessionManagerGetActualizaLastUsed(t *testing.T) {
 
 	before := s.lastUsed
 	time.Sleep(2 * time.Millisecond)
-	got, _ := m.get("s2")
-	if !got.lastUsed.After(before) {
-		t.Error("get debe actualizar lastUsed")
+	if _, found, owned := m.checkoutOwned("s2", "bob"); !found || !owned {
+		t.Fatal("checkoutOwned debe encontrar la sesión del propietario")
+	}
+	m.mu.Lock()
+	last := s.lastUsed
+	m.mu.Unlock()
+	if !last.After(before) {
+		t.Error("checkoutOwned debe actualizar lastUsed")
 	}
 }
 
 func TestSessionManagerGetInexistente(t *testing.T) {
 	m := newTestSessionManager(t)
-	_, ok := m.get("nope")
-	if ok {
-		t.Error("get de id inexistente debe devolver false")
+	if _, ok := peek(m, "nope"); ok {
+		t.Error("peek de id inexistente debe devolver false")
 	}
 }
 
 func TestSessionManagerRemoveInexistente(t *testing.T) {
 	m := newTestSessionManager(t)
-	_, ok := m.remove("nope")
-	if ok {
-		t.Error("remove de id inexistente debe devolver false")
+	if _, found, _ := m.removeOwned("nope", "alice"); found {
+		t.Error("removeOwned de id inexistente debe devolver found=false")
 	}
 }
 
@@ -185,7 +197,7 @@ func TestSessionManagerReaperIdleTTL(t *testing.T) {
 		t.Error("el reaper debería haber eliminado la sesión stale")
 	}
 
-	if _, ok := m.get("stale"); ok {
+	if _, ok := peek(m, "stale"); ok {
 		t.Error("la sesión stale no debería existir tras el reaper")
 	}
 }
@@ -203,9 +215,9 @@ func TestSessionManagerReaperNoMataSesionesOcupadas(t *testing.T) {
 	_ = m.add(s)
 
 	// Marcar la sesión como ocupada (comando en vuelo).
-	got, ok := m.checkout("busy")
-	if !ok || got != s {
-		t.Fatalf("checkout: ok=%v", ok)
+	got, found, owned := m.checkoutOwned("busy", "alice")
+	if !found || !owned || got != s {
+		t.Fatalf("checkoutOwned: found=%v owned=%v", found, owned)
 	}
 
 	// Forzar el vencimiento de idle TTL y maxLife.
@@ -215,7 +227,7 @@ func TestSessionManagerReaperNoMataSesionesOcupadas(t *testing.T) {
 	m.mu.Unlock()
 
 	m.reapExpired(time.Now())
-	if _, ok := m.get("busy"); !ok {
+	if _, ok := peek(m, "busy"); !ok {
 		t.Fatal("el reaper no debe cerrar una sesión con un comando en vuelo")
 	}
 	select {
@@ -232,7 +244,7 @@ func TestSessionManagerReaperNoMataSesionesOcupadas(t *testing.T) {
 	m.mu.Unlock()
 
 	m.reapExpired(time.Now())
-	if _, ok := m.get("busy"); ok {
+	if _, ok := peek(m, "busy"); ok {
 		t.Error("la sesión libre con maxLife vencido debe recolectarse en el primer tick")
 	}
 	select {
@@ -253,9 +265,9 @@ func TestSessionManagerCheckinActualizaLastUsed(t *testing.T) {
 	s := dummySession("s-checkin", "alice")
 	_ = m.add(s)
 
-	got, ok := m.checkout("s-checkin")
-	if !ok {
-		t.Fatal("checkout debe encontrar la sesión")
+	got, found, owned := m.checkoutOwned("s-checkin", "alice")
+	if !found || !owned {
+		t.Fatal("checkoutOwned debe encontrar la sesión del propietario")
 	}
 	m.mu.Lock()
 	got.lastUsed = time.Now().Add(-10 * time.Minute) // simular comando largo
@@ -703,7 +715,7 @@ func TestCloseSessionOwnershipC1(t *testing.T) {
 	}
 
 	// La sesión debe seguir existiendo.
-	_, ok := e.sessions.get("sess-close")
+	_, ok := peek(e.sessions, "sess-close")
 	if !ok {
 		t.Error("la sesión no debe eliminarse si el caller no es el propietario")
 	}
@@ -728,7 +740,7 @@ func TestCloseSessionHappyPath(t *testing.T) {
 	}
 
 	// Después del cierre la sesión no debe existir.
-	_, ok := e.sessions.get("sess-ok")
+	_, ok := peek(e.sessions, "sess-ok")
 	if ok {
 		t.Error("la sesión debe eliminarse tras CloseSession exitoso")
 	}
@@ -798,20 +810,19 @@ func TestShellQuoteSession(t *testing.T) {
 	}
 }
 
-func TestElevationLabelFromPrefix(t *testing.T) {
+func TestExecOptionsElevationLabel(t *testing.T) {
 	cases := []struct {
-		prefix string
-		want   string
+		opts ExecOptions
+		want string
 	}{
-		{"sudo -n", "sudo:root"},
-		{"sudo -n -u deploy", "sudo:deploy"},
-		{"sudo -n -u appuser", "sudo:appuser"},
-		{"sudo -n something-else", "sudo:?"},
+		{ExecOptions{}, ""},
+		{ExecOptions{Sudo: true}, "sudo:root"},
+		{ExecOptions{Sudo: true, SudoUser: "deploy"}, "sudo:deploy"},
+		{ExecOptions{Sudo: true, SudoUser: "appuser"}, "sudo:appuser"},
 	}
 	for _, c := range cases {
-		got := elevationLabelFromPrefix(c.prefix)
-		if got != c.want {
-			t.Errorf("prefix=%q got=%q want=%q", c.prefix, got, c.want)
+		if got := c.opts.elevationLabel(); got != c.want {
+			t.Errorf("opts=%+v got=%q want=%q", c.opts, got, c.want)
 		}
 	}
 }

--- a/internal/mcpserver/tools_k8s.go
+++ b/internal/mcpserver/tools_k8s.go
@@ -105,6 +105,12 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			"Omit namespace to list across all namespaces the ServiceAccount can read. " +
 			"REQUIRES an allow rule; use dry_run=true to preview.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sListInput) (*mcp.CallToolResult, k8sOutput, error) {
+		// The selectors are model-controlled and reach the API-server query
+		// string; validate them like every other field (length cap + null-byte
+		// rejection) since runK8s only covers the K8sAction fields.
+		if err := validateInput(map[string]string{"label_selector": in.LabelSelector, "field_selector": in.FieldSelector}); err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+		}
 		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
 			Verb: signer.K8sVerbList, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace,
 		}, nil, in.DryRun, broker.K8sExecuteOpts{List: k8s.ListOptions{
@@ -117,6 +123,11 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 		Description: "Read a pod's container logs (plain text). " +
 			"REQUIRES an allow rule for verb=logs; use dry_run=true to preview.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sLogsInput) (*mcp.CallToolResult, k8sOutput, error) {
+		// container is model-controlled and reaches the API-server query string;
+		// validate it like every other field (runK8s only covers K8sAction fields).
+		if err := validateInput(map[string]string{"container": in.Container}); err != nil {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+		}
 		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
 			Verb: signer.K8sVerbLogs, Resource: "pods", Namespace: in.Namespace, Name: in.Pod,
 		}, nil, in.DryRun, broker.K8sExecuteOpts{Logs: k8s.LogOptions{

--- a/internal/mcpserver/tools_k8s_test.go
+++ b/internal/mcpserver/tools_k8s_test.go
@@ -1,0 +1,132 @@
+package mcpserver
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/luisgf/infrabroker/internal/broker"
+)
+
+// testEngineNoClusters builds a minimal engine (no Kubernetes clusters) good
+// enough to register the k8s tools. The input-validation gate short-circuits
+// before the engine is ever touched, so no live cluster is needed.
+func testEngineNoClusters(t *testing.T) *broker.Engine {
+	t.Helper()
+	dir := t.TempDir()
+
+	_, caPriv, _ := ed25519.GenerateKey(rand.Reader)
+	blk, err := ssh.MarshalPrivateKey(caPriv, "ca-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(dir, "ca")
+	if err := os.WriteFile(caPath, pem.EncodeToMemory(blk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedPath := filepath.Join(dir, "audit.seed")
+	seed := make([]byte, 32)
+	_, _ = rand.Read(seed)
+	if err := os.WriteFile(seedPath, seed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng, err := broker.NewEngine(&broker.Config{
+		CAKey:         caPath,
+		AuditLog:      filepath.Join(dir, "audit.log"),
+		AuditKey:      seedPath,
+		SourceAddress: "127.0.0.1",
+		MaxTTLSeconds: 120,
+		Hosts: map[string]broker.HostConfig{
+			"web01": {Addr: "10.0.0.21:22", User: "deploy", Principal: "host:web01", HostKey: "ssh-ed25519 AAAAC3Nz"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { eng.Close() })
+	return eng
+}
+
+// k8sTestSession registers the k8s tools on an in-memory server and returns a
+// connected client session.
+func k8sTestSession(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	eng := testEngineNoClusters(t)
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	RegisterK8s(srv, eng, func(context.Context) broker.Caller { return broker.Caller{ID: "test"} })
+
+	ct, st := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(context.Background(), st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	sess, err := client.Connect(context.Background(), ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	return sess
+}
+
+func k8sToolText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	return sb.String()
+}
+
+// TestK8sSelectorAndContainerValidated is the regression test for the gap where
+// k8s_list selectors and the k8s_logs container bypassed validateInput. Before
+// the fix a null byte in those fields passed the input gate and reached the
+// engine (producing a cluster-not-found error, not a validation error); the fix
+// rejects it up front with the same null-byte/length guarantees every other
+// field gets.
+func TestK8sSelectorAndContainerValidated(t *testing.T) {
+	t.Parallel()
+	sess := k8sTestSession(t)
+	ctx := context.Background()
+	big := strings.Repeat("a", 64*1024+1)
+
+	cases := []struct {
+		name string
+		tool string
+		args map[string]any
+		want string
+	}{
+		{"list_label_selector_null", "k8s_list",
+			map[string]any{"cluster": "c1", "resource": "pods", "label_selector": "app=x\x00y"}, "null bytes"},
+		{"list_field_selector_null", "k8s_list",
+			map[string]any{"cluster": "c1", "resource": "pods", "field_selector": "status.phase=\x00"}, "null bytes"},
+		{"list_label_selector_too_long", "k8s_list",
+			map[string]any{"cluster": "c1", "resource": "pods", "label_selector": big}, "exceeds the limit"},
+		{"logs_container_null", "k8s_logs",
+			map[string]any{"cluster": "c1", "namespace": "ns", "pod": "p", "container": "c\x00"}, "null bytes"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := sess.CallTool(ctx, &mcp.CallToolParams{Name: tc.tool, Arguments: tc.args})
+			if err != nil {
+				t.Fatalf("CallTool transport error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("expected a tool error, got success: %s", k8sToolText(t, res))
+			}
+			if got := k8sToolText(t, res); !strings.Contains(got, tc.want) {
+				t.Fatalf("error %q does not contain %q — validation gate did not fire", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/policyrec/policyrec.go
+++ b/internal/policyrec/policyrec.go
@@ -57,6 +57,7 @@ type Options struct {
 type stat struct {
 	count, approved int
 	callers         map[string]struct{}
+	seenApprovals   map[string]struct{} // ApprovalIDs already counted (dedup)
 	first, last     time.Time
 	samples         []string
 }
@@ -64,21 +65,47 @@ type stat struct {
 func (s *stat) observe(e audit.Entry, approved bool) {
 	if s.callers == nil {
 		s.callers = map[string]struct{}{}
+		s.seenApprovals = map[string]struct{}{}
 		s.first = e.Time
+	}
+	// A single human approval is written to the control-plane audit log twice —
+	// once at the decision (approval-decision-allow[-learn]) and once at the
+	// consumption (approval-granted), with the same ApprovalID. Count each
+	// distinct approval once so a lone approve-then-run does not inflate support
+	// to 2. Entries without an ApprovalID (executed/session_exec/dry_run_*)
+	// carry an empty ID and always count.
+	if e.ApprovalID != "" {
+		if _, dup := s.seenApprovals[e.ApprovalID]; dup {
+			s.callers[e.Caller] = struct{}{}
+			s.bumpTimes(e.Time)
+			s.addSample(e.Command)
+			return
+		}
+		s.seenApprovals[e.ApprovalID] = struct{}{}
 	}
 	s.count++
 	if approved {
 		s.approved++
 	}
 	s.callers[e.Caller] = struct{}{}
-	if e.Time.Before(s.first) {
-		s.first = e.Time
+	s.bumpTimes(e.Time)
+	s.addSample(e.Command)
+}
+
+// bumpTimes widens the [first, last] window to include t.
+func (s *stat) bumpTimes(t time.Time) {
+	if t.Before(s.first) {
+		s.first = t
 	}
-	if e.Time.After(s.last) {
-		s.last = e.Time
+	if t.After(s.last) {
+		s.last = t
 	}
-	if len(s.samples) < 3 && !contains(s.samples, e.Command) {
-		s.samples = append(s.samples, e.Command)
+}
+
+// addSample records up to three distinct example commands.
+func (s *stat) addSample(cmd string) {
+	if len(s.samples) < 3 && !contains(s.samples, cmd) {
+		s.samples = append(s.samples, cmd)
 	}
 }
 

--- a/internal/policyrec/policyrec_test.go
+++ b/internal/policyrec/policyrec_test.go
@@ -127,6 +127,42 @@ func TestRecommendDeniedApprovalNotPromoted(t *testing.T) {
 	}
 }
 
+// TestRecommendApprovalCountedOncePerApprovalID is the regression test for the
+// double-count where one human approval, written to the audit log twice (the
+// approval-decision-allow[-learn] decision AND the approval-granted
+// consumption, sharing an ApprovalID), was counted as support 2. A single
+// approve-then-run must count once; two distinct approvals count twice.
+func TestRecommendApprovalCountedOncePerApprovalID(t *testing.T) {
+	t.Parallel()
+	compiled := testPolicy(t)
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	mk := func(outcome, id string, ts time.Time) audit.Entry {
+		return audit.Entry{Host: "web01", Command: "systemctl restart nginx", Outcome: outcome, Caller: "a", Time: ts, ApprovalID: id}
+	}
+
+	// One approval lifecycle: decision + consumption share ApprovalID appr-1.
+	one := Recommend([]audit.Entry{
+		mk("approval-decision-allow", "appr-1", now),
+		mk("approval-granted", "appr-1", now.Add(time.Second)),
+	}, compiled, Options{})
+	if p := find(t, one, Promote, "web01", "^systemctl restart nginx$"); p == nil {
+		t.Fatalf("approved command must be promoted; got %+v", one)
+	} else if p.Count != 1 || p.Approved != 1 {
+		t.Errorf("one approval double-counted: count=%d approved=%d (want 1/1)", p.Count, p.Approved)
+	}
+
+	// Two DISTINCT approvals of the same command count twice.
+	two := Recommend([]audit.Entry{
+		mk("approval-decision-allow", "appr-1", now),
+		mk("approval-granted", "appr-1", now.Add(time.Second)),
+		mk("approval-decision-allow-learn", "appr-2", now.Add(2*time.Second)),
+		mk("approval-granted", "appr-2", now.Add(3*time.Second)),
+	}, compiled, Options{})
+	if p := find(t, two, Promote, "web01", "^systemctl restart nginx$"); p == nil || p.Count != 2 || p.Approved != 2 {
+		t.Errorf("two distinct approvals should count 2/2: %+v", p)
+	}
+}
+
 func TestRecommendMinCountAndHostFilter(t *testing.T) {
 	t.Parallel()
 	compiled := testPolicy(t)


### PR DESCRIPTION
Autonomous `/audit` pass. Six findings were surfaced by a parallel read-only
audit and each was adversarially re-verified (2 independent skeptic lenses per
finding) before filing. This PR lands the five fixable ones, one commit each,
each with tests. The sixth (#101) is a real defect but its only fix changes a
deliberate fail-closed tamper-evidence contract, so it is labeled
`needs-human` and intentionally excluded.

| Issue | Sev | Fix |
|------|-----|-----|
| #96 (security) | low | `.gitignore` the secret-carrying `control-plane.json` (sibling of the other three service configs) |
| #97 (security) | low | Validate `k8s_list` selectors and `k8s_logs` container as MCP inputs (length cap + null-byte), closing the every-field gap |
| #98 (logic) | low | Count each human approval once in policyrec Promote support (dedupe by ApprovalID; decision + consumption no longer double-count) |
| #99 (logic) | low | Reject a global `max_ttl_seconds` over the 900s cap at load (sibling of the per-host #45 fix) |
| #100 (logic) | low | Remove dead test-only session accessors + orphaned elevation-label helper (class of #68); port coverage to the production owned-variants |

**Excluded:** #101 (logic/medium) — a mid-object torn final audit record bricks
signer startup, but recovering means changing the fail-closed contract that
`TestRestoreChainUltimaLineaMalformada` deliberately encodes (a truncated
trailing record is indistinguishable from a truncation attack). Labeled
`needs-human` for a maintainer posture decision.

**Verification:** `make verify` green — gofmt, vet, build, `go test -race ./...`,
govulncheck (no vulnerabilities), docs drift gate, and strict mkdocs site build.
Every fix ships a regression test; the #97/#98 tests were confirmed to fail
without their fix.