### PR TITLE
feat(signer): kill-switch freeze store + endpoints + deny-on-sign (#117 phase 1, signer)

### DIFF
--- a/cmd/broker-ctl/freeze.go
+++ b/cmd/broker-ctl/freeze.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// resolveFreezeSubject maps the mutually-exclusive subject flags to a (kind,
+// value) pair, requiring exactly one to be set.
+func resolveFreezeSubject(caller, endUser, sessionID, serial string) (kind, value string) {
+	n := 0
+	if caller != "" {
+		n, kind, value = n+1, signer.FreezeCaller, caller
+	}
+	if endUser != "" {
+		n, kind, value = n+1, signer.FreezeEndUser, endUser
+	}
+	if sessionID != "" {
+		n, kind, value = n+1, signer.FreezeSessionID, sessionID
+	}
+	if serial != "" {
+		n, kind, value = n+1, signer.FreezeSerial, serial
+	}
+	if n != 1 {
+		fatalf("exactly one of --caller / --end-user / --session-id / --serial is required")
+	}
+	return kind, value
+}
+
+// subjectFlags registers the four mutually-exclusive freeze subject flags.
+func subjectFlags(fs *flag.FlagSet) (caller, endUser, sessionID, serial *string) {
+	caller = fs.String("caller", "", "freeze/unfreeze a broker mTLS CN")
+	endUser = fs.String("end-user", "", "freeze/unfreeze an end-user identity")
+	sessionID = fs.String("session-id", "", "freeze/unfreeze a specific live session")
+	serial = fs.String("serial", "", "freeze/unfreeze a specific certificate serial")
+	return
+}
+
+// cmdFreeze calls the signer's POST /v1/freeze (mTLS, reload_callers) to freeze a
+// subject: it gets no new certificate and no connectivity, and brokers kill its
+// live sessions. Freezing a caller/end_user also revokes its runtime grants.
+func cmdFreeze(args []string) {
+	fs := flag.NewFlagSet("freeze", flag.ExitOnError)
+	caller, endUser, sessionID, serial := subjectFlags(fs)
+	reason := fs.String("reason", "", "optional reason recorded in the audit log")
+	urlFlag, cert, key, ca := signerFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] freeze (--caller cn | --end-user u | --session-id id | --serial n) [--reason r]")
+		fs.PrintDefaults()
+	}
+	must(fs.Parse(args))
+	kind, value := resolveFreezeSubject(*caller, *endUser, *sessionID, *serial)
+	resolveSignerTarget(fs)
+
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value, "reason": *reason})
+	req, err := http.NewRequest(http.MethodPost, base+"/v1/freeze", bytes.NewReader(body))
+	if err != nil {
+		fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		fatalf("POST %s/v1/freeze: %v", base, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fatalf("signer rejected the freeze (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	var result struct {
+		NewlyFrozen   bool `json:"newly_frozen"`
+		GrantsRevoked int  `json:"grants_revoked"`
+	}
+	_ = json.Unmarshal(rb, &result)
+	state := "frozen"
+	if !result.NewlyFrozen {
+		state = "already frozen (refreshed)"
+	}
+	fmt.Printf("%s %s=%s (grants revoked: %d)\n", state, kind, value, result.GrantsRevoked)
+}
+
+// cmdUnfreeze calls the signer's POST /v1/unfreeze (mTLS, reload_callers) to
+// release a previously frozen subject.
+func cmdUnfreeze(args []string) {
+	fs := flag.NewFlagSet("unfreeze", flag.ExitOnError)
+	caller, endUser, sessionID, serial := subjectFlags(fs)
+	urlFlag, cert, key, ca := signerFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] unfreeze (--caller cn | --end-user u | --session-id id | --serial n)")
+		fs.PrintDefaults()
+	}
+	must(fs.Parse(args))
+	kind, value := resolveFreezeSubject(*caller, *endUser, *sessionID, *serial)
+	resolveSignerTarget(fs)
+
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value})
+	req, err := http.NewRequest(http.MethodPost, base+"/v1/unfreeze", bytes.NewReader(body))
+	if err != nil {
+		fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		fatalf("POST %s/v1/unfreeze: %v", base, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fatalf("signer rejected the unfreeze (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	var result struct {
+		WasFrozen bool `json:"was_frozen"`
+	}
+	_ = json.Unmarshal(rb, &result)
+	if result.WasFrozen {
+		fmt.Printf("unfrozen %s=%s\n", kind, value)
+	} else {
+		fmt.Printf("%s=%s was not frozen\n", kind, value)
+	}
+}
+
+// cmdRevocations calls the signer's GET /v1/revocations (mTLS) and renders the
+// current freeze set — the same list brokers poll to kill matching sessions.
+func cmdRevocations(args []string) {
+	fs := flag.NewFlagSet("revocations", flag.ExitOnError)
+	asJSON := fs.Bool("json", false, "output as JSON")
+	urlFlag, cert, key, ca := signerFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] revocations [--json]")
+		fs.PrintDefaults()
+	}
+	must(fs.Parse(args))
+	resolveSignerTarget(fs)
+
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+	resp, err := client.Get(base + "/v1/revocations")
+	if err != nil {
+		fatalf("GET %s/v1/revocations: %v", base, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fatalf("signer rejected the request (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	if *asJSON {
+		os.Stdout.Write(rb)
+		if len(rb) > 0 && rb[len(rb)-1] != '\n' {
+			fmt.Println()
+		}
+		return
+	}
+	var frozen []signer.FrozenEntry
+	if err := json.Unmarshal(rb, &frozen); err != nil {
+		fatalf("decode revocations: %v", err)
+	}
+	if len(frozen) == 0 {
+		fmt.Println("(no frozen subjects)")
+		return
+	}
+	fmt.Printf("%-12s %-24s %-20s %-16s %s\n", "KIND", "VALUE", "FROZEN AT (UTC)", "BY", "REASON")
+	for _, e := range frozen {
+		fmt.Printf("%-12s %-24s %-20s %-16s %s\n",
+			e.Kind, e.Value, e.FrozenAt.UTC().Format(time.RFC3339), e.FrozenBy, e.Reason)
+	}
+}

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -91,6 +91,12 @@ func main() {
 		cmdPolicy(args[1:])
 	case "cluster":
 		cmdCluster(args[1:])
+	case "freeze":
+		cmdFreeze(args[1:])
+	case "unfreeze":
+		cmdUnfreeze(args[1:])
+	case "revocations":
+		cmdRevocations(args[1:])
 	case "version":
 		cmdVersion(args[1:])
 	case "help":
@@ -163,6 +169,9 @@ Commands:
   broker-ctl policy grants  [--json]                        List active runtime grants
   broker-ctl policy revoke  <grant-id>                      Revoke a runtime grant
   broker-ctl cluster list  --remote                         List Kubernetes clusters live from the signer (mTLS)
+  broker-ctl freeze        (--caller cn|--end-user u|--session-id id|--serial n) [--reason r]  Freeze a subject: no new certs, kill its live sessions (mTLS)
+  broker-ctl unfreeze      (--caller cn|--end-user u|--session-id id|--serial n)  Release a frozen subject (mTLS)
+  broker-ctl revocations   [--json]                         List currently frozen subjects (mTLS)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/cmd/signer/freeze_http_test.go
+++ b/cmd/signer/freeze_http_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// freezeTestServer builds a minimal server with a freeze store, an in-memory
+// grant store, and reload_callers={admin}. The sign path's freeze check runs
+// before host/pubkey resolution, so no CA or host policy is needed to exercise
+// a frozen denial.
+func freezeTestServer(t *testing.T) *server {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	auditLog, err := audit.Open(filepath.Join(t.TempDir(), "audit.log"), ed25519.NewKeyFromSeed(seed))
+	if err != nil {
+		t.Fatalf("audit open: %v", err)
+	}
+	t.Cleanup(func() { auditLog.Close() })
+	return &server{
+		audit:    auditLog,
+		reloadCN: map[string]struct{}{"admin": {}},
+		grants:   signer.NewGrantStore(),
+		freezes:  signer.NewFreezeStore(),
+	}
+}
+
+func freezeMux(s *server) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/freeze", s.handleFreeze)
+	mux.HandleFunc("POST /v1/unfreeze", s.handleUnfreeze)
+	mux.HandleFunc("GET /v1/revocations", s.handleRevocations)
+	mux.HandleFunc("/v1/sign", s.handleSign)
+	return mux
+}
+
+func TestFreezeEndpointRequiresReloadCN(t *testing.T) {
+	t.Parallel()
+	mux := freezeMux(freezeTestServer(t))
+
+	// A non-admin CN may not freeze.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "brk1", map[string]any{"kind": "caller", "value": "brk2"}))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("freeze as non-admin: status = %d, want 403", rec.Code)
+	}
+
+	// admin may.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin", map[string]any{"kind": "caller", "value": "brk2"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze as admin: status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFreezeDeniesSignAndUnfreezeRestores(t *testing.T) {
+	t.Parallel()
+	srv := freezeTestServer(t)
+	mux := freezeMux(srv)
+
+	signAs := func(cn string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/sign", cn, signer.WireRequest{
+			Host: "web01", Role: signer.RoleTarget, Purpose: signer.PurposeOneshot, Command: "uptime",
+		}))
+		return rec
+	}
+
+	// Freeze caller brk1.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin", map[string]any{"kind": "caller", "value": "brk1"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze: status = %d", rec.Code)
+	}
+
+	// brk1 can no longer sign.
+	if rec := signAs("brk1"); rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "frozen") {
+		t.Fatalf("sign as frozen brk1: status = %d body = %q, want 403 + frozen", rec.Code, rec.Body.String())
+	}
+	// A different caller is unaffected by brk1's freeze (it fails later, not on the freeze gate).
+	if rec := signAs("brk2"); strings.Contains(rec.Body.String(), "subject is frozen") {
+		t.Errorf("sign as brk2 must not be frozen-denied; body = %q", rec.Body.String())
+	}
+
+	// revocations lists brk1.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodGet, "/v1/revocations", "brk2", nil))
+	var frozen []signer.FrozenEntry
+	if err := json.Unmarshal(rec.Body.Bytes(), &frozen); err != nil {
+		t.Fatalf("decode revocations: %v", err)
+	}
+	if len(frozen) != 1 || frozen[0].Kind != signer.FreezeCaller || frozen[0].Value != "brk1" || frozen[0].FrozenBy != "admin" {
+		t.Fatalf("revocations = %+v, want one caller=brk1 by admin", frozen)
+	}
+
+	// Unfreeze restores brk1 (freeze gate no longer fires).
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/unfreeze", "admin", map[string]any{"kind": "caller", "value": "brk1"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unfreeze: status = %d", rec.Code)
+	}
+	if rec := signAs("brk1"); strings.Contains(rec.Body.String(), "subject is frozen") {
+		t.Errorf("brk1 must not be frozen-denied after unfreeze; body = %q", rec.Body.String())
+	}
+}
+
+func TestFreezeRevokesSubjectGrants(t *testing.T) {
+	t.Parallel()
+	srv := freezeTestServer(t)
+	mux := freezeMux(srv)
+
+	// A grant scoped to brk1 and a host-wide grant.
+	if _, err := srv.grants.Add(signer.Grant{Host: "web01", Allow: []string{"^ls"}, Caller: "brk1", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("add scoped grant: %v", err)
+	}
+	if _, err := srv.grants.Add(signer.Grant{Host: "web01", Allow: []string{"^df"}, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("add host-wide grant: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin", map[string]any{"kind": "caller", "value": "brk1"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze: status = %d", rec.Code)
+	}
+	var result struct {
+		GrantsRevoked int `json:"grants_revoked"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &result)
+	if result.GrantsRevoked != 1 {
+		t.Errorf("grants_revoked = %d, want 1", result.GrantsRevoked)
+	}
+	if got := len(srv.grants.List(time.Now())); got != 1 {
+		t.Errorf("remaining grants = %d, want 1 (host-wide survives)", got)
+	}
+}
+
+// TestFreezeRejectsTokenInjection: a value carrying whitespace would splice
+// forged key=value tokens into the audit stream, so it must be rejected with 400
+// before any audit write.
+func TestFreezeRejectsTokenInjection(t *testing.T) {
+	t.Parallel()
+	mux := freezeMux(freezeTestServer(t))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin",
+		map[string]any{"kind": "caller", "value": "brk1 grants_revoked=0 reason=pwned"}))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("freeze with whitespace value: status = %d, want 400", rec.Code)
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -162,8 +162,9 @@ func main() {
 	// restarts (write-through + reload at startup); without it they are lost
 	// on restart (fail-safe: grants only widen).
 	grantStore := signer.NewGrantStore()
+	freezeStore := signer.NewFreezeStore()
 	if cfg.StateDB != "" {
-		stateDB, err := statedb.Open(cfg.StateDB, signer.GrantSchema)
+		stateDB, err := statedb.Open(cfg.StateDB, signer.StateMigrations())
 		if err != nil {
 			log.Fatalf("state db: %v", err)
 		}
@@ -172,7 +173,14 @@ func main() {
 		if err != nil {
 			log.Fatalf("state db: %v", err)
 		}
-		log.Printf("state db: %s (%d live grants restored)", cfg.StateDB, len(grantStore.List(time.Now())))
+		// Fail-closed: unlike grants, a freeze that fails to load must abort
+		// startup rather than silently un-freeze a blocked subject.
+		freezeStore, err = signer.NewFreezeStoreDB(stateDB)
+		if err != nil {
+			log.Fatalf("state db: %v", err)
+		}
+		log.Printf("state db: %s (%d live grants, %d freezes restored)",
+			cfg.StateDB, len(grantStore.List(time.Now())), len(freezeStore.List()))
 	}
 
 	local, err := buildState(context.Background(), cfg, grantStore)
@@ -218,6 +226,7 @@ func main() {
 		signRateMin: cfg.SignRateLimitPerMin,
 		cfgPath:     *cfgPath,
 		grants:      grantStore,
+		freezes:     freezeStore,
 		maxGrantTTL: time.Duration(cfg.MaxGrantTTLSeconds) * time.Second,
 		rateLimiter: signer.NewRateLimiter(),
 	}
@@ -242,6 +251,13 @@ func main() {
 	// Kubernetes cluster connectivity for the broker (group-filtered like
 	// /v1/hosts). No-op when no clusters are configured.
 	mux.HandleFunc("GET /v1/clusters", srv.handleClusters)
+
+	// Kill switch (#117): freeze/unfreeze a subject (auth: reload_callers) and
+	// stream the current freeze set to brokers (auth: any mTLS caller, like
+	// /v1/hosts) so they can kill matching live sessions.
+	mux.HandleFunc("POST /v1/freeze", srv.handleFreeze)
+	mux.HandleFunc("POST /v1/unfreeze", srv.handleUnfreeze)
+	mux.HandleFunc("GET /v1/revocations", srv.handleRevocations)
 
 	// Hot-reload via SIGHUP (in addition to the HTTP endpoint). Local to the
 	// host, so it bypasses the reload_callers allowlist.
@@ -431,6 +447,11 @@ type server struct {
 	grants      *signer.GrantStore
 	maxGrantTTL time.Duration
 
+	// freezes is the shared kill-switch freeze store (#117): frozen subjects are
+	// denied on /v1/sign and /v1/hosts and streamed to brokers via
+	// /v1/revocations. Created once and reused across reloads; own mutex.
+	freezes *signer.FreezeStore
+
 	// rateLimiter holds the per-CN /v1/sign token buckets. Created once and
 	// kept across reloads (its own mutex makes it concurrency-safe); the limit
 	// itself lives in signRateMin so a reload applies instantly.
@@ -568,6 +589,24 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Kill switch (#117): a frozen caller CN or end user gets no new certificate.
+	// Checked before the ssh/k8s split so it covers one-shot, session open, and
+	// every session-exec preflight — all of which reach /v1/sign. caller and
+	// req.EndUser are both charset-checked above, so they are safe to audit.
+	if subj, frozen := s.freezes.Frozen(caller, req.EndUser); frozen {
+		signRequestsTotal.With("frozen-denied").Inc()
+		if aerr := s.audit.Append(audit.Entry{
+			Caller:  caller,
+			Host:    req.Host,
+			Outcome: "frozen_denied",
+			Err:     fmt.Sprintf("frozen: %s=%s", subj.Kind, subj.Value),
+		}); aerr != nil {
+			log.Printf("warning: error writing signer audit log: %v", aerr)
+		}
+		http.Error(w, "subject is frozen", http.StatusForbidden)
+		return
+	}
+
 	// Kubernetes target: separate descriptor, group table, and audit shape.
 	if req.TargetType == signer.TargetTypeK8s {
 		s.handleSignK8s(w, r, caller, req, isForwarder, effectiveApproved, local, callers)
@@ -682,6 +721,21 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Kill switch (#117): a frozen caller sees no connectivity, so it cannot even
+	// discover hosts to attempt. A match means caller equals a value that was
+	// charset-validated when it was frozen, so subj is safe to audit.
+	if subj, frozen := s.freezes.Frozen(caller, ""); frozen {
+		if aerr := s.audit.Append(audit.Entry{
+			Caller:  caller,
+			Outcome: "frozen_denied",
+			Err:     fmt.Sprintf("frozen: %s=%s", subj.Kind, subj.Value),
+		}); aerr != nil {
+			log.Printf("warning: error writing signer audit log: %v", aerr)
+		}
+		http.Error(w, "subject is frozen", http.StatusForbidden)
+		return
+	}
+
 	result := make(map[string]signer.WireHostInfo, len(hosts))
 	for name, hp := range hosts {
 		result[name] = signer.WireHostInfo{
@@ -764,6 +818,138 @@ func (s *server) auditReload(caller string, hosts int, outcome string, err error
 		e.Err = err.Error()
 	}
 	// M1: log the error instead of silently discarding it.
+	if aerr := s.audit.Append(e); aerr != nil {
+		log.Printf("warning: error writing signer audit log: %v", aerr)
+	}
+}
+
+// requireReloadCN authenticates a mutation request and checks the CN is in
+// reload_callers. On failure it writes the response and returns ok=false. The
+// route pattern already scopes the method.
+func (s *server) requireReloadCN(w http.ResponseWriter, r *http.Request) (string, bool) {
+	caller, err := auth.CallerCN(r)
+	if err != nil {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return "", false
+	}
+	s.mu.RLock()
+	_, allowed := s.reloadCN[caller]
+	s.mu.RUnlock()
+	if !allowed {
+		http.Error(w, "not authorised", http.StatusForbidden)
+		return "", false
+	}
+	return caller, true
+}
+
+// freezeRequest is the POST /v1/freeze and /v1/unfreeze body.
+type freezeRequest struct {
+	Kind   string `json:"kind"`
+	Value  string `json:"value"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// decodeFreezeSubject reads and validates a freeze subject from the request
+// body. The value and reason are rejected if they carry control/whitespace so a
+// forged token cannot splice into the audit stream (auditFreeze writes them as
+// key=value tokens). Returns ok=false with the response already written.
+func (s *server) decodeFreezeSubject(w http.ResponseWriter, r *http.Request) (signer.FreezeSubject, string, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, 16*1024)
+	var req freezeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return signer.FreezeSubject{}, "", false
+	}
+	if !signer.ValidFreezeKind(req.Kind) {
+		http.Error(w, "invalid kind (caller|end_user|session_id|serial)", http.StatusBadRequest)
+		return signer.FreezeSubject{}, "", false
+	}
+	if req.Value == "" || signer.HasUnsafeTokenChar(req.Value) || signer.HasUnsafeTokenChar(req.Reason) {
+		http.Error(w, "invalid value or reason: empty, control or whitespace characters not allowed", http.StatusBadRequest)
+		return signer.FreezeSubject{}, "", false
+	}
+	return signer.FreezeSubject{Kind: req.Kind, Value: req.Value}, req.Reason, true
+}
+
+// handleFreeze serves POST /v1/freeze: freeze a subject so it gets no new
+// certificate (/v1/sign) and no connectivity (/v1/hosts), and brokers kill its
+// live sessions. reload_callers only. Freezing a caller/end_user also revokes
+// that subject's runtime grants and approve-and-learn waivers.
+func (s *server) handleFreeze(w http.ResponseWriter, r *http.Request) {
+	caller, ok := s.requireReloadCN(w, r)
+	if !ok {
+		return
+	}
+	subj, reason, ok := s.decodeFreezeSubject(w, r)
+	if !ok {
+		return
+	}
+	// Serialise freeze mutations with the other config mutations so the freeze
+	// and its grant revocation apply as one step.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	newly, err := s.freezes.Add(subj, reason, caller, time.Now())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	revoked, gerr := s.grants.RevokeForSubject(subj.Kind, subj.Value)
+	s.auditFreeze(caller, "frozen", subj, reason, revoked, gerr)
+	if gerr != nil {
+		http.Error(w, fmt.Sprintf("subject frozen, but revoking its grants failed: %v", gerr), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "newly_frozen": newly, "grants_revoked": revoked})
+}
+
+// handleUnfreeze serves POST /v1/unfreeze: release a previously frozen subject.
+// reload_callers only.
+func (s *server) handleUnfreeze(w http.ResponseWriter, r *http.Request) {
+	caller, ok := s.requireReloadCN(w, r)
+	if !ok {
+		return
+	}
+	subj, _, ok := s.decodeFreezeSubject(w, r)
+	if !ok {
+		return
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	existed, err := s.freezes.Remove(subj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.auditFreeze(caller, "unfrozen", subj, "", 0, nil)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "was_frozen": existed})
+}
+
+// handleRevocations serves GET /v1/revocations: the current freeze set, for
+// brokers to poll and kill matching live sessions. Any authenticated mTLS caller
+// may read it (operational data the broker needs), like GET /v1/hosts.
+func (s *server) handleRevocations(w http.ResponseWriter, r *http.Request) {
+	if _, err := auth.CallerCN(r); err != nil {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.freezes.List())
+}
+
+// auditFreeze records a freeze/unfreeze in the audit log. subj.Value and reason
+// are charset-validated by decodeFreezeSubject, so the key=value stream stays
+// unambiguous.
+func (s *server) auditFreeze(caller, outcome string, subj signer.FreezeSubject, reason string, grantsRevoked int, err error) {
+	cmd := fmt.Sprintf("%s kind=%s value=%s", outcome, subj.Kind, subj.Value)
+	if outcome == "frozen" {
+		cmd += fmt.Sprintf(" grants_revoked=%d", grantsRevoked)
+	}
+	if reason != "" {
+		cmd += " reason=" + reason
+	}
+	e := audit.Entry{Caller: caller, Command: cmd, Outcome: outcome}
+	if err != nil {
+		e.Err = err.Error()
+	}
 	if aerr := s.audit.Append(e); aerr != nil {
 		log.Printf("warning: error writing signer audit log: %v", aerr)
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -442,6 +442,35 @@ are revoked by `DELETE /v1/policy/grants/{id}` like any grant. Audit outcomes:
 
 ---
 
+### Kill switch — POST /v1/freeze · POST /v1/unfreeze · GET /v1/revocations
+
+Freeze a subject so it gets no new certificate and no connectivity, and brokers
+kill its live sessions (#117). A **freeze subject** is a `{ "kind": ..., "value":
+... }` pair where `kind` is one of `caller` (broker mTLS CN), `end_user`,
+`session_id`, or `serial`.
+
+- **`POST /v1/freeze`** (mTLS, CN in `reload_callers`). Body: `{ "kind": "caller",
+  "value": "broker-1", "reason": "incident-4821" }` (`reason` optional). Freezing
+  a `caller`/`end_user` also revokes that subject's runtime grants and
+  approve-and-learn waivers. `value` and `reason` must not contain
+  control/whitespace characters (audit-stream safety) → `400` otherwise.
+  Response: `{ "status": "ok", "newly_frozen": true, "grants_revoked": 1 }`.
+- **`POST /v1/unfreeze`** (mTLS, `reload_callers`). Body: `{ "kind": "caller",
+  "value": "broker-1" }`. Response: `{ "status": "ok", "was_frozen": true }`.
+- **`GET /v1/revocations`** (mTLS, any authenticated caller — operational data a
+  broker needs, like `GET /v1/hosts`). Returns the current freeze set:
+  `[{ "kind": "caller", "value": "broker-1", "reason": "...", "frozen_by":
+  "admin", "frozen_at": "2026-07-09T06:00:00Z" }]`. Brokers poll it to force-close
+  matching live sessions.
+
+Enforcement points: a frozen subject is rejected at `POST /v1/sign` (audited
+`frozen_denied`) and `GET /v1/hosts`. The freeze set is persisted in `state_db`
+**fail-closed** — the signer refuses to start if it cannot load the set, and
+without `state_db` freezes do not survive a restart. CLI: `broker-ctl freeze`,
+`broker-ctl unfreeze`, `broker-ctl revocations`.
+
+---
+
 ### GET /v1/policy/hosts
 
 Return the **full host-policy table** — the current in-memory state, so it

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -462,6 +462,43 @@ with `state_db` set they also **survive a signer restart** (without it they are
 dropped — fail-safe, the baseline is more restrictive); every create/revoke is in
 the signed audit log (`grant-created` / `grant-revoked`).
 
+### Freezing a subject: the kill switch (#117)
+
+A **freeze** immediately cuts a subject off: it gets **no new certificate**
+(`/v1/sign`) and **no connectivity** (`/v1/hosts`), its runtime grants and
+approve-and-learn waivers are revoked, and brokers **force-close its live
+sessions** (broker-side kill path). Operator-only (mTLS, CN in `reload_callers`),
+audited (`frozen` / `unfrozen`). A subject is one of: `--caller <CN>`,
+`--end-user <u>`, `--session-id <id>`, `--serial <n>`.
+
+```bash
+# Incident: broker-1 looks compromised. Freeze it — no new access, sessions killed.
+broker-ctl freeze --caller broker-1 --reason incident-4821
+# → frozen caller=broker-1 (grants revoked: 2)
+
+# Freeze one end user, or one specific live session / certificate:
+broker-ctl freeze --end-user alice --reason offboarding
+broker-ctl freeze --session-id 7f3c... 
+broker-ctl freeze --serial 12345
+
+# List what is frozen; release when the incident is over:
+broker-ctl revocations
+# KIND         VALUE          FROZEN AT (UTC)       BY      REASON
+# caller       broker-1       2026-07-09T06:00:00Z  admin   incident-4821
+broker-ctl unfreeze --caller broker-1
+```
+
+> **Requires `state_db`.** Freezes are persisted **fail-closed**: with `state_db`
+> set they survive a signer restart, and the signer **refuses to start** if it
+> cannot load the freeze set (a lost freeze would fail *open*). **Without**
+> `state_db`, a restart clears all freezes — set `state_db` in production.
+
+> **Avoid self-lockout.** Do not freeze the `caller` CN your own tooling or the
+> control plane uses, or you cut off the path you administer through. Freezes are
+> keyed on the mTLS CN, so a broker sharing a CN with an approver/forwarder is
+> affected too. Prefer freezing a narrower subject (`end_user`, `session_id`,
+> `serial`) when possible.
+
 ### Approvals (mTLS to the control plane, approver cert)
 
 ```bash

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -223,9 +223,33 @@ as trusting every CN authorised for that cluster.
 
 ### 3. No certificate revocation (KRL)
 Mitigation is the short TTL (minutes). A certificate leaked within its validity
-window is usable until it expires; there is no way to cut it short.
-- **Roadmap:** a `/v1/revoke` endpoint generating an OpenSSH KRL by serial, plus
-  `RevokedKeys` in sshd. Tracked in [HANDOFF.md](https://github.com/luisgf/infrabroker/blob/main/docs/HANDOFF.md).
+window is usable until it expires; there is no way to cut *that individual
+issued cert* short.
+
+The **kill switch** (#117) addresses the exposures a KRL would, at the policy
+layer rather than by distributing revocation lists to every `sshd`. A frozen
+subject (`broker CN`, `end_user`, `session_id`, or certificate `serial`,
+`POST /v1/freeze`, `reload_callers` only):
+- is denied every new certificate at `POST /v1/sign` and all connectivity at
+  `GET /v1/hosts` — so one-shot, session-open, and each session-exec preflight
+  fail immediately — and has its runtime grants and approve-and-learn waivers
+  revoked. This is enforced by the signer today.
+- is streamed to brokers via `GET /v1/revocations`. A broker polling that
+  endpoint force-closes the subject's live sessions, including one with a
+  command in flight (bounding a compromised subject to one poll interval rather
+  than the session lifetime). This broker-side kill path is the companion change
+  to the signer enforcement above.
+
+The freeze set is fail-closed persistent (`state_db`): unlike a grant, a freeze
+that failed to load would fail *open*, so the signer refuses to start on a load
+error rather than silently un-freezing a blocked subject. Freezing requires
+`state_db` to survive a signer restart.
+
+- **Residual:** an already-issued **one-shot** cert stays valid for its
+  remaining window (`<= max_ttl`, minutes) — a freeze denies the *next* sign and
+  (with the broker kill path) ends *sessions*, but does not recall a one-shot
+  cert already handed to a live connection. An OpenSSH KRL by serial (roadmap)
+  would close that last gap.
 
 ### 4. Rate limiting on the signer is opt-in
 The signer supports a per-CN token-bucket rate limit on `POST /v1/sign`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,9 @@ Commands:
   broker-ctl policy grants  [--json]                        List active runtime grants
   broker-ctl policy revoke  <grant-id>                      Revoke a runtime grant
   broker-ctl cluster list  --remote                         List Kubernetes clusters live from the signer (mTLS)
+  broker-ctl freeze        (--caller cn|--end-user u|--session-id id|--serial n) [--reason r]  Freeze a subject: no new certs, kill its live sessions (mTLS)
+  broker-ctl unfreeze      (--caller cn|--end-user u|--session-id id|--serial n)  Release a frozen subject (mTLS)
+  broker-ctl revocations   [--json]                         List currently frozen subjects (mTLS)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -18,8 +18,11 @@ Every route registered across the services, extracted from the `mux.HandleFunc` 
 | `GET /v1/clusters` | `srv.handleClusters` |
 | `GET /v1/policy/grants` | `srv.handleGrantList` |
 | `GET /v1/policy/hosts` | `srv.handlePolicyHostsRead` |
+| `GET /v1/revocations` | `srv.handleRevocations` |
+| `POST /v1/freeze` | `srv.handleFreeze` |
 | `POST /v1/policy/hosts/{host}/allow` | `srv.handlePolicyAllow` |
 | `POST /v1/policy/hosts/{host}/grants` | `srv.handleGrantCreate` |
+| `POST /v1/unfreeze` | `srv.handleUnfreeze` |
 
 ## Control plane
 

--- a/internal/signer/freeze.go
+++ b/internal/signer/freeze.go
@@ -1,0 +1,204 @@
+package signer
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Freeze subject kinds. A frozen subject is denied on the signer decision path
+// (/v1/sign, /v1/hosts) and drives the broker's live-session kill (#117).
+const (
+	FreezeCaller    = "caller"     // broker mTLS CN (or on_behalf_of identity)
+	FreezeEndUser   = "end_user"   // asserted end-user identity
+	FreezeSessionID = "session_id" // a specific live broker session
+	FreezeSerial    = "serial"     // a specific issued certificate serial
+)
+
+// ValidFreezeKind reports whether kind is a recognised freeze subject kind.
+func ValidFreezeKind(kind string) bool {
+	switch kind {
+	case FreezeCaller, FreezeEndUser, FreezeSessionID, FreezeSerial:
+		return true
+	}
+	return false
+}
+
+// FreezeSubject identifies who/what is frozen. It is used as a map key, so it
+// must stay comparable.
+type FreezeSubject struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+// FrozenEntry is a FreezeSubject plus its provenance, returned by List and
+// served on GET /v1/revocations.
+type FrozenEntry struct {
+	FreezeSubject
+	Reason   string    `json:"reason,omitempty"`
+	FrozenBy string    `json:"frozen_by"`
+	FrozenAt time.Time `json:"frozen_at"`
+}
+
+// FreezeMigration is statedb migration #2 for the signer (grants is #1). Times
+// are unix seconds. Append-only: never reorder or edit once shipped, or an
+// existing database refuses to open under the old binary.
+var FreezeMigration = `
+CREATE TABLE freezes (
+	kind      TEXT NOT NULL,
+	value     TEXT NOT NULL,
+	reason    TEXT NOT NULL DEFAULT '',
+	frozen_by TEXT NOT NULL DEFAULT '',
+	frozen_at INTEGER NOT NULL,
+	PRIMARY KEY (kind, value)
+);`
+
+// StateMigrations is the ordered statedb migration list for the signer: grants
+// (schema v0→1) then freezes (v1→2). Append-only — never reorder or edit a
+// shipped entry.
+func StateMigrations() []string {
+	out := make([]string, 0, len(GrantSchema)+1)
+	out = append(out, GrantSchema...)
+	out = append(out, FreezeMigration)
+	return out
+}
+
+// FreezeStore is an in-memory, concurrency-safe set of frozen subjects. Its
+// persistence discipline is the INVERSE of the GrantStore's: a lost grant fails
+// safe (policy narrows to the file baseline), but a lost freeze fails OPEN — a
+// subject the operator blocked silently regains access. So the load path is
+// fail-closed (any read error aborts startup rather than starting with a partial
+// set) and mutations are durable (insert/delete first, fail the caller on a db
+// error), never best-effort.
+type FreezeStore struct {
+	mu     sync.Mutex
+	frozen map[FreezeSubject]FrozenEntry
+	db     *sql.DB // nil = memory-only (does NOT survive restart; set state_db in prod)
+}
+
+// NewFreezeStore returns an empty memory-only store. Without a state db a freeze
+// does not survive a restart, which fails OPEN, so production deployments must
+// set state_db (see [NewFreezeStoreDB]).
+func NewFreezeStore() *FreezeStore {
+	return &FreezeStore{frozen: map[FreezeSubject]FrozenEntry{}}
+}
+
+// NewFreezeStoreDB returns a store backed by db, preloaded with every persisted
+// freeze. Fail-closed: any read/scan error — or a row whose kind this binary
+// does not recognise (written by a newer binary) — aborts with an error rather
+// than starting with a partial freeze set, because a dropped freeze silently
+// restores access to a subject the operator blocked.
+func NewFreezeStoreDB(db *sql.DB) (*FreezeStore, error) {
+	s := &FreezeStore{frozen: map[FreezeSubject]FrozenEntry{}, db: db}
+	rows, err := db.Query(`SELECT kind, value, reason, frozen_by, frozen_at FROM freezes`)
+	if err != nil {
+		return nil, fmt.Errorf("loading freezes: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			e        FrozenEntry
+			frozenAt int64
+		)
+		if err := rows.Scan(&e.Kind, &e.Value, &e.Reason, &e.FrozenBy, &frozenAt); err != nil {
+			return nil, fmt.Errorf("scanning freeze row: %w", err)
+		}
+		if !ValidFreezeKind(e.Kind) {
+			return nil, fmt.Errorf("freeze row has unknown kind %q (state db written by a newer binary?)", e.Kind)
+		}
+		e.FrozenAt = time.Unix(frozenAt, 0).UTC()
+		s.frozen[e.FreezeSubject] = e
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("loading freezes: %w", err)
+	}
+	return s, nil
+}
+
+// Add freezes subj. Write-through, insert-first: if it cannot be persisted the
+// call fails and the in-memory set does not diverge from disk (an in-memory-only
+// freeze would vanish on restart — fail-open). Re-freezing a subject refreshes
+// its reason/provenance. Returns whether the subject was newly frozen.
+func (s *FreezeStore) Add(subj FreezeSubject, reason, by string, now time.Time) (bool, error) {
+	if !ValidFreezeKind(subj.Kind) {
+		return false, fmt.Errorf("invalid freeze kind %q", subj.Kind)
+	}
+	if subj.Value == "" {
+		return false, fmt.Errorf("freeze value must not be empty")
+	}
+	e := FrozenEntry{FreezeSubject: subj, Reason: reason, FrozenBy: by, FrozenAt: now.UTC()}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db != nil {
+		if _, err := s.db.Exec(`INSERT INTO freezes (kind, value, reason, frozen_by, frozen_at)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(kind, value) DO UPDATE SET
+				reason=excluded.reason, frozen_by=excluded.frozen_by, frozen_at=excluded.frozen_at`,
+			subj.Kind, subj.Value, reason, by, e.FrozenAt.Unix()); err != nil {
+			return false, fmt.Errorf("persisting freeze: %w", err)
+		}
+	}
+	_, existed := s.frozen[subj]
+	s.frozen[subj] = e
+	return !existed, nil
+}
+
+// Remove unfreezes subj. The db delete is durable (delete-first, fail the caller
+// on error): a freeze that survives on disk after a successful-looking unfreeze
+// would resurrect on restart and keep denying a subject the operator released.
+// Returns whether the subject was frozen.
+func (s *FreezeStore) Remove(subj FreezeSubject) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.frozen[subj]; !ok {
+		return false, nil
+	}
+	if s.db != nil {
+		if _, err := s.db.Exec(`DELETE FROM freezes WHERE kind = ? AND value = ?`, subj.Kind, subj.Value); err != nil {
+			return false, fmt.Errorf("removing freeze in state db: %w", err)
+		}
+	}
+	delete(s.frozen, subj)
+	return true, nil
+}
+
+// Frozen reports whether the caller CN or the asserted end user is frozen,
+// returning the matching subject. Consulted on the signer decision path; an
+// empty caller or endUser skips that half of the check. A nil store (only test
+// doubles — main always constructs one) reports "not frozen".
+func (s *FreezeStore) Frozen(caller, endUser string) (FreezeSubject, bool) {
+	if s == nil {
+		return FreezeSubject{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if caller != "" {
+		subj := FreezeSubject{Kind: FreezeCaller, Value: caller}
+		if _, ok := s.frozen[subj]; ok {
+			return subj, true
+		}
+	}
+	if endUser != "" {
+		subj := FreezeSubject{Kind: FreezeEndUser, Value: endUser}
+		if _, ok := s.frozen[subj]; ok {
+			return subj, true
+		}
+	}
+	return FreezeSubject{}, false
+}
+
+// List returns every frozen subject with provenance, for GET /v1/revocations and
+// operator listing. A nil store (test doubles only) returns no entries.
+func (s *FreezeStore) List() []FrozenEntry {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]FrozenEntry, 0, len(s.frozen))
+	for _, e := range s.frozen {
+		out = append(out, e)
+	}
+	return out
+}

--- a/internal/signer/freeze_test.go
+++ b/internal/signer/freeze_test.go
@@ -1,0 +1,211 @@
+package signer
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/statedb"
+)
+
+// openStateDB opens (or reopens) a state db with the full signer migration set
+// (grants + freezes).
+func openStateDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := statedb.Open(path, StateMigrations())
+	if err != nil {
+		t.Fatalf("statedb.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestFreezeStoreMemoryBasic(t *testing.T) {
+	t.Parallel()
+	s := NewFreezeStore()
+	now := time.Now()
+
+	newly, err := s.Add(FreezeSubject{Kind: FreezeCaller, Value: "brk1"}, "incident", "admin", now)
+	if err != nil || !newly {
+		t.Fatalf("Add caller: newly=%v err=%v", newly, err)
+	}
+	// Re-freeze refreshes provenance, reports not-newly.
+	if newly, err := s.Add(FreezeSubject{Kind: FreezeCaller, Value: "brk1"}, "incident2", "admin", now); err != nil || newly {
+		t.Fatalf("re-Add caller: newly=%v err=%v (want newly=false)", newly, err)
+	}
+
+	if subj, ok := s.Frozen("brk1", ""); !ok || subj.Kind != FreezeCaller || subj.Value != "brk1" {
+		t.Fatalf("Frozen(brk1) = %+v, %v; want caller=brk1, true", subj, ok)
+	}
+	if _, ok := s.Frozen("brk2", ""); ok {
+		t.Error("brk2 must not be frozen")
+	}
+	if _, ok := s.Frozen("", "alice"); ok {
+		t.Error("end user alice must not be frozen yet")
+	}
+
+	if _, err := s.Add(FreezeSubject{Kind: FreezeEndUser, Value: "alice"}, "", "admin", now); err != nil {
+		t.Fatalf("Add end_user: %v", err)
+	}
+	if _, ok := s.Frozen("brk2", "alice"); !ok {
+		t.Error("Frozen must match on end_user even when caller is not frozen")
+	}
+
+	if len(s.List()) != 2 {
+		t.Fatalf("List len = %d, want 2", len(s.List()))
+	}
+
+	existed, err := s.Remove(FreezeSubject{Kind: FreezeCaller, Value: "brk1"})
+	if err != nil || !existed {
+		t.Fatalf("Remove: existed=%v err=%v", existed, err)
+	}
+	if _, ok := s.Frozen("brk1", ""); ok {
+		t.Error("brk1 must not be frozen after Remove")
+	}
+	if existed, _ := s.Remove(FreezeSubject{Kind: FreezeCaller, Value: "brk1"}); existed {
+		t.Error("second Remove must report not-existed")
+	}
+}
+
+// TestFreezeStoreSessionSerialNotOnSignPath: session_id/serial freezes are for
+// the broker's live-session kill; the signer sign-path check (Frozen) must not
+// match them (a new sign carries neither).
+func TestFreezeStoreSessionSerialNotOnSignPath(t *testing.T) {
+	t.Parallel()
+	s := NewFreezeStore()
+	now := time.Now()
+	_, _ = s.Add(FreezeSubject{Kind: FreezeSessionID, Value: "sess-123"}, "", "admin", now)
+	_, _ = s.Add(FreezeSubject{Kind: FreezeSerial, Value: "42"}, "", "admin", now)
+
+	// Passing those values as caller/end_user must NOT be treated as frozen:
+	// Frozen only checks the caller/end_user kinds.
+	if _, ok := s.Frozen("sess-123", "42"); ok {
+		t.Error("Frozen must not match a session_id/serial value on the sign path")
+	}
+	if len(s.List()) != 2 {
+		t.Fatalf("List len = %d, want 2 (both stored for the broker)", len(s.List()))
+	}
+}
+
+func TestFreezeStoreInvalidInput(t *testing.T) {
+	t.Parallel()
+	s := NewFreezeStore()
+	now := time.Now()
+	if _, err := s.Add(FreezeSubject{Kind: "bogus", Value: "x"}, "", "admin", now); err == nil {
+		t.Error("Add with invalid kind must fail")
+	}
+	if _, err := s.Add(FreezeSubject{Kind: FreezeCaller, Value: ""}, "", "admin", now); err == nil {
+		t.Error("Add with empty value must fail")
+	}
+}
+
+func TestFreezeStoreSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "state.db")
+	now := time.Now()
+
+	s1, err := NewFreezeStoreDB(openStateDB(t, path))
+	if err != nil {
+		t.Fatalf("NewFreezeStoreDB: %v", err)
+	}
+	if _, err := s1.Add(FreezeSubject{Kind: FreezeCaller, Value: "brk1"}, "incident", "admin", now); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := s1.Add(FreezeSubject{Kind: FreezeSessionID, Value: "sess-9"}, "", "admin", now); err != nil {
+		t.Fatalf("Add session: %v", err)
+	}
+
+	// "Restart": a new store over the same db.
+	s2, err := NewFreezeStoreDB(openStateDB(t, path))
+	if err != nil {
+		t.Fatalf("NewFreezeStoreDB after restart: %v", err)
+	}
+	if _, ok := s2.Frozen("brk1", ""); !ok {
+		t.Error("caller freeze must survive restart")
+	}
+	if len(s2.List()) != 2 {
+		t.Errorf("List len after restart = %d, want 2", len(s2.List()))
+	}
+}
+
+func TestFreezeStoreRemoveDurable(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "state.db")
+	now := time.Now()
+
+	s1, err := NewFreezeStoreDB(openStateDB(t, path))
+	if err != nil {
+		t.Fatalf("NewFreezeStoreDB: %v", err)
+	}
+	subj := FreezeSubject{Kind: FreezeCaller, Value: "brk1"}
+	if _, err := s1.Add(subj, "", "admin", now); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := s1.Remove(subj); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	// A removed freeze must NOT resurrect on restart (durable delete).
+	s2, err := NewFreezeStoreDB(openStateDB(t, path))
+	if err != nil {
+		t.Fatalf("NewFreezeStoreDB after restart: %v", err)
+	}
+	if _, ok := s2.Frozen("brk1", ""); ok {
+		t.Error("a removed freeze must not resurrect on restart")
+	}
+}
+
+// TestFreezeStoreLoadFailClosed: a persisted row this binary cannot enforce
+// (unknown kind, e.g. written by a newer binary) must abort the load rather than
+// starting with a partial freeze set that silently un-freezes a subject.
+func TestFreezeStoreLoadFailClosed(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "state.db")
+	db := openStateDB(t, path)
+	if _, err := db.Exec(`INSERT INTO freezes (kind, value, frozen_at) VALUES ('future_kind', 'x', ?)`, time.Now().Unix()); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+	if _, err := NewFreezeStoreDB(db); err == nil {
+		t.Fatal("NewFreezeStoreDB must fail closed on an unknown freeze kind")
+	}
+}
+
+func TestGrantStoreRevokeForSubject(t *testing.T) {
+	t.Parallel()
+	s := NewGrantStore()
+	exp := time.Now().Add(time.Hour)
+	mustAdd := func(g Grant) {
+		t.Helper()
+		if _, err := s.Add(g); err != nil {
+			t.Fatalf("Add grant: %v", err)
+		}
+	}
+	mustAdd(Grant{Host: "h1", Allow: []string{"^ls"}, Caller: "brk1", ExpiresAt: exp})
+	mustAdd(Grant{Host: "h1", Allow: []string{"^cat"}, EndUser: "alice", ExpiresAt: exp})
+	mustAdd(Grant{Host: "h1", Allow: []string{"^df"}, ExpiresAt: exp}) // host-wide
+
+	// Freezing caller brk1 removes only the brk1-scoped grant.
+	n, err := s.RevokeForSubject(FreezeCaller, "brk1")
+	if err != nil || n != 1 {
+		t.Fatalf("RevokeForSubject(caller brk1) = %d, %v; want 1, nil", n, err)
+	}
+	if got := len(s.List(time.Now())); got != 2 {
+		t.Fatalf("after revoke: %d grants, want 2 (host-wide + alice)", got)
+	}
+
+	// Freezing end_user alice removes the alice-scoped grant; host-wide stays.
+	n, err = s.RevokeForSubject(FreezeEndUser, "alice")
+	if err != nil || n != 1 {
+		t.Fatalf("RevokeForSubject(end_user alice) = %d, %v; want 1, nil", n, err)
+	}
+	remaining := s.List(time.Now())
+	if len(remaining) != 1 || remaining[0].Host != "h1" || remaining[0].Caller != "" || remaining[0].EndUser != "" {
+		t.Fatalf("host-wide grant must survive; remaining=%+v", remaining)
+	}
+
+	// session_id/serial kinds match no grants.
+	if n, err := s.RevokeForSubject(FreezeSessionID, "sess-1"); err != nil || n != 0 {
+		t.Fatalf("RevokeForSubject(session_id) = %d, %v; want 0, nil", n, err)
+	}
+}

--- a/internal/signer/grants.go
+++ b/internal/signer/grants.go
@@ -347,6 +347,40 @@ func (s *GrantStore) Revoke(id string) (bool, error) {
 	return true, nil
 }
 
+// RevokeForSubject removes every grant scoped to a frozen subject (#117): grants
+// whose Caller matches a frozen caller CN, or whose EndUser matches a frozen end
+// user. Host-wide grants (empty scope) are left alone — a frozen caller is
+// already denied at the sign path, so only its explicitly-scoped widen-only
+// allowances and approve-and-learn waivers are stripped. Kinds other than
+// caller/end_user match nothing (grants are not keyed by session_id/serial). The
+// db delete is durable like [GrantStore.Revoke]: a surviving grant would
+// resurrect on restart and silently widen policy again. Returns the count
+// removed; on the first db error it stops and returns that error with the count
+// removed so far.
+func (s *GrantStore) RevokeForSubject(kind, value string) (int, error) {
+	if value == "" || (kind != FreezeCaller && kind != FreezeEndUser) {
+		return 0, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for id, g := range s.grants {
+		match := (kind == FreezeCaller && g.Caller == value) ||
+			(kind == FreezeEndUser && g.EndUser == value)
+		if !match {
+			continue
+		}
+		if s.db != nil {
+			if _, err := s.db.Exec("DELETE FROM grants WHERE id = ?", id); err != nil {
+				return n, fmt.Errorf("revoking grant %s in state db: %w", id, err)
+			}
+		}
+		delete(s.grants, id)
+		n++
+	}
+	return n, nil
+}
+
 // List returns the active (non-expired) grants, purging expired ones in passing.
 func (s *GrantStore) List(now time.Time) []Grant {
 	s.mu.Lock()


### PR DESCRIPTION
**Part of #117** (kill switch), phase 1 — the **signer** half. The broker-side revocation poll and forceful live-session kill land in a companion PR that will close #117.

Design decision (confirmed with maintainer): **staged kill** — explicit freeze/kill will force-close even busy sessions (companion PR); the automatic cert-expiry cap from #124 stays graceful.

## What an operator gets

Freeze a subject so it is cut off at the policy layer:

```
broker-ctl freeze --caller broker-1 --reason incident-4821   # → frozen caller=broker-1 (grants revoked: 2)
broker-ctl revocations
broker-ctl unfreeze --caller broker-1
```

A **subject** is `caller` (broker mTLS CN), `end_user`, `session_id`, or certificate `serial`.

## Signer enforcement (this PR)

- A frozen `caller`/`end_user` is denied at **POST /v1/sign** (audited `frozen_denied`) and **GET /v1/hosts**, checked before the ssh/k8s split so one-shot, session-open, and every session-exec preflight fail immediately.
- Freezing a `caller`/`end_user` also **revokes its runtime grants and approve-and-learn waivers** (`GrantStore.RevokeForSubject`, durable delete).
- New endpoints: `POST /v1/freeze`, `POST /v1/unfreeze` (`reload_callers`), `GET /v1/revocations` (any mTLS caller — the list brokers will poll).

## The store is the inverse of the grant store

A lost grant fails *safe* (policy narrows to the file baseline); a lost freeze fails **open** (a blocked subject regains access). So:
- **Load is fail-closed**: any read error — or a row with a `kind` this binary doesn't recognise (newer binary) — aborts signer startup rather than starting with a partial freeze set.
- **Mutations are durable** (insert/delete-first, fail the caller on a db error), never best-effort.
- Persisted via a new `state_db` migration (grants stays v0→1, freezes v1→2). Without `state_db`, freezes don't survive a restart — documented; set `state_db` in production.

Freeze `value`/`reason` are charset-checked so a forged token can't splice into the tamper-evident audit stream.

## Tests

- Store: memory ops, persistence across restart, durable delete (no resurrection), **fail-closed load** on an unknown kind, `RevokeForSubject` scoping (host-wide grants survive).
- HTTP surface: reload_callers auth, **deny-on-sign**, unfreeze restores, grant revocation on freeze, token-injection rejection.
- Full suite green under `-race`; gofmt + govulncheck clean.

## Docs

THREAT_MODEL gap #3 (freeze supersedes the KRL for `<= max_ttl` certs; the one-shot-cert-in-flight residual is noted), API.md (the three endpoints), OPERATIONS runbook (self-lockout warning + `state_db` requirement).