### PR TITLE
feat: broker-ctl audit repair — explicit recovery for a torn final audit record (#101)

### DIFF
--- a/cmd/broker-ctl/audit_repair_test.go
+++ b/cmd/broker-ctl/audit_repair_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/audit"
+)
+
+func rec(seq int) string { return fmt.Sprintf(`{"seq":%d,"outcome":"executed"}`, seq) }
+
+func TestAuditTrailingCorruption(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		data        string
+		wantGood    int
+		wantLastSeq uint64
+		wantCorrupt string // expected corruptTail contents ("" = none)
+		wantMiddle  bool
+	}{
+		{"clean", rec(1) + "\n" + rec(2) + "\n", 2, 2, "", false},
+		{"torn_tail", rec(1) + "\n" + rec(2) + "\n" + `{"seq":3,"outc`, 2, 2, `{"seq":3,"outc`, false},
+		{"complete_no_newline", rec(1) + "\n" + rec(2), 2, 2, "", false},
+		{"middle_corruption", rec(1) + "\n" + "garbage\n" + rec(3) + "\n", 1, 1, "", true},
+		{"all_corrupt", "garbage-line\n", 0, 0, "garbage-line\n", false},
+		{"trailing_blank", rec(1) + "\n\n", 1, 1, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cleanEnd, lastSeq, good, corrupt, middle := auditTrailingCorruption([]byte(c.data))
+			if good != c.wantGood || lastSeq != c.wantLastSeq || middle != c.wantMiddle {
+				t.Errorf("good=%d lastSeq=%d middle=%v; want %d/%d/%v", good, lastSeq, middle, c.wantGood, c.wantLastSeq, c.wantMiddle)
+			}
+			if string(corrupt) != c.wantCorrupt {
+				t.Errorf("corruptTail=%q; want %q", corrupt, c.wantCorrupt)
+			}
+			// cleanEnd must point exactly past the kept prefix.
+			if string(corrupt) != "" && cleanEnd != len(c.data)-len(c.wantCorrupt) {
+				t.Errorf("cleanEnd=%d; want %d", cleanEnd, len(c.data)-len(c.wantCorrupt))
+			}
+		})
+	}
+}
+
+// TestAuditRepairEndToEnd reproduces the #101 startup brick (a torn final
+// record makes audit.Open fail) and proves that `audit repair --apply`
+// quarantines the corrupt bytes, restores bootability, and keeps the chain
+// verifiable.
+func TestAuditRepairEndToEnd(t *testing.T) {
+	path, key := buildLog(t, 3)
+	good, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read good log: %v", err)
+	}
+
+	// Simulate a torn write: a truncated JSON record with no closing brace and
+	// no trailing newline appended after the last good record.
+	torn := append(append([]byte{}, good...), []byte(`{"seq":4,"caller":"x","comm`)...)
+	if err := os.WriteFile(path, torn, 0o600); err != nil {
+		t.Fatalf("write torn log: %v", err)
+	}
+
+	// Repro: the signer path (audit.Open -> restoreChain) refuses to boot.
+	if _, err := audit.Open(path, key); err == nil {
+		t.Fatal("expected audit.Open to fail on a torn trailing record (repro #101)")
+	}
+
+	// Recover with the explicit operator command.
+	cmdAuditRepair([]string{"--log", path, "--apply"})
+
+	// The signer can boot again.
+	l, err := audit.Open(path, key)
+	if err != nil {
+		t.Fatalf("audit.Open after repair still fails: %v", err)
+	}
+	l.Close()
+
+	// The repaired file is exactly the well-formed prefix.
+	repaired, _ := os.ReadFile(path)
+	if !bytes.Equal(repaired, good) {
+		t.Errorf("repaired file != good prefix\n got  %q\n want %q", repaired, good)
+	}
+
+	// The chain still verifies end to end (signatures included).
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open repaired log: %v", err)
+	}
+	defer f.Close()
+	if _, errs := verifyAuditChain(f, key.Public().(ed25519.PublicKey), func(string, ...any) {}); errs != 0 {
+		t.Errorf("repaired log fails verification: %d error(s)", errs)
+	}
+
+	// The torn bytes are preserved in a single quarantine sidecar (forensics).
+	matches, _ := filepath.Glob(path + ".corrupt-*")
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly 1 quarantine file, got %d: %v", len(matches), matches)
+	}
+	qb, _ := os.ReadFile(matches[0])
+	if !bytes.Contains(qb, []byte(`"seq":4`)) {
+		t.Errorf("quarantine file missing the torn bytes: %q", qb)
+	}
+}
+
+// TestAuditRepairCleanLogIsNoop confirms repair does not touch a healthy log.
+func TestAuditRepairCleanLogIsNoop(t *testing.T) {
+	path, _ := buildLog(t, 2)
+	before, _ := os.ReadFile(path)
+	cmdAuditRepair([]string{"--log", path}) // dry-run
+	cmdAuditRepair([]string{"--log", path, "--apply"})
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(before, after) {
+		t.Error("repair modified a clean log")
+	}
+	if matches, _ := filepath.Glob(path + ".corrupt-*"); len(matches) != 0 {
+		t.Errorf("repair quarantined bytes from a clean log: %v", matches)
+	}
+}

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -16,6 +16,7 @@
 //	broker-ctl audit tail   --log <f> [-n N]        # Follow log in real time
 //	broker-ctl audit show   --log <f> [filters]     # Search/filter entries
 //	broker-ctl audit verify --log <f> [--key seed]  # Verify chain integrity
+//	broker-ctl audit repair --log <f> [--apply]     # Recover a torn final record so the signer can boot
 //	broker-ctl --version [--verbose]                # Print the build version
 package main
 
@@ -153,6 +154,7 @@ Commands:
   broker-ctl audit tail    --log <f> [-n N]                 Follow audit log in real time
   broker-ctl audit show    --log <f> [filters]              Search and filter log entries
   broker-ctl audit verify  --log <f> [--key seed]           Verify chain integrity
+  broker-ctl audit repair  --log <f> [--apply --key seed]   Quarantine a torn final record so the signer can boot
   broker-ctl policy explain --host <n> [--command c]        Show a host's composed command policy
   broker-ctl policy recommend --audit <f> [filters]         Suggest policy changes from the audit log
   broker-ctl policy add     --host <n> --allow <regex>      Add a command-policy allow rule (signer API, mTLS)
@@ -1453,7 +1455,7 @@ func must(err error) {
 
 func cmdAudit(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: broker-ctl audit {tail|show|verify} [flags]")
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl audit {tail|show|verify|repair} [flags]")
 		os.Exit(1)
 	}
 	switch args[0] {
@@ -1463,6 +1465,8 @@ func cmdAudit(args []string) {
 		cmdAuditShow(args[1:])
 	case "verify":
 		cmdAuditVerify(args[1:])
+	case "repair":
+		cmdAuditRepair(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown audit subcommand: %q\n", args[0])
 		os.Exit(1)
@@ -1654,6 +1658,143 @@ func cmdAuditVerify(args []string) {
 		fmt.Fprintf(os.Stderr, "FAIL: %d entries checked, %d error(s) found\n", total, errs)
 		os.Exit(1)
 	}
+}
+
+// auditTrailingCorruption scans an audit log for a corrupt/truncated trailing
+// record — the case that wedges signer startup (internal/audit.restoreChain
+// fails to json.Unmarshal the last physical line and Open returns an error).
+// It returns the byte offset of the clean prefix (all records up to there parse
+// and are newline-terminated), the last good seq, the count of well-formed
+// records in that prefix, the corrupt trailing bytes, and whether a well-formed
+// record appears AFTER a malformed one (middle corruption — unsafe to truncate,
+// and not the startup-brick case since restoreChain reads the last line). Blank
+// lines are benign and skipped. A complete final record with no trailing newline
+// (the #14 case, which restoreChain already repairs) is treated as clean.
+func auditTrailingCorruption(data []byte) (cleanEnd int, lastGoodSeq uint64, goodCount int, corruptTail []byte, middleCorruption bool) {
+	offset := 0
+	sawBad := false
+	for offset < len(data) {
+		rest := data[offset:]
+		nl := bytes.IndexByte(rest, '\n')
+		var line []byte
+		var lineLen int
+		if nl < 0 {
+			line, lineLen = rest, len(rest)
+		} else {
+			line, lineLen = rest[:nl], nl+1
+		}
+		trimmed := bytes.TrimRight(line, "\r")
+		if len(bytes.TrimSpace(trimmed)) == 0 {
+			offset += lineLen // blank line: harmless
+			continue
+		}
+		var e audit.Entry
+		if json.Unmarshal(trimmed, &e) == nil {
+			if sawBad {
+				middleCorruption = true
+			} else {
+				cleanEnd = offset + lineLen
+				lastGoodSeq = e.Seq
+				goodCount++
+			}
+		} else {
+			sawBad = true
+		}
+		offset += lineLen
+	}
+	if sawBad && !middleCorruption {
+		corruptTail = data[cleanEnd:]
+	}
+	return
+}
+
+// cmdAuditRepair is the explicit operator recovery path for a log whose FINAL
+// record was torn by a crash. The signer stays fail-closed by design (a
+// truncated trailing record is indistinguishable from a truncation attack, so
+// Open refuses to boot); this command lets an operator deliberately quarantine
+// the corrupt bytes and truncate the log to the last well-formed record, so the
+// hash chain continues cleanly and the signer can start. It is a no-op unless
+// --apply is passed.
+func cmdAuditRepair(args []string) {
+	fs := flag.NewFlagSet("audit repair", flag.ExitOnError)
+	logPath := fs.String("log", "", "path to audit log file (required)")
+	keyPath := fs.String("key", "", "audit seed file: also verify the kept prefix's Ed25519 signatures before repairing (optional)")
+	apply := fs.Bool("apply", false, "quarantine the corrupt tail and truncate the log (default: dry-run, no changes)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl audit repair --log <path> [--apply] [--key seed-path]")
+		fmt.Fprintln(os.Stderr, "\nRecover a log whose final record was torn by a crash. A truncated, unparseable")
+		fmt.Fprintln(os.Stderr, "trailing record makes the signer refuse to boot (fail-closed by design). This is")
+		fmt.Fprintln(os.Stderr, "the explicit recovery path: it quarantines the corrupt trailing bytes to")
+		fmt.Fprintln(os.Stderr, "<log>.corrupt-<timestamp> and truncates the log to the last well-formed record,")
+		fmt.Fprintln(os.Stderr, "preserving the hash chain. Runs as a dry-run unless --apply is given.")
+		fs.PrintDefaults()
+	}
+	must(fs.Parse(args))
+	if *logPath == "" {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	data, err := os.ReadFile(*logPath)
+	if err != nil {
+		fatalf("read log: %v", err)
+	}
+	cleanEnd, lastGoodSeq, goodCount, corruptTail, middle := auditTrailingCorruption(data)
+
+	if middle {
+		fmt.Fprintf(os.Stderr, "FAIL: %s has a malformed record BEFORE a well-formed one (not a torn tail).\n", *logPath)
+		fmt.Fprintln(os.Stderr, "  The signer will still boot (the last record is intact), so no repair is applied.")
+		fmt.Fprintln(os.Stderr, "  Run 'broker-ctl audit verify' to locate the integrity break and investigate manually.")
+		os.Exit(1)
+	}
+	if len(corruptTail) == 0 {
+		fmt.Printf("OK: %s ends on a well-formed record (%d records); nothing to repair.\n", *logPath, goodCount)
+		return
+	}
+
+	// Optionally assure the operator that the prefix being kept is itself intact.
+	if *keyPath != "" {
+		seed, err := os.ReadFile(*keyPath)
+		if err != nil {
+			fatalf("read key: %v", err)
+		}
+		if len(seed) < ed25519.SeedSize {
+			fatalf("seed file too short (need %d bytes, got %d)", ed25519.SeedSize, len(seed))
+		}
+		pub := ed25519.NewKeyFromSeed(seed[:ed25519.SeedSize]).Public().(ed25519.PublicKey)
+		if _, errs := verifyAuditChain(bytes.NewReader(data[:cleanEnd]), pub, func(format string, a ...any) {
+			fmt.Fprintf(os.Stderr, "  prefix integrity: "+format+"\n", a...)
+		}); errs > 0 {
+			fatalf("the well-formed prefix itself fails verification (%d error(s)); refusing to repair — investigate manually", errs)
+		}
+	}
+
+	preview := corruptTail
+	if len(preview) > 120 {
+		preview = preview[:120]
+	}
+	fmt.Printf("Torn final record detected in %s:\n", *logPath)
+	fmt.Printf("  well-formed records kept: %d (last seq %d, ending at byte %d)\n", goodCount, lastGoodSeq, cleanEnd)
+	fmt.Printf("  corrupt trailing bytes:   %d\n", len(corruptTail))
+	fmt.Printf("  preview:                  %q\n", preview)
+
+	if !*apply {
+		fmt.Println("\nDry run — no changes written. Re-run with --apply to quarantine the corrupt tail")
+		fmt.Println("and truncate the log so the signer can boot (the chain continues from the last")
+		fmt.Println("well-formed record).")
+		return
+	}
+
+	quarantine := fmt.Sprintf("%s.corrupt-%s", *logPath, time.Now().UTC().Format("20060102T150405Z"))
+	if err := os.WriteFile(quarantine, corruptTail, 0o600); err != nil {
+		fatalf("writing quarantine file: %v", err)
+	}
+	if err := os.Truncate(*logPath, int64(cleanEnd)); err != nil {
+		fatalf("truncating log (corrupt bytes preserved in %s): %v", quarantine, err)
+	}
+	fmt.Printf("\nRepaired: quarantined %d byte(s) to %s and truncated %s to %d byte(s).\n", len(corruptTail), quarantine, *logPath, cleanEnd)
+	fmt.Printf("The signer can now boot; the chain continues from seq %d. Keep the quarantine file\n", lastGoodSeq)
+	fmt.Println("for forensics — it holds the torn record dropped from the trail.")
 }
 
 // discoverAuditSegments returns the rotated segments of logPath (matching

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -532,6 +532,34 @@ broker-ctl audit verify --log signer_audit.log --key pki/signer_audit.seed
 broker-ctl audit verify --log audit.log --all --key pki/audit.seed
 ```
 
+#### Recovering a torn audit log (signer won't boot)
+
+The signer is **fail-closed** on audit-log corruption. If a crash or power loss
+tears the *final* record mid-write (a truncated, unparseable trailing line), the
+signer refuses to start — you will see a fatal
+`audit: restoring audit chain: parsing last log entry: …` — rather than silently
+continuing over a gap. On a tamper-evident, hash-chained log a truncated tail is
+indistinguishable from a truncation attack, so recovery is a deliberate operator
+action, never automatic:
+
+```bash
+# 1. Inspect what would be dropped (dry-run — makes NO changes):
+broker-ctl audit repair --log /var/lib/infrabroker/signer/signer_audit.log
+
+# 2. (optional) confirm the kept prefix's signatures are intact first:
+broker-ctl audit repair --log signer_audit.log --key pki/signer_audit.seed
+
+# 3. Apply: quarantine the torn bytes to <log>.corrupt-<timestamp> and truncate
+#    the log to the last well-formed record so the signer can boot. The hash
+#    chain continues from there; keep the quarantine file for forensics.
+broker-ctl audit repair --log signer_audit.log --apply
+```
+
+`repair` only ever removes a contiguous corrupt *suffix*. If it finds a malformed
+record *before* a well-formed one (mid-file corruption, which does not block
+startup because the signer reads the last line), it refuses and points you to
+`audit verify` to investigate.
+
 See [USAGE.md § 7](USAGE.md#7-reviewing-audit-logs) for the full audit-review
 guide (jq recipes, field reference, chain-integrity details).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,6 +27,7 @@ Commands:
   broker-ctl audit tail    --log <f> [-n N]                 Follow audit log in real time
   broker-ctl audit show    --log <f> [filters]              Search and filter log entries
   broker-ctl audit verify  --log <f> [--key seed]           Verify chain integrity
+  broker-ctl audit repair  --log <f> [--apply --key seed]   Quarantine a torn final record so the signer can boot
   broker-ctl policy explain --host <n> [--command c]        Show a host's composed command policy
   broker-ctl policy recommend --audit <f> [filters]         Suggest policy changes from the audit log
   broker-ctl policy add     --host <n> --allow <regex>      Add a command-policy allow rule (signer API, mTLS)


### PR DESCRIPTION
Implements the maintainer decision on [#101](https://github.com/luisgf/infrabroker/issues/101) — **option (a): keep the signer fail-closed, add an explicit operator recovery path.**

### Problem
A mid-object torn final audit write (crash/power loss leaving a truncated, unparseable trailing line) makes `restoreChain` fail and the signer `log.Fatalf` on boot. The prior #14 fix only covered the complete-JSON-missing-newline case.

### Posture (unchanged, deliberate)
The signer stays **fail-closed**: on a tamper-evident hash-chained log, a truncated tail is indistinguishable from a truncation attack, so `Open` must keep refusing. `TestRestoreChainUltimaLineaMalformada` is untouched — no security control weakened, no test inverted.

### New command
`broker-ctl audit repair --log <f> [--apply] [--key seed]`
- Scans for a contiguous corrupt **suffix** (`auditTrailingCorruption`).
- **Dry-run by default** — reports the last good seq and the bytes that would be dropped; writes nothing.
- `--apply` quarantines the torn bytes to `<log>.corrupt-<timestamp>` (0600, forensics) and truncates the log to the last well-formed record, so the hash chain continues cleanly and the signer boots.
- `--key` verifies the kept prefix's signatures before repairing.
- **Refuses mid-file corruption** (a good record after a bad one — not the startup-brick case), pointing to `audit verify`.

### Tests
- `TestAuditRepairEndToEnd` reproduces the #101 brick (`audit.Open` fails on the torn tail), then proves repair restores bootability, preserves the exact good prefix, keeps the chain verifiable (signatures included), and quarantines the torn bytes.
- `TestAuditTrailingCorruption` table-covers clean / torn-tail / complete-no-newline (#14) / middle-corruption / all-corrupt / trailing-blank.
- `TestAuditRepairCleanLogIsNoop` — no-op on a healthy log.

### Docs
OPERATIONS recovery runbook + regenerated `cli.md`.

**Verification:** `make verify` green — gofmt, vet, build, `go test -race ./...`, govulncheck (no vulns), docs drift gate, strict mkdocs.