### PR TITLE
chore: v1.38.0 release (changelog + version bump)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,37 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publish server.json to the MCP Registry after the image is live. The registry
+  # validates OCI ownership by pulling the image referenced in server.json and
+  # reading its io.modelcontextprotocol.server.name label, so this MUST run after
+  # the release job has pushed ghcr.io/luisgf/infrabroker:<version>. Auth is
+  # GitHub Actions OIDC (id-token) — it proves the io.github.luisgf namespace
+  # belongs to this repo's owner, so no PAT or stored secret is needed.
+  mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+
+      # Pinned publisher from github.com/modelcontextprotocol/registry; the
+      # installed binary is named `publisher`.
+      - name: Install mcp-publisher
+        run: go install github.com/modelcontextprotocol/registry/cmd/publisher@v1.7.9
+
+      # login writes a short-lived registry token consumed by publish in the same
+      # job. server.json is the tagged revision (checkout defaults to the tag ref),
+      # so its version/OCI identifier already match the release just published.
+      - name: Publish server.json to the MCP Registry
+        run: |
+          publisher login github-oidc
+          publisher publish

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,13 @@ Security & correctness audit pass, plus an explicit audit-log recovery command.
   corruption (not the startup-brick case). The signer stays fail-closed —
   recovery is never automatic. Runbook in `docs/OPERATIONS.md`.
 
+### Changed
+- **`release.yml` now publishes `server.json` to the MCP Registry automatically**
+  after every tagged release: a `mcp-registry` job (authenticated with GitHub
+  Actions OIDC, no PAT) that runs once the `release` job has pushed the ghcr
+  image, so the registry can validate OCI ownership. Manual `mcp-publisher
+  publish` is no longer part of the release runbook.
+
 ### Fixed
 - **k8s MCP input validation**: `k8s_list` label/field selectors and `k8s_logs`
   `container` are now length- and null-byte-validated like every other tool

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [v1.38.0] - 2026-07-04
+
+Security & correctness audit pass, plus an explicit audit-log recovery command.
+
+### Added
+- **`broker-ctl audit repair`** — recover a signer whose audit log had its
+  *final* record torn by a crash. A truncated, unparseable trailing line makes
+  the signer refuse to boot (by design: on a tamper-evident, hash-chained log a
+  truncated tail is indistinguishable from a truncation attack). The command is
+  the explicit operator recovery path: dry-run by default; `--apply` quarantines
+  the corrupt tail to `<log>.corrupt-<timestamp>` and truncates the log to the
+  last well-formed record so the signer can boot, preserving the hash chain;
+  `--key` verifies the kept prefix's signatures first. It refuses mid-file
+  corruption (not the startup-brick case). The signer stays fail-closed —
+  recovery is never automatic. Runbook in `docs/OPERATIONS.md`.
+
+### Fixed
+- **k8s MCP input validation**: `k8s_list` label/field selectors and `k8s_logs`
+  `container` are now length- and null-byte-validated like every other tool
+  field (previously they reached the API-server query string without the input
+  gate). No injection was possible — query values are percent-encoded — but the
+  stdio frontend had no length bound; this closes the unbounded / null-byte gap.
+- **Policy recommender double-count**: a single human approval, written to the
+  audit log twice (the approval-decision and the consumption), was counted as
+  support 2 in `broker-ctl policy recommend`, halving the effective `--min-count`
+  for approved commands. Occurrences are now deduplicated by approval id.
+- **Global `max_ttl_seconds` load check**: a global cap above the 900s
+  certificate limit is now rejected at load (mirroring the per-host cap),
+  instead of failing every issuance at request time for a host with no per-host
+  cap.
+
+### Internal
+- Removed dead test-only session accessors and an orphaned elevation-label
+  helper (coverage ported to the production ownership-gated paths).
+- `.gitignore` now excludes `control-plane.json`, so a real, secret-bearing
+  control-plane config cannot be accidentally committed.
+
 ## [v1.37.0] - 2026-07-04
 
 Distribution release: prebuilt binaries, an official OCI image and a

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,18 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-04 (v1.37.0, distribución: binarios + OCI + demo).
+> actualización: 2026-07-04 (v1.38.0, pasada de auditoría + `broker-ctl audit repair`).
 >
 > Estado reciente:
+> - **v1.38.0**: pasada de auditoría de seguridad/correctitud (6 hallazgos: 5
+>   fixes low + `broker-ctl audit repair`). El signer sigue fail-closed ante un
+>   registro final de auditoría truncado; `audit repair` es la ruta explícita de
+>   recuperación del operador (dry-run por defecto, `--apply` pone en cuarentena
+>   el tail corrupto y trunca al último registro válido). Fixes: validación de
+>   selectores/container en tools k8s, doble conteo en policy recommend, chequeo
+>   de `max_ttl_seconds` global en carga, borrado de código muerto, gitignore de
+>   `control-plane.json`. `server.json` en 1.38.0 (pendiente publicar en el MCP
+>   Registry con `mcp-publisher`).
 > - **v1.37.0**: release de distribución. goreleaser (archives por plataforma
 >   con los 6 binarios; el tarball del installer se conserva vía
 >   `release.extra_files`), imagen OCI multi-arch `ghcr.io/luisgf/infrabroker`

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -11,8 +11,9 @@
 >   el tail corrupto y trunca al último registro válido). Fixes: validación de
 >   selectores/container en tools k8s, doble conteo en policy recommend, chequeo
 >   de `max_ttl_seconds` global en carga, borrado de código muerto, gitignore de
->   `control-plane.json`. `server.json` en 1.38.0 (pendiente publicar en el MCP
->   Registry con `mcp-publisher`).
+>   `control-plane.json`. `server.json` en 1.38.0, publicado en el MCP Registry
+>   automáticamente por `release.yml` (job `mcp-registry`, auth GitHub OIDC, corre
+>   tras subir la imagen a ghcr) — ya no es un paso manual post-release.
 > - **v1.37.0**: release de distribución. goreleaser (archives por plataforma
 >   con los 6 binarios; el tarball del installer se conserva vía
 >   `release.extra_files`), imagen OCI multi-arch `ghcr.io/luisgf/infrabroker`

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "1.37.0",
+  "version": "1.38.0",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:1.37.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:1.38.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release prep for **v1.38.0** — a minor bump over v1.37.0.

**Why minor:** a new user-facing command shipped (`broker-ctl audit repair`, PR #103) alongside the security & correctness audit fixes (PRs #102–#103, issues #96–#101).

- `docs/CHANGELOG.md` — v1.38.0 section (Added: `audit repair`; Fixed: k8s MCP input validation, policyrec approval double-count, global `max_ttl_seconds` load check; Internal: dead-code removal, `control-plane.json` gitignore).
- `server.json` — `version` → `1.38.0`, OCI identifier → `ghcr.io/luisgf/infrabroker:1.38.0`. Validated with `mcp-publisher validate` (✅), description 83 chars.
- `docs/HANDOFF.md` — current-version header + v1.38.0 note.

**Verification:** `make verify` green.

**On merge**, tag `v1.38.0` on `main` to trigger `release.yml` (goreleaser: per-platform archives + checksums, multi-arch ghcr images, GitHub release, installer tarball). The MCP Registry publish (`mcp-publisher publish`) remains a separate manual step.