### PR TITLE
chore: add glama.json (maintainers) to claim the Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "luisgf"
+  ]
+}


### PR DESCRIPTION
Adds a root `glama.json` that names the repo maintainer, following the schema published at https://glama.ai/mcp/schemas/server.json (single required field `maintainers`, an array of GitHub usernames).

This claims ownership of the infrabroker listing on the Glama MCP index and pairs with the introspection Dockerfile from #112.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["luisgf"]
}
```