### PR TITLE
feat(broker): revocation poll + forceful session kill (#117 phase 1, broker)

### DIFF
--- a/cmd/broker-ctl/freeze.go
+++ b/cmd/broker-ctl/freeze.go
@@ -62,7 +62,13 @@ func cmdFreeze(args []string) {
 	resolveSignerTarget(fs)
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
-	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value, "reason": *reason})
+	freezePost(client, base, kind, value, *reason)
+}
+
+// freezePost calls POST /v1/freeze and prints the outcome. Shared by
+// `broker-ctl freeze` and `broker-ctl session kill`.
+func freezePost(client *http.Client, base, kind, value, reason string) {
+	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value, "reason": reason})
 	req, err := http.NewRequest(http.MethodPost, base+"/v1/freeze", bytes.NewReader(body))
 	if err != nil {
 		fatalf("request: %v", err)
@@ -87,6 +93,31 @@ func cmdFreeze(args []string) {
 		state = "already frozen (refreshed)"
 	}
 	fmt.Printf("%s %s=%s (grants revoked: %d)\n", state, kind, value, result.GrantsRevoked)
+}
+
+// cmdSession implements `broker-ctl session kill <id>` — sugar for freezing a
+// session_id, which the broker's revocation poll turns into a forced close.
+func cmdSession(args []string) {
+	if len(args) == 0 || args[0] != "kill" {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] session kill <session-id> [--reason r]")
+		os.Exit(1)
+	}
+	fs := flag.NewFlagSet("session kill", flag.ExitOnError)
+	reason := fs.String("reason", "", "optional reason recorded in the audit log")
+	urlFlag, cert, key, ca := signerFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] session kill <session-id> [--reason r]")
+		fs.PrintDefaults()
+	}
+	must(fs.Parse(args[1:]))
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(1)
+	}
+	id := fs.Arg(0)
+	resolveSignerTarget(fs)
+	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
+	freezePost(client, base, signer.FreezeSessionID, id, *reason)
 }
 
 // cmdUnfreeze calls the signer's POST /v1/unfreeze (mTLS, reload_callers) to

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -97,6 +97,8 @@ func main() {
 		cmdUnfreeze(args[1:])
 	case "revocations":
 		cmdRevocations(args[1:])
+	case "session":
+		cmdSession(args[1:])
 	case "version":
 		cmdVersion(args[1:])
 	case "help":
@@ -172,6 +174,7 @@ Commands:
   broker-ctl freeze        (--caller cn|--end-user u|--session-id id|--serial n) [--reason r]  Freeze a subject: no new certs, kill its live sessions (mTLS)
   broker-ctl unfreeze      (--caller cn|--end-user u|--session-id id|--serial n)  Release a frozen subject (mTLS)
   broker-ctl revocations   [--json]                         List currently frozen subjects (mTLS)
+  broker-ctl session kill  <session-id> [--reason r]        Force-close a live session (freezes its session_id, mTLS)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -466,10 +466,12 @@ the signed audit log (`grant-created` / `grant-revoked`).
 
 A **freeze** immediately cuts a subject off: it gets **no new certificate**
 (`/v1/sign`) and **no connectivity** (`/v1/hosts`), its runtime grants and
-approve-and-learn waivers are revoked, and brokers **force-close its live
-sessions** (broker-side kill path). Operator-only (mTLS, CN in `reload_callers`),
-audited (`frozen` / `unfrozen`). A subject is one of: `--caller <CN>`,
-`--end-user <u>`, `--session-id <id>`, `--serial <n>`.
+approve-and-learn waivers are revoked, and every broker force-closes its live
+sessions on its next revocation poll (`revocation_poll_seconds`, default 10s —
+this is the kill latency for an established session, including one running a
+command). Operator-only (mTLS, CN in `reload_callers`), audited (`frozen` /
+`unfrozen`; the broker records `session_killed`). A subject is one of:
+`--caller <CN>`, `--end-user <u>`, `--session-id <id>`, `--serial <n>`.
 
 ```bash
 # Incident: broker-1 looks compromised. Freeze it — no new access, sessions killed.
@@ -478,8 +480,10 @@ broker-ctl freeze --caller broker-1 --reason incident-4821
 
 # Freeze one end user, or one specific live session / certificate:
 broker-ctl freeze --end-user alice --reason offboarding
-broker-ctl freeze --session-id 7f3c... 
 broker-ctl freeze --serial 12345
+
+# Kill a single runaway session by id (sugar for freeze --session-id):
+broker-ctl session kill 7f3c...
 
 # List what is frozen; release when the incident is over:
 broker-ctl revocations

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -234,11 +234,13 @@ subject (`broker CN`, `end_user`, `session_id`, or certificate `serial`,
   `GET /v1/hosts` — so one-shot, session-open, and each session-exec preflight
   fail immediately — and has its runtime grants and approve-and-learn waivers
   revoked. This is enforced by the signer today.
-- is streamed to brokers via `GET /v1/revocations`. A broker polling that
-  endpoint force-closes the subject's live sessions, including one with a
-  command in flight (bounding a compromised subject to one poll interval rather
-  than the session lifetime). This broker-side kill path is the companion change
-  to the signer enforcement above.
+- is streamed to brokers via `GET /v1/revocations`, which every broker polls
+  (`revocation_poll_seconds`, default 10s). A matching session is force-closed
+  **including one with a command in flight** — the kill overrides the reaper's
+  never-close-a-busy-session rule — so a compromised subject is bound to one
+  poll interval rather than the session lifetime. `session_id`/`serial` target a
+  specific session/cert; a frozen `end_user` closes all of that user's sessions;
+  a frozen broker `caller` CN closes every session that broker holds.
 
 The freeze set is fail-closed persistent (`state_db`): unlike a grant, a freeze
 that failed to load would fail *open*, so the signer refuses to start on a load
@@ -247,9 +249,11 @@ error rather than silently un-freezing a blocked subject. Freezing requires
 
 - **Residual:** an already-issued **one-shot** cert stays valid for its
   remaining window (`<= max_ttl`, minutes) — a freeze denies the *next* sign and
-  (with the broker kill path) ends *sessions*, but does not recall a one-shot
-  cert already handed to a live connection. An OpenSSH KRL by serial (roadmap)
-  would close that last gap.
+  ends *sessions*, but does not recall a one-shot cert already handed to a live
+  connection. A truly compromised broker can also ignore the revocation poll and
+  skip its own session kills (though it still gets no *new* certificates); the
+  signer-side deny is the hard guarantee, the broker kill is best-effort
+  containment. An OpenSSH KRL by serial (roadmap) would close the one-shot gap.
 
 ### 4. Rate limiting on the signer is opt-in
 The signer supports a per-CN token-bucket rate limit on `POST /v1/sign`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,6 +39,7 @@ Commands:
   broker-ctl freeze        (--caller cn|--end-user u|--session-id id|--serial n) [--reason r]  Freeze a subject: no new certs, kill its live sessions (mTLS)
   broker-ctl unfreeze      (--caller cn|--end-user u|--session-id id|--serial n)  Release a frozen subject (mTLS)
   broker-ctl revocations   [--json]                         List currently frozen subjects (mTLS)
+  broker-ctl session kill  <session-id> [--reason r]        Force-close a live session (freezes its session_id, mTLS)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -22,6 +22,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `source_address` | `string` | SourceAddress: broker egress IP/CIDR, used in local mode. |
 | `max_ttl_seconds` | `int` | MaxTTLSeconds caps the maximum requestable TTL. |
 | `hosts_refresh_seconds` | `int` | HostsRefreshSeconds: host-list reload interval from the signer. Remote mode only. Default: 300 (5 minutes). |
+| `revocation_poll_seconds` | `int` | RevocationPollSeconds: how often the broker polls the signer's freeze set and force-closes matching live sessions (kill switch, #117). Remote mode only; this is the kill latency for an established session. Default: 10. |
 | `session_idle_seconds` | `int` | Persistent session idle-close and maximum lifetime. |
 | `session_max_seconds` | `int` | default 1800 |
 | `session_recording_dir` | `string` | SessionRecordingDir: directory for session recordings in ASCIIcast v2 format (.cast files). One file per session: <session_id>.cast. Empty = recording disabled. |

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -7,11 +7,14 @@ package broker
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -76,6 +79,11 @@ type Config struct {
 	// HostsRefreshSeconds: host-list reload interval from the signer. Remote
 	// mode only. Default: 300 (5 minutes).
 	HostsRefreshSeconds int `json:"hosts_refresh_seconds"`
+
+	// RevocationPollSeconds: how often the broker polls the signer's freeze set
+	// and force-closes matching live sessions (kill switch, #117). Remote mode
+	// only; this is the kill latency for an established session. Default: 10.
+	RevocationPollSeconds int `json:"revocation_poll_seconds"`
 
 	// Persistent session idle-close and maximum lifetime.
 	SessionIdleSeconds int `json:"session_idle_seconds"` // default 300
@@ -282,6 +290,12 @@ type clusterFetcher interface {
 	FetchClusters(context.Context, string) (map[string]signer.ClusterInfo, error)
 }
 
+// revocationFetcher retrieves the freeze set from the signer (kill switch, #117).
+// Implemented by *signer.Remote; nil in local mode (no signer to poll).
+type revocationFetcher interface {
+	FetchRevocations(context.Context) ([]signer.FrozenEntry, error)
+}
+
 // Engine executes commands by signing ephemeral credentials and auditing.
 type Engine struct {
 	cfg      *Config
@@ -295,6 +309,13 @@ type Engine struct {
 	// clusterFetcher fetches the k8s cluster list; nil when no k8s target is
 	// configured (local mode, or a signer with no clusters).
 	clusterFetcher clusterFetcher
+
+	// revFetcher polls the signer's freeze set (#117); nil in local mode. When
+	// set, a background poll force-closes sessions matching a frozen subject.
+	// ownIdentity is the broker's signer-facing identity (client-cert CN, or
+	// "local"), used to match a frozen caller CN against this broker's sessions.
+	revFetcher  revocationFetcher
+	ownIdentity string
 
 	mu    sync.RWMutex
 	hosts map[string]signer.HostInfo // cache refreshed periodically (remote mode)
@@ -335,6 +356,18 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		return nil, err
 	}
 
+	// The broker's signer-facing identity — its client-cert CN in remote mode,
+	// or "local" — is how a frozen caller CN (#117) is matched against this
+	// broker's sessions.
+	ownIdentity := localCaller
+	if cfg.Signer != nil {
+		cn, cerr := clientCertCN(cfg.Signer.ClientCert)
+		if cerr != nil {
+			return nil, fmt.Errorf("reading broker identity from client cert: %w", cerr)
+		}
+		ownIdentity = cn
+	}
+
 	seed, err := os.ReadFile(cfg.AuditKey)
 	if err != nil {
 		return nil, fmt.Errorf("reading audit key: %w", err)
@@ -369,7 +402,7 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		maxLife = 30 * time.Minute
 	}
 
-	e := &Engine{cfg: cfg, sgn: sgn, fetcher: fetcher, auditLog: al, redactor: redactor, maxTTL: maxTTL}
+	e := &Engine{cfg: cfg, sgn: sgn, fetcher: fetcher, auditLog: al, redactor: redactor, maxTTL: maxTTL, ownIdentity: ownIdentity}
 	e.sessions = newSessionManager(idle, maxLife, func(s *liveSession) {
 		e.auditE(audit.Entry{Caller: s.caller, Host: s.host, Serial: s.serial,
 			SessionID: s.id, Outcome: "session_close", Err: "reaped (idle/lifetime)"})
@@ -411,9 +444,38 @@ func NewEngine(cfg *Config) (*Engine, error) {
 			refresh = 5 * time.Minute
 		}
 		e.startHostRefresh(refresh)
+
+		// Kill switch (#117): poll the freeze set and force-close matching
+		// sessions. Shares refreshStop, so Close stops it too.
+		if rf, ok := fetcher.(revocationFetcher); ok {
+			e.revFetcher = rf
+			revPoll := time.Duration(cfg.RevocationPollSeconds) * time.Second
+			if revPoll <= 0 {
+				revPoll = 10 * time.Second
+			}
+			e.startRevocationPoll(revPoll)
+		}
 	}
 
 	return e, nil
+}
+
+// clientCertCN reads the CommonName from a PEM-encoded client certificate — the
+// broker's signer-facing identity, used to match a frozen caller CN (#117).
+func clientCertCN(certFile string) (string, error) {
+	pemBytes, err := os.ReadFile(certFile)
+	if err != nil {
+		return "", err
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return "", fmt.Errorf("no PEM certificate block in %s", certFile)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parsing %s: %w", certFile, err)
+	}
+	return cert.Subject.CommonName, nil
 }
 
 // startHostRefresh starts the goroutine that periodically reloads the host
@@ -451,6 +513,81 @@ func (e *Engine) startHostRefresh(interval time.Duration) {
 			}
 		}
 	}()
+}
+
+// startRevocationPoll starts the goroutine that polls the signer's freeze set
+// (#117) and force-closes matching live sessions. It shares e.refreshStop with
+// the host-refresh goroutine, so Close stops both.
+func (e *Engine) startRevocationPoll(interval time.Duration) {
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-e.refreshStop:
+				return
+			case <-t.C:
+				frozen, err := e.revFetcher.FetchRevocations(context.Background())
+				if err != nil {
+					log.Printf("warning: revocation poll failed: %v (retrying next tick)", err)
+					continue
+				}
+				e.enforceRevocations(frozen)
+			}
+		}
+	}()
+}
+
+// enforceRevocations force-closes every live session that matches a frozen
+// subject and audits each kill as session_killed. Idempotent: once a session is
+// killed it is gone, so subsequent polls with the same freeze set kill nothing.
+func (e *Engine) enforceRevocations(frozen []signer.FrozenEntry) {
+	pred := revocationPredicate(frozen, e.ownIdentity)
+	if pred == nil {
+		return
+	}
+	for _, s := range e.sessions.killMatching(pred) {
+		e.auditE(audit.Entry{
+			Caller: s.caller, Host: s.host, Serial: s.serial, SessionID: s.id,
+			Outcome: "session_killed", Err: "frozen (kill switch)",
+		})
+	}
+}
+
+// revocationPredicate builds the "should this session be killed?" test from the
+// freeze set. Mapping to liveSession fields: a frozen end_user matches
+// liveSession.caller (the broker sends the end user as the signer's end_user);
+// session_id and serial match directly; a frozen caller CN matches THIS broker's
+// identity, in which case every one of its sessions is killed. Returns nil when
+// nothing in the set could match a session, so the caller can skip the sweep.
+func revocationPredicate(frozen []signer.FrozenEntry, ownIdentity string) func(*liveSession) bool {
+	endUsers := map[string]bool{}
+	sessionIDs := map[string]bool{}
+	serials := map[string]bool{}
+	brokerFrozen := false
+	for _, f := range frozen {
+		switch f.Kind {
+		case signer.FreezeCaller:
+			if f.Value == ownIdentity {
+				brokerFrozen = true
+			}
+		case signer.FreezeEndUser:
+			endUsers[f.Value] = true
+		case signer.FreezeSessionID:
+			sessionIDs[f.Value] = true
+		case signer.FreezeSerial:
+			serials[f.Value] = true
+		}
+	}
+	if !brokerFrozen && len(endUsers) == 0 && len(sessionIDs) == 0 && len(serials) == 0 {
+		return nil
+	}
+	return func(s *liveSession) bool {
+		return brokerFrozen ||
+			endUsers[s.caller] ||
+			sessionIDs[s.id] ||
+			serials[strconv.FormatUint(s.serial, 10)]
+	}
 }
 
 // buildSigner constructs a remote signer (when a Signer block is present) or a

--- a/internal/broker/killswitch_test.go
+++ b/internal/broker/killswitch_test.go
@@ -1,0 +1,85 @@
+package broker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// TestKillMatchingClosesBusySessions pins the core of the kill switch (#117):
+// unlike the reaper, killMatching force-closes a session with a command in
+// flight (busy). Non-matching sessions are untouched.
+func TestKillMatchingClosesBusySessions(t *testing.T) {
+	t.Parallel()
+	m := newSessionManager(5*time.Minute, 30*time.Minute, nil)
+	t.Cleanup(func() { m.closeAll() })
+
+	a := dummySession("a", "alice")
+	b := dummySession("b", "bob")
+	_ = m.add(a)
+	_ = m.add(b)
+	// Mark "a" busy — the reaper would spare it; killMatching must not.
+	if _, _, owned := m.checkoutOwned("a", "alice"); !owned {
+		t.Fatal("checkoutOwned failed")
+	}
+
+	victims := m.killMatching(func(s *liveSession) bool { return s.caller == "alice" })
+	if len(victims) != 1 || victims[0].id != "a" {
+		t.Fatalf("victims = %+v, want exactly [a]", victims)
+	}
+	if _, ok := peek(m, "a"); ok {
+		t.Error("a busy matching session must be force-closed by killMatching")
+	}
+	if _, ok := peek(m, "b"); !ok {
+		t.Error("a non-matching session must survive")
+	}
+}
+
+func TestRevocationPredicate(t *testing.T) {
+	t.Parallel()
+	sess := func(id, caller string, serial uint64) *liveSession {
+		return &liveSession{id: id, caller: caller, serial: serial}
+	}
+	entry := func(kind, value string) signer.FrozenEntry {
+		return signer.FrozenEntry{FreezeSubject: signer.FreezeSubject{Kind: kind, Value: value}}
+	}
+
+	// A frozen end_user matches liveSession.caller (the broker sends the end
+	// user as the signer's end_user); session_id and serial match directly.
+	pred := revocationPredicate([]signer.FrozenEntry{
+		entry(signer.FreezeEndUser, "alice"),
+		entry(signer.FreezeSessionID, "s9"),
+		entry(signer.FreezeSerial, "42"),
+	}, "broker-1")
+	if pred == nil {
+		t.Fatal("predicate must be non-nil when the set has matchable subjects")
+	}
+	if !pred(sess("x", "alice", 1)) {
+		t.Error("frozen end_user must match a session whose caller is that end user")
+	}
+	if !pred(sess("s9", "bob", 1)) {
+		t.Error("frozen session_id must match")
+	}
+	if !pred(sess("x", "bob", 42)) {
+		t.Error("frozen serial must match")
+	}
+	if pred(sess("x", "bob", 7)) {
+		t.Error("an unrelated session must not match")
+	}
+
+	// A frozen caller CN equal to our own identity kills every session.
+	predSelf := revocationPredicate([]signer.FrozenEntry{entry(signer.FreezeCaller, "broker-1")}, "broker-1")
+	if predSelf == nil || !predSelf(sess("any", "anyone", 99)) {
+		t.Error("our broker's CN frozen → every session matches")
+	}
+
+	// A different broker's freeze produces no predicate (nothing to sweep here).
+	if revocationPredicate([]signer.FrozenEntry{entry(signer.FreezeCaller, "other-broker")}, "broker-1") != nil {
+		t.Error("another broker's caller freeze must not sweep our sessions")
+	}
+	// Empty set → nil (skip the sweep).
+	if revocationPredicate(nil, "broker-1") != nil {
+		t.Error("empty freeze set → nil predicate")
+	}
+}

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -165,6 +165,30 @@ func (m *sessionManager) reapExpired(now time.Time) {
 	}
 }
 
+// killMatching force-closes and removes every session for which pred returns
+// true, and returns the victims. Unlike the reaper it does NOT spare a busy
+// session — a kill switch (#117) must interrupt a command in flight. Closing the
+// connection under a running command makes that command's next read/write fail
+// and return; the recorder is mutex-safe against a concurrent write, so the
+// close races cleanly. Victims are removed from the map under the lock, then
+// closed outside it (close() does network I/O). The onReap callback is NOT
+// invoked — the caller audits kills distinctly from idle/lifetime reaps.
+func (m *sessionManager) killMatching(pred func(*liveSession) bool) []*liveSession {
+	m.mu.Lock()
+	var victims []*liveSession
+	for id, s := range m.sessions {
+		if pred(s) {
+			delete(m.sessions, id)
+			victims = append(victims, s)
+		}
+	}
+	m.mu.Unlock()
+	for _, s := range victims {
+		s.close()
+	}
+	return victims
+}
+
 func (m *sessionManager) add(s *liveSession) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/signer/remote.go
+++ b/internal/signer/remote.go
@@ -415,6 +415,33 @@ func (r *Remote) FetchHosts(ctx context.Context, onBehalfOf string) (map[string]
 	return hosts, nil
 }
 
+// FetchRevocations calls GET /v1/revocations on the signer and returns the
+// current freeze set (#117). The broker polls this and force-closes matching
+// live sessions. Any authenticated caller may read it.
+func (r *Remote) FetchRevocations(ctx context.Context) ([]FrozenEntry, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.url+"/v1/revocations", nil)
+	if err != nil {
+		return nil, fmt.Errorf("building /v1/revocations request: %w", err)
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching revocations: %w", err)
+	}
+	defer resp.Body.Close()
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading /v1/revocations response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("signer returned %d: %s", resp.StatusCode, bytes.TrimSpace(rb))
+	}
+	var frozen []FrozenEntry
+	if err := json.Unmarshal(rb, &frozen); err != nil {
+		return nil, fmt.Errorf("invalid /v1/revocations response: %w", err)
+	}
+	return frozen, nil
+}
+
 // FetchClusters calls GET /v1/clusters on the signer and returns the
 // connectivity data for the Kubernetes clusters the caller may reach. Like
 // FetchHosts, onBehalfOf (when non-empty) is sent in X-On-Behalf-Of so the


### PR DESCRIPTION
Closes #117.

Completes the kill switch. PR #125 landed the signer half (freeze denies new signs/hosts, revokes grants, exposes `GET /v1/revocations`); this PR is the **broker half** — enforcing the freeze set on **live sessions**.

Design decision (confirmed with maintainer): **staged kill** — an explicit freeze/kill force-closes even a session with a command in flight; the automatic cert-expiry cap (#124) stays graceful.

## What it does

- `signer.Remote.FetchRevocations` → `GET /v1/revocations`.
- The broker starts a **poll goroutine** (`revocation_poll_seconds`, default **10s**; shares `refreshStop` with the host-refresh loop, so `Close` stops it) that fetches the freeze set and force-closes matching sessions. 10s is the kill latency for an established session.
- `sessionManager.killMatching` force-closes and removes matching sessions, **overriding the reaper's never-close-a-busy-session rule**. Closing the connection makes the in-flight command's next read/write fail and return; the recorder is mutex-safe against a concurrent write, so the close races cleanly.
- `revocationPredicate` maps freeze subjects → sessions: a frozen `end_user` matches `liveSession.caller` (the broker sends the end user as the signer's `end_user`), `session_id`/`serial` match directly, and a frozen broker `caller` CN equal to this broker's identity (client-cert CN, or `local`) kills **all** its sessions. Each kill is audited `session_killed`.
- `broker-ctl session kill <id>` — sugar for `freeze --session-id`.

## Honest threat-model note (in the diff)

A truly compromised broker can ignore the poll and skip its own kills — it still gets **no new certificates** (signer-side deny is the hard guarantee); the live-session kill is best-effort containment for a cooperative broker and for killing a specific runaway `session_id`/`serial`/`end_user`.

## Tests

- `TestKillMatchingClosesBusySessions`: a **busy** matching session is force-closed (the reaper would spare it); non-matching sessions survive.
- `TestRevocationPredicate`: matches by `end_user`/`session_id`/`serial`, the own-CN-kills-all case, and returns nil when nothing could match (skip the sweep).
- Full suite green under `-race`; gofmt, vet, govulncheck clean; reference docs regenerated.