### PR TITLE
contrib: add a Glama introspection Dockerfile

### DIFF
--- a/contrib/glama/Dockerfile
+++ b/contrib/glama/Dockerfile
@@ -1,0 +1,44 @@
+# Introspection-only image for the Glama MCP index (https://glama.ai/mcp/servers).
+#
+# Glama scores a server by BUILDING this Dockerfile, STARTING the container and
+# issuing an MCP introspection request (initialize + tools/list). infrabroker's
+# real entrypoint needs a signer/PKI or a full local config, so it cannot start
+# bare. This image starts mcp-broker in a *zero-host local mode* with throwaway
+# credentials generated AT BUILD TIME (never committed, never reused): an SSH CA
+# that signs certificates for zero hosts and an audit seed for a throwaway log.
+# It exposes the exact tool surface (ssh_execute, ssh_session_*, ssh_*_file,
+# ssh_list_servers) so introspection passes — and can do nothing else, because
+# there is no host to reach and no signer. Do NOT use this image to run the
+# broker; the real images are ghcr.io/luisgf/infrabroker (see docs/CONTAINERS.md).
+#
+# Build context is the repo root:
+#   docker build -f contrib/glama/Dockerfile -t infrabroker-introspect .
+#   docker run --rm -i infrabroker-introspect   # then speaks MCP over stdio
+
+FROM golang:1.26-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /out/mcp-broker ./cmd/mcp-broker
+
+# Generate the throwaway local-mode config + credentials. openssh-client gives us
+# ssh-keygen for the Ed25519 CA key; the audit seed is 32 random bytes.
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-client \
+ && mkdir -p /introspect/pki \
+ && ssh-keygen -t ed25519 -N '' -C 'glama-introspect-ca' -f /introspect/pki/ssh_ca >/dev/null \
+ && head -c 32 /dev/urandom > /introspect/pki/audit.seed \
+ && printf '%s\n' '{' \
+      '  "ca_key": "/introspect/pki/ssh_ca",' \
+      '  "audit_key": "/introspect/pki/audit.seed",' \
+      '  "audit_log": "/tmp/introspect-audit.log",' \
+      '  "max_ttl_seconds": 300,' \
+      '  "hosts": {}' \
+      '}' > /introspect/config.json
+
+# Same runtime as the release image: distroless static, nonroot, no shell.
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/mcp-broker /usr/local/bin/mcp-broker
+COPY --from=build --chown=65532:65532 /introspect /introspect
+USER nonroot
+ENTRYPOINT ["/usr/local/bin/mcp-broker", "-config", "/introspect/config.json"]

--- a/contrib/glama/README.md
+++ b/contrib/glama/README.md
@@ -1,0 +1,30 @@
+# Glama introspection image
+
+[Glama](https://glama.ai/mcp/servers) scores an MCP server by building a
+Dockerfile, starting the container and issuing an MCP introspection request
+(`initialize` + `tools/list`). infrabroker's real entrypoint cannot start bare —
+it needs a signer/PKI (remote mode) or a full local config with a CA key.
+
+`Dockerfile` here starts `mcp-broker` in a **zero-host local mode** with
+throwaway credentials generated **at build time** (never committed, never
+reused): an SSH CA that signs certificates for zero hosts, and an audit seed for
+a throwaway log. It exposes the exact tool surface and can do nothing else —
+there is no host to reach and no signer. It is **only** for Glama introspection;
+to actually run the broker use `ghcr.io/luisgf/infrabroker` (see
+[docs/CONTAINERS.md](../../docs/CONTAINERS.md)).
+
+Build and verify locally (context is the repo root):
+
+```sh
+docker build -f contrib/glama/Dockerfile -t infrabroker-introspect .
+
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | docker run --rm -i infrabroker-introspect
+```
+
+The second response lists the tools (`ssh_execute`, `ssh_session_open` /
+`ssh_session_exec` / `ssh_session_close`, `ssh_list_servers`, `ssh_put_file` /
+`ssh_get_file`), which is what Glama's check needs.


### PR DESCRIPTION
Glama (https://glama.ai/mcp/servers) scores an MCP server by **building a Dockerfile, starting the container and issuing an MCP introspection request** (`initialize` + `tools/list`). The awesome-mcp-servers maintainers now require a passing Glama listing before merging a PR, so we need an image that introspects cleanly.

The real `mcp-broker` can't start bare: remote mode does a `FetchHosts` to the signer at startup, and even local mode needs a CA key + a config. This adds a **Glama-only** image under `contrib/glama/`:

- Starts `mcp-broker` in a **zero-host local mode** with throwaway credentials **generated at build time** — an Ed25519 SSH CA that signs certs for zero hosts, plus an audit seed for a throwaway log. Nothing is committed and nothing is reusable.
- Exposes the exact tool surface (`ssh_execute`, `ssh_session_*`, `ssh_*_file`, `ssh_list_servers`) and can do nothing else: there is no host to reach and no signer.
- Same runtime as the release image (distroless static, nonroot). The runnable images stay `ghcr.io/luisgf/infrabroker`.

Verified locally: `docker build -f contrib/glama/Dockerfile -t infrabroker-introspect .` then piping an `initialize` + `tools/list` handshake into `docker run --rm -i` returns the 7 tools. Repro steps are in `contrib/glama/README.md`.