### PR TITLE
feat(mcp): structured dry-run decision with a machine-readable reason_code (#119)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -184,6 +184,7 @@ Response (allowed, but approval-gated):
 
 ```
 [dry-run] ALLOWED (requires human approval before executing)
+reason_code: needs_approval
 rule: require_approval:^systemctl restart
 force-command: systemctl restart nginx
 ttl: 120s
@@ -193,17 +194,29 @@ Response (denied by command policy):
 
 ```
 [dry-run] DENIED: command not allowed on "web01" by command_policy (allowlist:no-match)
+reason_code: allowlist_no_match
+rule: allowlist:no-match
 ```
 
 Response (allowed because the host is in command-policy audit mode):
 
 ```
 [dry-run] ALLOWED
+reason_code: allowed
 rule: allowlist:no-match
 warning: command_policy audit: would deny (allowlist:no-match)
 force-command: rm -rf /tmp/example
 ttl: 120s
 ```
+
+**Structured decision.** Besides the text above, a dry-run returns a machine-readable
+`decision` object in the tool's `structuredContent`, so an agent can branch on it
+instead of parsing prose. It carries `allowed`, `matched_rule`, `require_approval`,
+`enforcement`, `ttl_seconds`, `warning`, and a stable **`reason_code`** — one of
+`allowed`, `needs_approval`, `command_denied`, `allowlist_no_match`,
+`shell_parse_error`, or `denied`. The intended loop: dry-run a risky command, read
+`reason_code`, and self-correct — narrow the command (`command_denied` /
+`allowlist_no_match`), request approval (`needs_approval`), or proceed (`allowed`).
 
 Use dry-run to decide whether to proceed before committing an action. A host may
 restrict commands via an **allowlist** or **denylist** (see the

--- a/internal/mcpserver/decision_test.go
+++ b/internal/mcpserver/decision_test.go
@@ -1,0 +1,157 @@
+package mcpserver
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/luisgf/infrabroker/internal/broker"
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+func TestReasonCode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		d    signer.DecisionInfo
+		want string
+	}{
+		{"allowed", signer.DecisionInfo{Allowed: true, MatchedRule: "allow:^uptime$"}, "allowed"},
+		{"needs_approval", signer.DecisionInfo{Allowed: true, RequireApproval: true}, "needs_approval"},
+		{"command_denied", signer.DecisionInfo{MatchedRule: "deny:^rm "}, "command_denied"},
+		{"allowlist_no_match", signer.DecisionInfo{MatchedRule: "allowlist:no-match"}, "allowlist_no_match"},
+		{"shell_parse_error", signer.DecisionInfo{MatchedRule: "shell-parse:syntax error"}, "shell_parse_error"},
+		{"denied_fallback", signer.DecisionInfo{MatchedRule: "something-unexpected"}, "denied"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reasonCode(&tc.d); got != tc.want {
+				t.Errorf("reasonCode = %q, want %q", got, tc.want)
+			}
+			out := decisionToOutput(&tc.d)
+			if out.ReasonCode != tc.want {
+				t.Errorf("decisionToOutput.ReasonCode = %q, want %q", out.ReasonCode, tc.want)
+			}
+			if out.Allowed != tc.d.Allowed {
+				t.Errorf("decisionToOutput.Allowed = %v, want %v", out.Allowed, tc.d.Allowed)
+			}
+		})
+	}
+	if decisionToOutput(nil) != nil {
+		t.Error("decisionToOutput(nil) must be nil")
+	}
+}
+
+// sshDryRunSession registers the SSH tools on an in-memory server with two
+// policy hosts: web01 (denylist ^rm ) and web02 (allowlist ^uptime$). Dry-run
+// resolves the policy without connecting, so no live host is needed.
+func sshDryRunSession(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	dir := t.TempDir()
+	_, caPriv, _ := ed25519.GenerateKey(rand.Reader)
+	blk, err := ssh.MarshalPrivateKey(caPriv, "ca-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(dir, "ca")
+	if err := os.WriteFile(caPath, pem.EncodeToMemory(blk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedPath := filepath.Join(dir, "audit.seed")
+	seed := make([]byte, 32)
+	_, _ = rand.Read(seed)
+	if err := os.WriteFile(seedPath, seed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng, err := broker.NewEngine(&broker.Config{
+		CAKey:         caPath,
+		AuditLog:      filepath.Join(dir, "audit.log"),
+		AuditKey:      seedPath,
+		SourceAddress: "127.0.0.1",
+		MaxTTLSeconds: 120,
+		Hosts: map[string]broker.HostConfig{
+			"web01": {Addr: "10.0.0.21:22", User: "deploy", Principal: "host:web01", HostKey: "ssh-ed25519 AAAAC3Nz",
+				CommandPolicy: signer.CommandPolicy{Mode: signer.CmdPolicyDenylist, Deny: []string{"^rm "}}},
+			"web02": {Addr: "10.0.0.22:22", User: "deploy", Principal: "host:web02", HostKey: "ssh-ed25519 AAAAC3Nz",
+				CommandPolicy: signer.CommandPolicy{Mode: signer.CmdPolicyAllowlist, Allow: []string{"^uptime$"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { eng.Close() })
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	Register(srv, eng, func(context.Context) broker.Caller { return broker.Caller{ID: "test"} })
+	ct, st := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(context.Background(), st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	sess, err := client.Connect(context.Background(), ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	return sess
+}
+
+// TestSSHExecuteDryRunStructuredDecision pins the point of #119: a dry-run
+// returns the decision as structuredContent (not just prose), with a stable
+// reason_code the agent can branch on.
+func TestSSHExecuteDryRunStructuredDecision(t *testing.T) {
+	t.Parallel()
+	sess := sshDryRunSession(t)
+	ctx := context.Background()
+
+	type dec struct {
+		Allowed    bool   `json:"allowed"`
+		ReasonCode string `json:"reason_code"`
+	}
+	call := func(server, command string) dec {
+		t.Helper()
+		res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "ssh_execute",
+			Arguments: map[string]any{"server": server, "command": command, "dry_run": true},
+		})
+		if err != nil {
+			t.Fatalf("CallTool: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("unexpected tool error: %s", k8sToolText(t, res))
+		}
+		var out struct {
+			Decision *dec `json:"decision"`
+		}
+		raw, _ := json.Marshal(res.StructuredContent)
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("decode structuredContent: %v (%s)", err, raw)
+		}
+		if out.Decision == nil {
+			t.Fatalf("dry-run must populate structuredContent.decision; got %s", raw)
+		}
+		return *out.Decision
+	}
+
+	if d := call("web01", "rm -rf /tmp/x"); d.Allowed || d.ReasonCode != "command_denied" {
+		t.Errorf("denylist deny: allowed=%v reason_code=%q, want false/command_denied", d.Allowed, d.ReasonCode)
+	}
+	if d := call("web01", "id"); !d.Allowed || d.ReasonCode != "allowed" {
+		t.Errorf("denylist allow: allowed=%v reason_code=%q, want true/allowed", d.Allowed, d.ReasonCode)
+	}
+	if d := call("web02", "reboot"); d.Allowed || d.ReasonCode != "allowlist_no_match" {
+		t.Errorf("allowlist no-match: allowed=%v reason_code=%q, want false/allowlist_no_match", d.Allowed, d.ReasonCode)
+	}
+	if d := call("web02", "uptime"); !d.Allowed || d.ReasonCode != "allowed" {
+		t.Errorf("allowlist match: allowed=%v reason_code=%q, want true/allowed", d.Allowed, d.ReasonCode)
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -58,6 +58,67 @@ type executeOutput struct {
 	ExitCode int      `json:"exit_code"          jsonschema:"exit code of the remote command: 0=success, non-zero=command failure (NOT a tool error)"`
 	Serial   uint64   `json:"serial"             jsonschema:"audit identifier; ignore when reasoning about the result"`
 	Warnings []string `json:"warnings,omitempty" jsonschema:"advisory warnings; command_policy audit-mode warnings mean the command was allowed but would have been blocked or approval-gated in enforce mode"`
+	// Decision is set only on a dry-run (dry_run=true): the policy decision,
+	// with no stdout/exit_code. Branch on decision.reason_code to self-correct.
+	Decision *decisionOutput `json:"decision,omitempty" jsonschema:"present only on a dry_run: the policy decision (allow/deny/approval) with a machine-readable reason_code, instead of executed output"`
+}
+
+// decisionOutput is the machine-readable policy decision returned as
+// structuredContent on a dry-run, so an agent can branch on reason_code
+// (execute / narrow the command / request approval / pick another host) instead
+// of parsing prose.
+type decisionOutput struct {
+	Allowed         bool   `json:"allowed"                    jsonschema:"whether the command would be authorised"`
+	ReasonCode      string `json:"reason_code"                jsonschema:"machine-readable outcome: allowed | needs_approval | command_denied | allowlist_no_match | shell_parse_error | denied"`
+	Reason          string `json:"reason,omitempty"           jsonschema:"human-readable explanation of a denial (empty when allowed)"`
+	RequireApproval bool   `json:"require_approval,omitempty" jsonschema:"true when the command is allowed but needs out-of-band human approval before it will execute"`
+	MatchedRule     string `json:"matched_rule,omitempty"     jsonschema:"the command_policy rule that drove the decision, e.g. 'deny:^rm ' or 'allowlist:no-match'"`
+	Enforcement     string `json:"enforcement,omitempty"      jsonschema:"effective command_policy enforcement mode (enforce or audit)"`
+	ForceCommand    string `json:"force_command,omitempty"    jsonschema:"the force-command that would be baked into the certificate"`
+	TTLSeconds      int    `json:"ttl_seconds,omitempty"      jsonschema:"TTL the issued certificate would carry, in seconds"`
+	Warning         string `json:"warning,omitempty"          jsonschema:"audit-mode observation: allowed now, but would be blocked or approval-gated in enforce mode"`
+	WouldDeny       bool   `json:"would_deny,omitempty"       jsonschema:"audit mode only: the command would have been denied in enforce mode"`
+}
+
+// reasonCode classifies a policy decision into a stable, machine-readable code.
+// The denial codes derive from the signer's MatchedRule prefixes (policyset.go).
+func reasonCode(d *signer.DecisionInfo) string {
+	if d.Allowed {
+		if d.RequireApproval {
+			return "needs_approval"
+		}
+		return "allowed"
+	}
+	switch {
+	case strings.HasPrefix(d.MatchedRule, "deny:"):
+		return "command_denied"
+	case strings.HasPrefix(d.MatchedRule, "shell-parse:"):
+		return "shell_parse_error"
+	case d.MatchedRule == "allowlist:no-match":
+		return "allowlist_no_match"
+	default:
+		return "denied"
+	}
+}
+
+// decisionToOutput maps the signer's DecisionInfo to the MCP structured output,
+// adding the reason_code. Returns nil for a nil decision (non-dry-run path).
+func decisionToOutput(d *signer.DecisionInfo) *decisionOutput {
+	if d == nil {
+		return nil
+	}
+	return &decisionOutput{
+		Allowed:         d.Allowed,
+		ReasonCode:      reasonCode(d),
+		Reason:          d.Reason,
+		RequireApproval: d.RequireApproval,
+		MatchedRule:     d.MatchedRule,
+		Enforcement:     d.Enforcement,
+		ForceCommand:    d.ForceCommand,
+		TTLSeconds:      d.TTLSeconds,
+		Warning:         d.Warning,
+		WouldDeny:       d.WouldDeny,
+	}
 }
 
 type listInput struct{}
@@ -157,9 +218,11 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 				Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
 			}, executeOutput{}, nil
 		}
-		// Dry-run: return the policy decision instead of executed output.
+		// Dry-run: return the policy decision (as structuredContent too) instead
+		// of executed output, so the agent can branch on decision.reason_code.
 		if res.DryRun != nil {
-			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderDecision(res.DryRun)}}}, executeOutput{}, nil
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderDecision(res.DryRun)}}},
+				executeOutput{Decision: decisionToOutput(res.DryRun)}, nil
 		}
 		out := executeOutput{Stdout: res.Stdout, Stderr: res.Stderr, ExitCode: res.ExitCode, Serial: res.Serial, Warnings: res.Warnings}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderResult(out)}}}, out, nil
@@ -328,6 +391,7 @@ func renderDecision(d *signer.DecisionInfo) string {
 			fmt.Fprintf(&b, ": %s", d.Reason)
 		}
 	}
+	fmt.Fprintf(&b, "\nreason_code: %s", reasonCode(d))
 	if d.MatchedRule != "" {
 		fmt.Fprintf(&b, "\nrule: %s", d.MatchedRule)
 	}

--- a/internal/mcpserver/tools_k8s.go
+++ b/internal/mcpserver/tools_k8s.go
@@ -66,6 +66,9 @@ type k8sOutput struct {
 	Output   string   `json:"output"             jsonschema:"the API server's JSON response (get/list/delete/apply) or the pod logs (logs)"`
 	Serial   uint64   `json:"serial"             jsonschema:"audit identifier; ignore when reasoning about the result"`
 	Warnings []string `json:"warnings,omitempty" jsonschema:"advisory command-policy audit-mode warnings"`
+	// Decision is set only on a dry-run: the policy decision with a
+	// machine-readable reason_code, instead of the API response.
+	Decision *decisionOutput `json:"decision,omitempty" jsonschema:"present only on a dry_run: the policy decision (allow/deny/approval) with a machine-readable reason_code"`
 }
 
 // RegisterK8s adds the Kubernetes tool family to the MCP server. The frontends
@@ -176,7 +179,8 @@ func runK8s(ctx context.Context, eng *broker.Engine, callerFn CallerFunc, cluste
 		return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
 	}
 	if res.DryRun != nil {
-		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderDecision(res.DryRun)}}}, k8sOutput{}, nil
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderDecision(res.DryRun)}}},
+			k8sOutput{Decision: decisionToOutput(res.DryRun)}, nil
 	}
 	out := k8sOutput{Output: res.Output, Serial: res.Serial, Warnings: res.Warnings}
 	text := res.Output

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -400,7 +400,17 @@ func (p PolicyTable) resolve(in Intent, defaultMaxTTL time.Duration, grants Gran
 
 	cp, err := resolveCommandPolicy(hp, in, grants)
 	if err != nil {
-		return Decision{}, err
+		// A command_policy denial carries a verdict (MatchedRule/Enforcement/
+		// Warning); preserve it on the returned Decision so a dry-run can explain
+		// WHY, not just that it was denied. The non-dry-run path ignores the
+		// Decision on error, so this only enriches the dry-run/audit view.
+		return Decision{
+			MatchedRule:              cp.MatchedRule,
+			CommandPolicyEnforcement: cp.Enforcement,
+			Warning:                  cp.Warning,
+			WouldDeny:                cp.WouldDeny,
+			WouldRequireApproval:     cp.WouldRequireApproval,
+		}, err
 	}
 
 	maxTTL := hp.MaxTTL
@@ -905,7 +915,15 @@ func (l *Local) SignIntent(ctx context.Context, in Intent) (*Issued, error) {
 	d, err := l.policy.resolve(in, l.defaultTTL, l.grants)
 	if in.DryRun {
 		if err != nil {
-			return &Issued{Decision: &DecisionInfo{Allowed: false, Reason: err.Error()}}, nil
+			// A command_policy denial returns a populated Decision alongside the
+			// error (MatchedRule/Enforcement/Warning); pre-policy denials (unknown
+			// host, pty/file-transfer not allowed, caller not authorised) return a
+			// zero Decision. Project whichever we got and attach the human-readable
+			// reason, so the dry-run decision carries the matched rule instead of
+			// only prose.
+			dec := decisionInfo(d, false)
+			dec.Reason = err.Error()
+			return &Issued{Decision: dec}, nil
 		}
 		return &Issued{Decision: decisionInfo(d, true)}, nil
 	}


### PR DESCRIPTION
Closes #119.

Makes the firewall **talk back to the agent** in a machine-readable way. A dry-run already returned an allow/deny decision as text; this adds it as **`structuredContent`** so an agent branches on it instead of scraping prose — the self-correction loop that reads well in a Claude Code session.

## What changed

- New `decision` object on the `ssh_execute` and k8s tool outputs, populated on the **dry-run** branch. It carries `allowed`, `reason`, `matched_rule`, `require_approval`, `enforcement`, `force_command`, `ttl_seconds`, `warning`, and a stable **`reason_code`**:
  `allowed` · `needs_approval` · `command_denied` · `allowlist_no_match` · `shell_parse_error` · `denied`.
- `reason_code` derives from the signer's `MatchedRule` prefixes (`policyset.go`: `deny:`, `allowlist:no-match`, `shell-parse:`), so it stays in sync with the firewall rather than parsing English.

## A real gap fixed in the signer

A dry-run **denial** was throwing away its own verdict: `PolicyTable.resolve` returned `Decision{}` on a command_policy error (discarding `resolveCommandPolicy`'s `MatchedRule`/`Enforcement`/`Warning`), and `SignIntent`'s dry-run branch built a bare `DecisionInfo` from the error string. So `matched_rule` was empty on exactly the case where you most want it. Now the verdict survives to the decision — `reason_code` is reliable, and the text `renderDecision` shows `rule:` on a denial too. Non-dry-run paths ignore the `Decision` on error, so this only enriches the dry-run/audit view (no behavior change to issuance).

## Tests

- `TestReasonCode`: every classification (allowed, needs_approval, command_denied, allowlist_no_match, shell_parse_error, denied fallback).
- `TestSSHExecuteDryRunStructuredDecision`: end-to-end over the in-memory MCP transport — asserts `structuredContent.decision.reason_code` for a denylist deny, an allowlist no-match, and allowed commands.
- Full suite green under `-race`; gofmt, vet, govulncheck clean.

## Docs

USAGE dry-run examples updated (denials now show `reason_code` + `rule`) plus a note documenting the structured `decision` and the `reason_code` enum.

Foundation for #118 (in-conversation approvals): both build on the MCP structured-output / spec-compliance surface.