### PR TITLE
feat(broker): cap session lifetime at cert expiry (#117 phase 0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luisgf/infrabroker
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -882,23 +882,26 @@ func (e *Engine) buildHops(ctx context.Context, c Caller, host string, ttl time.
 }
 
 // buildHopsWithPrefix is like buildHops but also returns the ElevationPrefix,
-// the physical connectivity signature, and the policy decision issued by the
-// signer for the target hop (sessions).
-func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string, ttl time.Duration, purpose, sessionMode string, opts ExecOptions) ([]sshrun.Hop, uint64, string, string, *signer.DecisionInfo, error) {
+// the physical connectivity signature, the policy decision issued by the
+// signer for the target hop (sessions), and the target certificate's expiry
+// (NotAfter), so a retained session can be capped at the life of the very
+// credential that opened it.
+func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string, ttl time.Duration, purpose, sessionMode string, opts ExecOptions) ([]sshrun.Hop, uint64, string, string, *signer.DecisionInfo, time.Time, error) {
 	chain, err := e.resolveChain(host)
 	if err != nil {
-		return nil, 0, "", "", nil, err
+		return nil, 0, "", "", nil, time.Time{}, err
 	}
 
 	hops := make([]sshrun.Hop, 0, len(chain))
 	var finalSerial uint64
+	var finalNotAfter time.Time
 	var elevPrefix string
 	var targetDecision *signer.DecisionInfo
 	var connectivitySig strings.Builder
 	for i, name := range chain {
 		hi, ok := e.hostInfo(name)
 		if !ok {
-			return nil, 0, "", "", nil, fmt.Errorf("unknown host in chain: %q", name)
+			return nil, 0, "", "", nil, time.Time{}, fmt.Errorf("unknown host in chain: %q", name)
 		}
 		isTarget := i == len(chain)-1
 		writeSignaturePart(&connectivitySig, name)
@@ -910,7 +913,7 @@ func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string,
 
 		priv, pub, err := ca.GenerateEphemeralKey()
 		if err != nil {
-			return nil, 0, "", "", nil, err
+			return nil, 0, "", "", nil, time.Time{}, err
 		}
 		in := signer.Intent{
 			Caller:        localCaller,
@@ -933,14 +936,14 @@ func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string,
 		}
 		issued, err := e.sgn.SignIntent(ctx, in)
 		if err != nil {
-			return nil, 0, "", "", nil, fmt.Errorf("signing cert for %q: %w", name, err)
+			return nil, 0, "", "", nil, time.Time{}, fmt.Errorf("signing cert for %q: %w", name, err)
 		}
 		if issued.Certificate == nil {
-			return nil, 0, "", "", nil, approvalError(name, issued.Decision)
+			return nil, 0, "", "", nil, time.Time{}, approvalError(name, issued.Decision)
 		}
 		hostKey, err := e.parseHostKeyCached(hi.HostKey)
 		if err != nil {
-			return nil, 0, "", "", nil, fmt.Errorf("host key for %q: %w", name, err)
+			return nil, 0, "", "", nil, time.Time{}, fmt.Errorf("host key for %q: %w", name, err)
 		}
 		hops = append(hops, sshrun.Hop{
 			Addr: hi.Addr, User: hi.User, HostKey: hostKey,
@@ -948,11 +951,15 @@ func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string,
 		})
 		if isTarget {
 			finalSerial = issued.Serial
+			// ValidBefore is the authoritative expiry the signer clamped to
+			// (<= max_ttl), not the broker's requested TTL. The signer always
+			// sets a bounded TTL, so this is a finite time.
+			finalNotAfter = time.Unix(int64(issued.Certificate.ValidBefore), 0)
 			elevPrefix = issued.ElevationPrefix
 			targetDecision = issued.Decision
 		}
 	}
-	return hops, finalSerial, elevPrefix, connectivitySig.String(), targetDecision, nil
+	return hops, finalSerial, elevPrefix, connectivitySig.String(), targetDecision, finalNotAfter, nil
 }
 
 // approvalError builds the error shown to a broker when a cert is not issued

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -41,6 +41,12 @@ type liveSession struct {
 	shell    *sshrun.ShellSession // only in "shell" and "pty" mode
 	created  time.Time
 	lastUsed time.Time
+	// certNotAfter is the target certificate's ValidBefore: the session must
+	// not outlive the credential that opened it (THREAT_MODEL gap #1). The
+	// reaper closes the session once this passes, bounding the exposure window
+	// to the cert TTL (<= max_ttl) instead of the longer session_max_seconds.
+	// Zero means "no cap" (defensive; OpenSession always sets it).
+	certNotAfter time.Time
 	// busy counts commands in flight on this session (protected by the
 	// manager's mutex). The reaper never closes a busy session: the exec
 	// timeout can exceed the idle TTL, and closing the connection under a
@@ -136,12 +142,15 @@ func (m *sessionManager) reapExpired(now time.Time) {
 	m.mu.Lock()
 	var victims []*liveSession
 	for id, s := range m.sessions {
-		// Never reap a session with a command in flight. A busy session
-		// past maxLife is reaped on the first tick after it goes idle.
+		// Never reap a session with a command in flight. A busy session past
+		// maxLife or its cert expiry is reaped on the first tick after it goes
+		// idle. Forcibly closing a busy session (a true kill switch) is a
+		// separate, deliberate control tracked in #117.
 		if s.busy > 0 {
 			continue
 		}
-		if now.Sub(s.lastUsed) > m.idleTTL || now.Sub(s.created) > m.maxLife {
+		if now.Sub(s.lastUsed) > m.idleTTL || now.Sub(s.created) > m.maxLife ||
+			(!s.certNotAfter.IsZero() && now.After(s.certNotAfter)) {
 			delete(m.sessions, id)
 			victims = append(victims, s)
 		}
@@ -279,7 +288,7 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 		opts.PTY = true
 	}
 
-	hops, serial, elevPrefix, connectivitySig, _, err := e.buildHopsWithPrefix(ctx, c, host, e.ttlFor(ttlSeconds), signer.PurposeSession, mode, opts)
+	hops, serial, elevPrefix, connectivitySig, _, certNotAfter, err := e.buildHopsWithPrefix(ctx, c, host, e.ttlFor(ttlSeconds), signer.PurposeSession, mode, opts)
 	if err != nil {
 		e.auditE(audit.Entry{Caller: c.ID, Host: host, Outcome: "error", Err: err.Error()})
 		return nil, err
@@ -293,6 +302,7 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 	s := &liveSession{
 		id: newSessionID(), caller: c.ID, host: host, serial: serial, mode: mode,
 		conn: conn, created: time.Now(), lastUsed: time.Now(),
+		certNotAfter:    certNotAfter,
 		elevationPrefix: elevPrefix,
 		elevLabel:       opts.elevationLabel(),
 		sudo:            opts.Sudo,

--- a/internal/broker/session_test.go
+++ b/internal/broker/session_test.go
@@ -257,6 +257,69 @@ func TestSessionManagerReaperNoMataSesionesOcupadas(t *testing.T) {
 	}
 }
 
+// TestSessionManagerReaperCapExpiryCert verifica que una sesión se recolecta en
+// cuanto expira su certificado, aunque no hayan vencido ni el idle TTL ni
+// maxLife: la sesión no debe sobrevivir a la credencial que la abrió
+// (THREAT_MODEL gap #1). El cert real lo clampa el signer a <= max_ttl, así que
+// certNotAfter suele adelantarse a maxLife.
+func TestSessionManagerReaperCapExpiryCert(t *testing.T) {
+	reaped := make(chan string, 1)
+	m := newSessionManager(5*time.Minute, 30*time.Minute, func(s *liveSession) { reaped <- s.id })
+	t.Cleanup(func() { m.closeAll() })
+
+	s := dummySession("s1", "alice")
+	// idle y maxLife lejos de vencer (created/lastUsed son "ahora"), pero el
+	// certificado ya expiró.
+	s.certNotAfter = time.Now().Add(-time.Second)
+	if err := m.add(s); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	m.reapExpired(time.Now())
+	if _, ok := peek(m, "s1"); ok {
+		t.Fatal("la sesión con cert expirado debe recolectarse aunque idle/maxLife no hayan vencido")
+	}
+	select {
+	case id := <-reaped:
+		if id != "s1" {
+			t.Errorf("onReap reportó %q, quiero \"s1\"", id)
+		}
+	default:
+		t.Error("onReap debería haberse disparado por expiración del cert")
+	}
+}
+
+// TestSessionManagerReaperCertExpiradoRespetaBusy verifica que el cap por
+// expiración del cert NO rompe la invariante de no cerrar sesiones ocupadas: una
+// sesión busy con cert expirado sobrevive y se recolecta en el primer tick tras
+// el checkin (el kill forzoso de sesiones busy es un control aparte, #117).
+func TestSessionManagerReaperCertExpiradoRespetaBusy(t *testing.T) {
+	reaped := make(chan string, 1)
+	m := newSessionManager(5*time.Minute, 30*time.Minute, func(s *liveSession) { reaped <- s.id })
+	t.Cleanup(func() { m.closeAll() })
+
+	s := dummySession("s1", "alice")
+	s.certNotAfter = time.Now().Add(-time.Second)
+	if err := m.add(s); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got, found, owned := m.checkoutOwned("s1", "alice")
+	if !found || !owned {
+		t.Fatalf("checkoutOwned: found=%v owned=%v", found, owned)
+	}
+
+	m.reapExpired(time.Now())
+	if _, ok := peek(m, "s1"); !ok {
+		t.Fatal("una sesión ocupada no debe recolectarse aunque el cert haya expirado")
+	}
+
+	m.checkin(got)
+	m.reapExpired(time.Now())
+	if _, ok := peek(m, "s1"); ok {
+		t.Error("tras el checkin, la sesión con cert expirado debe recolectarse")
+	}
+}
+
 // TestSessionManagerCheckinActualizaLastUsed verifica que lastUsed se refresca
 // al TERMINAR el comando, no solo al empezar: el idle TTL cuenta desde que la
 // sesión queda libre.


### PR DESCRIPTION
Phase 0 of #117 (kill switch). Resolves the default-side of THREAT_MODEL gap #1. The signer-side freeze store and the forceful busy-session kill are phase 1, tracked in #117 — which stays open until that lands.

## Problem

A retained SSH session outlived the certificate that opened it. OpenSSH validates the cert **only at authentication**, so once a session is established it lives until the reaper closes it — bounded only by `session_idle_seconds` / `session_max_seconds` (default **1800s**), even though the cert TTL is clamped to `<= max_ttl` (**<= 900s**). The threat model already names this as the session exposure window to worry about.

## Change

- `buildHopsWithPrefix` now also returns the **target certificate's `ValidBefore`** (the authoritative expiry the signer clamped to, not the broker's requested TTL).
- The session reaper closes a session once that expiry passes, in addition to the existing idle-TTL and max-life bounds. Effectively `min(session_max_seconds, cert ValidBefore)`.
- The **"never reap a busy session" invariant is preserved**: a busy session past its cert expiry is collected on the first tick after it goes idle, exactly as with max-life today. Forcibly terminating a busy session (the true *kill switch*) is the separate, decision-bearing control in phase 1.

## Scope

Single call site (`OpenSession`); one-shot execution is unaffected (its certs are per-command and the connection is not retained). No config or API change; strictly tightens an existing bound.

## Tests

- `TestSessionManagerReaperCapExpiryCert`: a cert-expired **free** session is reaped though neither idle TTL nor max-life has elapsed.
- `TestSessionManagerReaperCertExpiradoRespetaBusy`: a cert-expired **busy** session survives, then is reaped on the first tick after `checkin`.
- Full suite green under `-race`; gofmt and govulncheck clean.

## Note

Carried the same one-line Go 1.26.5 bump as #116 (now merged), so on main it is a no-op — go.mod already reads `go 1.26.5`.
