### PR TITLE
feat(mcp): in-conversation approvals via elicitation + tool annotations (#118)

### DIFF
--- a/cmd/mcp-broker-http/main.go
+++ b/cmd/mcp-broker-http/main.go
@@ -115,7 +115,7 @@ func newMux(ctx context.Context, eng *broker.Engine, cfg *broker.Config) (*http.
 		return nil, err
 	}
 
-	srv := mcpserver.New(eng, httpCaller)
+	srv := mcpserver.New(eng, httpCaller, false)
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
 
 	resourceMetadataURL := strings.TrimRight(cfg.ResourceURL, "/") + prmPath

--- a/cmd/mcp-broker/main.go
+++ b/cmd/mcp-broker/main.go
@@ -57,7 +57,7 @@ func main() {
 	// Optional monitoring listener (/healthz, /metrics); lives with the process.
 	go monitor.Serve(context.Background(), cfg.MonitorListen, "mcp-broker")
 
-	srv := mcpserver.New(eng, stdioCaller)
+	srv := mcpserver.New(eng, stdioCaller, cfg.ApprovalViaElicitation)
 
 	log.Printf("mcp-broker (stdio) ready; %d hosts configured", len(eng.Servers()))
 	if err := srv.Run(context.Background(), &mcp.StdioTransport{}); err != nil {

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -566,10 +566,14 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 
 	local, hosts, callers, forwarders := s.snapshot()
 
-	// approved is honoured only from a trusted forwarder (control plane); a
-	// broker cannot self-approve.
+	// approved is honoured from a trusted forwarder (control plane), or from a
+	// caller the operator opted into self-approval (#118, in-conversation
+	// approvals: the same human requests and approves in the MCP client). Every
+	// other broker cannot self-approve. Checked on the mTLS CN, before
+	// resolveCaller, so on_behalf_of cannot borrow another CN's opt-in.
 	_, isForwarder := forwarders[caller]
-	effectiveApproved := req.Approved && isForwarder
+	selfApproves := callers.MaySelfApprove(caller)
+	effectiveApproved := req.Approved && (isForwarder || selfApproves)
 
 	// Resolve the effective caller identity: a trusted forwarder (control plane)
 	// may act on behalf of the original broker via on_behalf_of.
@@ -653,6 +657,14 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 		s.auditEmission(caller, req, hosts, 0, "denied", nil, err)
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
+	}
+	// #118: record a self-approval distinctly — four-eyes was deliberately waived
+	// for this opted-in caller (the same human requested and approved in-chat).
+	// Only when the command actually required approval.
+	if selfApproves && !isForwarder && req.Approved && issued.Decision != nil && issued.Decision.RequireApproval {
+		if aerr := s.audit.Append(audit.Entry{Caller: caller, Host: req.Host, Outcome: "self_approved"}); aerr != nil {
+			log.Printf("warning: error writing signer audit log: %v", aerr)
+		}
 	}
 	// Approve-and-learn: mint a TTL'd approval waiver after an approved sign that
 	// requested it. The waiver is scoped to the effective caller/end-user/elevation.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -404,6 +404,18 @@ An explicitly-empty `--groups ""` writes `allowed_groups: []` (deny every
 host); combined with the reserved name `_default` it applies to every CN not
 explicitly listed, turning the table default-deny.
 
+**In-conversation approval opt-in (`self_approve`, #118).** A caller entry may
+carry `"self_approve": true`, which lets that broker CN approve its **own**
+`require_approval` commands — the signer otherwise honours `approved` only from
+the control plane. It deliberately **waives four-eyes** for that CN and is meant
+for a single-operator stdio broker where the same human requests and approves
+in the MCP client. Pair it with `approval_via_elicitation: true` on that broker's
+config (the broker asks the human via elicitation; on approval it re-signs with
+`approved`). In **single-binary** mode the broker is the signer, so
+`approval_via_elicitation` alone enables it. Leave both off (the default) to keep
+four-eyes and approve through `broker-ctl` / the web UI / the Slack bridge. Each
+self-approval is audited `self_approved`.
+
 ### Reload
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -247,6 +247,17 @@ You can check ahead of time whether a command needs approval with
 `dry_run: true` (the response says "requires human approval"). This lets you
 warn the user that the action will pause for approval before you run it.
 
+**In-conversation approval (opt-in, #118).** When the operator enables it
+(`approval_via_elicitation` on the stdio broker + `self_approve` on that broker's
+caller entry in the signer), a `require_approval` command does not fail — the
+broker asks **you, the human, right in the MCP client** ("Approve running … on
+…?") via an elicitation the model cannot answer. Approve and the command runs;
+decline and it does not. This deliberately collapses four-eyes: it is for a
+single operator where the person driving the agent and the person approving are
+the same. Multi-operator deployments should keep four-eyes and approve through
+`broker-ctl` / the web UI / the Slack bridge instead. Each in-chat approval is
+audited (`self_approved`).
+
 **Approve-and-learn.** When a human approves, they may also *learn* the decision
 (`broker-ctl approval allow <id> --learn --ttl 2h`). After that, the **same command
 on that host, from the same broker/end-user identity, runs without prompting again**

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,6 +23,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `max_ttl_seconds` | `int` | MaxTTLSeconds caps the maximum requestable TTL. |
 | `hosts_refresh_seconds` | `int` | HostsRefreshSeconds: host-list reload interval from the signer. Remote mode only. Default: 300 (5 minutes). |
 | `revocation_poll_seconds` | `int` | RevocationPollSeconds: how often the broker polls the signer's freeze set and force-closes matching live sessions (kill switch, #117). Remote mode only; this is the kill latency for an established session. Default: 10. |
+| `approval_via_elicitation` | `bool` | ApprovalViaElicitation lets the stdio mcp-broker ask the human to approve a require_approval command IN THE MCP CLIENT (#118) instead of failing. It waives four-eyes (the requesting and approving human are the same), so the signer must also opt the broker's CN into self-approval (caller self_approve). Off by default; only meaningful for the interactive stdio frontend. |
 | `session_idle_seconds` | `int` | Persistent session idle-close and maximum lifetime. |
 | `session_max_seconds` | `int` | default 1800 |
 | `session_recording_dir` | `string` | SessionRecordingDir: directory for session recordings in ASCIIcast v2 format (.cast files). One file per session: <session_id>.cast. Empty = recording disabled. |

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -85,6 +85,14 @@ type Config struct {
 	// only; this is the kill latency for an established session. Default: 10.
 	RevocationPollSeconds int `json:"revocation_poll_seconds"`
 
+	// ApprovalViaElicitation lets the stdio mcp-broker ask the human to approve a
+	// require_approval command IN THE MCP CLIENT (#118) instead of failing. It
+	// waives four-eyes (the requesting and approving human are the same), so the
+	// signer must also opt the broker's CN into self-approval (caller
+	// self_approve). Off by default; only meaningful for the interactive stdio
+	// frontend.
+	ApprovalViaElicitation bool `json:"approval_via_elicitation,omitempty"`
+
 	// Persistent session idle-close and maximum lifetime.
 	SessionIdleSeconds int `json:"session_idle_seconds"` // default 300
 	SessionMaxSeconds  int `json:"session_max_seconds"`  // default 1800
@@ -230,6 +238,12 @@ type ExecOptions struct {
 	// connecting or executing. Allows the model to preview whether a command
 	// would be permitted.
 	DryRun bool
+
+	// Approved marks a require_approval command as approved (#118). The signer
+	// honours it only from a trusted forwarder (control plane) or a caller the
+	// operator opted into self-approval; the mcp-broker sets it after an
+	// in-conversation elicitation the human accepted.
+	Approved bool
 
 	// Stdin, when non-empty, is streamed to the remote command's standard
 	// input (file uploads). One-shot only; ignored for sessions and PTY.
@@ -994,6 +1008,7 @@ func (e *Engine) buildHops(ctx context.Context, c Caller, host string, ttl time.
 			in.SudoUser = opts.SudoUser
 			in.PTY = opts.PTY
 			in.FileTransfer = opts.FileTransfer
+			in.Approved = opts.Approved
 		}
 		issued, err := e.sgn.SignIntent(ctx, in)
 		if err != nil {
@@ -1070,6 +1085,7 @@ func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string,
 			in.Sudo = opts.Sudo
 			in.SudoUser = opts.SudoUser
 			in.PTY = opts.PTY
+			in.Approved = opts.Approved
 		}
 		issued, err := e.sgn.SignIntent(ctx, in)
 		if err != nil {
@@ -1099,15 +1115,27 @@ func (e *Engine) buildHopsWithPrefix(ctx context.Context, c Caller, host string,
 	return hops, finalSerial, elevPrefix, connectivitySig.String(), targetDecision, finalNotAfter, nil
 }
 
-// approvalError builds the error shown to a broker when a cert is not issued
-// because human approval is required. On the direct broker→signer path (no
-// control plane) approval cannot be orchestrated, so the user is informed.
+// ApprovalRequiredError signals that a certificate was withheld because the
+// command requires human approval (#118). The mcp-broker inspects it (errors.As)
+// to offer in-conversation elicitation approval; every other frontend surfaces
+// it as an ordinary denial.
+type ApprovalRequiredError struct {
+	Host string
+	Rule string
+}
+
+func (e *ApprovalRequiredError) Error() string {
+	return fmt.Sprintf("command on %q requires human approval (%s); approve it in-chat (if enabled), via the control plane, or with broker-ctl", e.Host, e.Rule)
+}
+
+// approvalError builds the typed error returned when a cert is not issued
+// because human approval is required.
 func approvalError(host string, d *signer.DecisionInfo) error {
 	rule := ""
 	if d != nil {
 		rule = d.MatchedRule
 	}
-	return fmt.Errorf("command on %q requires human approval (%s); use the control plane to approve it", host, rule)
+	return &ApprovalRequiredError{Host: host, Rule: rule}
 }
 
 // resolveChain returns the host chain in dial order (outermost bastion first,

--- a/internal/mcpserver/approval_test.go
+++ b/internal/mcpserver/approval_test.go
@@ -1,0 +1,152 @@
+package mcpserver
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/luisgf/infrabroker/internal/broker"
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// approvalSession registers the SSH tools over an in-memory transport against a
+// local-mode engine whose host web01 requires approval for `systemctl restart`.
+// elicit toggles in-conversation approval; elicitHandler (when non-nil) answers
+// the server's elicitation on the client side.
+func approvalSession(t *testing.T, elicit bool, elicitHandler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) *mcp.ClientSession {
+	t.Helper()
+	dir := t.TempDir()
+	_, caPriv, _ := ed25519.GenerateKey(rand.Reader)
+	blk, err := ssh.MarshalPrivateKey(caPriv, "ca-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPath := filepath.Join(dir, "ca")
+	if err := os.WriteFile(caPath, pem.EncodeToMemory(blk), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedPath := filepath.Join(dir, "audit.seed")
+	seed := make([]byte, 32)
+	_, _ = rand.Read(seed)
+	if err := os.WriteFile(seedPath, seed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng, err := broker.NewEngine(&broker.Config{
+		CAKey:         caPath,
+		AuditLog:      filepath.Join(dir, "audit.log"),
+		AuditKey:      seedPath,
+		SourceAddress: "127.0.0.1",
+		MaxTTLSeconds: 120,
+		Hosts: map[string]broker.HostConfig{
+			// Unreachable addr + short key: after approval the sign succeeds and
+			// the flow fails LATER (host key / connect), never on the approval gate.
+			"web01": {Addr: "127.0.0.1:1", User: "deploy", Principal: "host:web01", HostKey: "ssh-ed25519 AAAAC3Nz",
+				CommandPolicy: signer.CommandPolicy{RequireApproval: []string{"^systemctl restart"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { eng.Close() })
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	Register(srv, eng, func(context.Context) broker.Caller { return broker.Caller{ID: "test"} }, elicit)
+	ct, st := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(context.Background(), st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, &mcp.ClientOptions{ElicitationHandler: elicitHandler})
+	sess, err := client.Connect(context.Background(), ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	return sess
+}
+
+func callRestart(t *testing.T, sess *mcp.ClientSession) *mcp.CallToolResult {
+	t.Helper()
+	res, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "ssh_execute",
+		Arguments: map[string]any{"server": "web01", "command": "systemctl restart nginx"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	return res
+}
+
+// TestApprovalRequiredWithoutElicitation: with elicitation off, a require_approval
+// command is denied with an approval message (the existing behaviour).
+func TestApprovalRequiredWithoutElicitation(t *testing.T) {
+	t.Parallel()
+	sess := approvalSession(t, false, nil)
+	res := callRestart(t, sess)
+	if !res.IsError || !strings.Contains(k8sToolText(t, res), "requires human approval") {
+		t.Fatalf("want approval-required error; got IsError=%v text=%q", res.IsError, k8sToolText(t, res))
+	}
+}
+
+// TestApprovalAcceptedViaElicitation: with elicitation on and the human accepting,
+// the command passes the approval gate — proven by the error no longer being an
+// approval error (it fails later on the unreachable host instead).
+func TestApprovalAcceptedViaElicitation(t *testing.T) {
+	t.Parallel()
+	accept := func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"approve": true}}, nil
+	}
+	sess := approvalSession(t, true, accept)
+	res := callRestart(t, sess)
+	text := k8sToolText(t, res)
+	if strings.Contains(text, "requires human approval") {
+		t.Fatalf("approval should have been granted via elicitation; still blocked: %q", text)
+	}
+	// It got past approval; the unreachable host makes it fail afterwards.
+	if !res.IsError {
+		t.Logf("note: command returned success (unexpected without a real host), text=%q", text)
+	}
+}
+
+// TestApprovalDeclinedViaElicitation: the human declines, so the command does not run.
+func TestApprovalDeclinedViaElicitation(t *testing.T) {
+	t.Parallel()
+	decline := func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"approve": false}}, nil
+	}
+	sess := approvalSession(t, true, decline)
+	res := callRestart(t, sess)
+	if !res.IsError || !strings.Contains(k8sToolText(t, res), "declined") {
+		t.Fatalf("want declined error; got IsError=%v text=%q", res.IsError, k8sToolText(t, res))
+	}
+}
+
+func TestCallerTableMaySelfApprove(t *testing.T) {
+	t.Parallel()
+	tbl := signer.CallerTable{
+		"broker-1": {SelfApprove: true},
+		"broker-2": {AllowedGroups: []string{"web"}},
+	}
+	if !tbl.MaySelfApprove("broker-1") {
+		t.Error("broker-1 opted into self-approve")
+	}
+	if tbl.MaySelfApprove("broker-2") {
+		t.Error("broker-2 did not opt in")
+	}
+	if tbl.MaySelfApprove("unknown") {
+		t.Error("unknown caller must not self-approve without a _default opt-in")
+	}
+	// A _default opt-in applies to unlisted callers.
+	tbl["_default"] = signer.CallerPolicy{SelfApprove: true}
+	if !tbl.MaySelfApprove("unknown") {
+		t.Error("_default self-approve should apply to unlisted callers")
+	}
+}

--- a/internal/mcpserver/decision_test.go
+++ b/internal/mcpserver/decision_test.go
@@ -91,7 +91,7 @@ func sshDryRunSession(t *testing.T) *mcp.ClientSession {
 	t.Cleanup(func() { eng.Close() })
 
 	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
-	Register(srv, eng, func(context.Context) broker.Caller { return broker.Caller{ID: "test"} })
+	Register(srv, eng, func(context.Context) broker.Caller { return broker.Caller{ID: "test"} }, false)
 	ct, st := mcp.NewInMemoryTransports()
 	if _, err := srv.Connect(context.Background(), st, nil); err != nil {
 		t.Fatalf("server connect: %v", err)

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -9,14 +9,16 @@ import (
 
 // New builds a *mcp.Server with the broker tools registered. callerFn
 // determines the caller identity per request (fixed in stdio, derived from the
-// OIDC token in HTTP).
-func New(eng *broker.Engine, callerFn CallerFunc) *mcp.Server {
+// OIDC token in HTTP). elicitApprovals turns a require_approval command into an
+// in-conversation elicitation (#118) instead of a denial — the interactive
+// stdio frontend passes it; HTTP passes false.
+func New(eng *broker.Engine, callerFn CallerFunc, elicitApprovals bool) *mcp.Server {
 	srv := mcp.NewServer(&mcp.Implementation{
 		Name:    "infrabroker",
 		Title:   "infrabroker (SSH & Kubernetes, ephemeral credentials)",
 		Version: version.String(),
 	}, nil)
-	Register(srv, eng, callerFn)
+	Register(srv, eng, callerFn, elicitApprovals)
 	// Register the Kubernetes tool family only when the broker actually sees a
 	// cluster, so an SSH-only deployment does not offer k8s_* tools to the model.
 	if HasK8sClusters(eng) {

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -195,9 +196,10 @@ type sessionOpenOutput struct {
 
 // Register adds the 7 broker tools to the MCP server. callerFn provides the
 // caller identity for each invocation (audit and signer RBAC).
-func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
+func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitApprovals bool) {
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "ssh_execute",
+		Name:        "ssh_execute",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
 		Description: "Execute a single command on a Linux host via SSH with an ephemeral credential. " +
 			"Prefer this tool over ssh_session_open when you only need to run one command or independent commands. " +
 			"Returns stdout, stderr and exit_code. " +
@@ -206,17 +208,30 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			"sudo=true ONLY if allow_sudo=true; if allow_sudo=false, DO NOT retry with sudo and inform the user. " +
 			"pty=true ONLY if allow_pty=true and the command needs a TTY (with pty, stdout and stderr are merged). " +
 			"ttl_seconds is optional; omit to use the maximum allowed by the host policy.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in executeInput) (*mcp.CallToolResult, executeOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in executeInput) (*mcp.CallToolResult, executeOutput, error) {
 		if err := validateInput(map[string]string{"server": in.Server, "command": in.Command, "sudo_user": in.SudoUser}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, executeOutput{}, nil
+			return toolError(err), executeOutput{}, nil
 		}
 		opts := broker.ExecOptions{Sudo: in.Sudo, SudoUser: in.SudoUser, PTY: in.PTY, DryRun: in.DryRun}
 		res, err := eng.Execute(ctx, callerFn(ctx), in.Server, in.Command, in.TTLSeconds, opts)
 		if err != nil {
-			return &mcp.CallToolResult{
-				IsError: true,
-				Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
-			}, executeOutput{}, nil
+			// #118: if the command needs approval and elicitation is enabled, ask
+			// the human in the MCP client and retry with approval if accepted.
+			var appErr *broker.ApprovalRequiredError
+			if elicitApprovals && errors.As(err, &appErr) {
+				approved, elErr := elicitApproval(ctx, req.Session, in.Server, in.Command, appErr)
+				if elErr != nil {
+					return toolError(elErr), executeOutput{}, nil
+				}
+				if !approved {
+					return toolError(fmt.Errorf("approval declined: %q was not run on %q", in.Command, in.Server)), executeOutput{}, nil
+				}
+				opts.Approved = true
+				res, err = eng.Execute(ctx, callerFn(ctx), in.Server, in.Command, in.TTLSeconds, opts)
+			}
+			if err != nil {
+				return toolError(err), executeOutput{}, nil
+			}
 		}
 		// Dry-run: return the policy decision (as structuredContent too) instead
 		// of executed output, so the agent can branch on decision.reason_code.
@@ -229,7 +244,8 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "ssh_list_servers",
+		Name:        "ssh_list_servers",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		Description: "List the hosts accessible to the caller with their capabilities " +
 			"(hosts outside the user's RBAC groups are not listed). " +
 			"ALWAYS call before ssh_execute or ssh_session_open. " +
@@ -283,7 +299,8 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "ssh_session_exec",
+		Name:        "ssh_session_exec",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
 		Description: "Execute a command in a session opened with ssh_session_open. " +
 			"Returns stdout, stderr and exit_code. " +
 			"exit_code != 0 means remote command failure, NOT a tool error. " +
@@ -317,7 +334,8 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "ssh_put_file",
+		Name:        "ssh_put_file",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
 		Description: "Write a file on a Linux host via SSH with an ephemeral credential. " +
 			"Creates or OVERWRITES the destination file with the given content. " +
 			"Use content_base64=true for binary data (the content field is decoded before writing). " +
@@ -348,7 +366,8 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "ssh_get_file",
+		Name:        "ssh_get_file",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		Description: "Read a file from a Linux host via SSH with an ephemeral credential. " +
 			"Returns the content as text, or base64 (base64=true in the result) when the file is not valid UTF-8. " +
 			"REQUIRES allow_file_transfer=true on the host (see ssh_list_servers); if false DO NOT retry, the signer will reject it. " +
@@ -375,6 +394,46 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 		}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, out, nil
 	})
+}
+
+// boolPtr returns a pointer to b, for the optional *bool tool annotation fields.
+func boolPtr(b bool) *bool { return &b }
+
+// toolError wraps an error as an MCP tool-error result (not a transport error).
+func toolError(err error) *mcp.CallToolResult {
+	return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}
+}
+
+// elicitApproval asks the human in the MCP client to approve a require_approval
+// command (#118). The client renders the prompt to the human; the model cannot
+// answer it. Returns true only on an explicit approval (action "accept" with
+// approve=true); "decline"/"cancel" or approve=false return false.
+func elicitApproval(ctx context.Context, ss *mcp.ServerSession, server, command string, appErr *broker.ApprovalRequiredError) (bool, error) {
+	if ss == nil {
+		return false, fmt.Errorf("cannot request approval: no interactive client session")
+	}
+	res, err := ss.Elicit(ctx, &mcp.ElicitParams{
+		Mode:    "form",
+		Message: fmt.Sprintf("Approve running %q on %q? Host policy requires approval (%s).", command, server, appErr.Rule),
+		RequestedSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"approve": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to approve and run the command, false to deny.",
+				},
+			},
+			"required": []string{"approve"},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("requesting approval from the client: %w", err)
+	}
+	if res.Action != "accept" {
+		return false, nil
+	}
+	approve, _ := res.Content["approve"].(bool)
+	return approve, nil
 }
 
 // renderDecision formats the result of a dry-run (policy simulation).

--- a/internal/mcpserver/tools_k8s.go
+++ b/internal/mcpserver/tools_k8s.go
@@ -77,7 +77,8 @@ type k8sOutput struct {
 // unconditionally so the reference always documents the full surface.
 func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "k8s_list_clusters",
+		Name:        "k8s_list_clusters",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		Description: "List the Kubernetes clusters accessible to the caller (clusters outside the user's RBAC groups are not listed). " +
 			"ALWAYS call before the other k8s_* tools to learn the available cluster names.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ k8sListClustersInput) (*mcp.CallToolResult, k8sListClustersOutput, error) {
@@ -92,7 +93,8 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "k8s_get",
+		Name:        "k8s_get",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		Description: "Get one Kubernetes object as JSON. " +
 			"REQUIRES an allow rule for this verb/resource in the cluster policy; if the broker returns not allowed, DO NOT retry — inform the user. " +
 			"Use dry_run=true to preview whether the action is permitted.",
@@ -103,7 +105,8 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "k8s_list",
+		Name:        "k8s_list",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		Description: "List Kubernetes objects of a resource type as JSON, optionally filtered by label/field selectors. " +
 			"Omit namespace to list across all namespaces the ServiceAccount can read. " +
 			"REQUIRES an allow rule; use dry_run=true to preview.",
@@ -122,7 +125,8 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "k8s_logs",
+		Name:        "k8s_logs",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 		Description: "Read a pod's container logs (plain text). " +
 			"REQUIRES an allow rule for verb=logs; use dry_run=true to preview.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sLogsInput) (*mcp.CallToolResult, k8sOutput, error) {
@@ -139,7 +143,8 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "k8s_apply",
+		Name:        "k8s_apply",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
 		Description: "Create or update a Kubernetes object from a JSON manifest (server-side apply). " +
 			"REQUIRES an allow rule for verb=apply; the action may be approval-gated (a human must approve before it runs). " +
 			"Use dry_run=true to preview the BROKER policy decision. " +
@@ -154,7 +159,8 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name: "k8s_delete",
+		Name:        "k8s_delete",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
 		Description: "Delete one Kubernetes object. " +
 			"REQUIRES an allow rule for verb=delete; the action may be approval-gated. " +
 			"Use dry_run=true to preview the policy decision without deleting.",

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -783,6 +783,25 @@ func HasUnsafeTokenChar(s string) bool {
 // groups.
 type CallerPolicy struct {
 	AllowedGroups []string `json:"allowed_groups"`
+	// SelfApprove lets this caller CN approve its OWN require_approval commands
+	// (#118, in-conversation approvals via MCP elicitation). It deliberately
+	// waives four-eyes for that CN — the operator opts in a specific stdio broker
+	// where the requesting human and the approving human are the same person.
+	// Off by default; every other CN keeps "a broker cannot self-approve".
+	SelfApprove bool `json:"self_approve,omitempty"`
+}
+
+// MaySelfApprove reports whether the caller CN may approve its own
+// require_approval commands (#118). Used to widen the signer's Approved gate,
+// which otherwise honours `approved` only from trusted_forwarders.
+func (t CallerTable) MaySelfApprove(cn string) bool {
+	if cp, ok := t[cn]; ok {
+		return cp.SelfApprove
+	}
+	if cp, ok := t[DefaultCallerKey]; ok {
+		return cp.SelfApprove
+	}
+	return false
 }
 
 // DefaultCallerKey is the reserved CallerTable key whose policy applies to any

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -193,8 +193,8 @@ func genMCPTools() string {
 
 	ctx := context.Background()
 	srv := mcp.NewServer(&mcp.Implementation{Name: "infrabroker", Version: "docgen"}, nil)
-	mcpserver.Register(srv, nil, nil)    // handlers are not invoked during registration
-	mcpserver.RegisterK8s(srv, nil, nil) // document the k8s family unconditionally
+	mcpserver.Register(srv, nil, nil, false) // handlers are not invoked during registration
+	mcpserver.RegisterK8s(srv, nil, nil)     // document the k8s family unconditionally
 	st, ct := mcp.NewInMemoryTransports()
 	if _, err := srv.Connect(ctx, st, nil); err != nil {
 		fatal(fmt.Errorf("server connect: %w", err))


### PR DESCRIPTION
Closes #118.

The headline: a `require_approval` command no longer dead-ends for a solo operator. With opt-in enabled, the stdio mcp-broker **asks the human to approve right in the MCP client** (Claude Code) via elicitation — the model cannot answer it — and runs the command on accept. This is the differentiator NetBird's Agent Network structurally cannot match (no MCP surface). Builds on the structured-output work from #119.

Design decision (confirmed with maintainer): **per-caller opt-in**, four-eyes waived only for the CN the operator marks, off by default.

## How it works

1. **Signer** — `CallerPolicy.SelfApprove` (+ `CallerTable.MaySelfApprove`) lets an opted-in broker CN approve its **own** `require_approval` commands. `handleSign`'s `Approved` gate now honours a trusted forwarder **or** a self-approve caller; every other broker still cannot self-approve. A self-approval is audited distinctly (`self_approved`).
2. **Broker** — `ExecOptions.Approved` flows to the target `Intent` → `WireRequest`; `approvalError` is now a typed `*broker.ApprovalRequiredError` the frontend matches with `errors.As`.
3. **mcp-broker (stdio only)** — `approval_via_elicitation` config enables it. On an `ApprovalRequiredError` the `ssh_execute` handler calls `ServerSession.Elicit` ("Approve running … on …?") and retries with `Approved` on accept. HTTP frontend passes `false`.

**Two modes:** in **single-binary** mode the broker *is* the signer, so `approval_via_elicitation` alone enables it. In **remote** mode it also needs `self_approve` on that broker's caller entry — the signer-side authorization.

## Kept invariants

Signer stays authoritative (no cert without approval); force-command binds the exact approved command; the model cannot answer the elicitation (the client renders it to the human); four-eyes is preserved for every non-opted-in CN and every HTTP / control-plane deployment.

## Spec compliance (2026-07-28)

`ToolAnnotations` on all tools: `ReadOnlyHint` on `ssh_list_servers`, `ssh_get_file`, and the k8s read verbs; `DestructiveHint` on `ssh_execute`, `ssh_put_file`, `ssh_session_exec`, `k8s_apply`, `k8s_delete`. (Structured output / `decision` landed in #119.)

## Tests

- `TestCallerTableMaySelfApprove`: the opt-in lookup incl. `_default`.
- Over the in-memory MCP transport: **approval-required without elicitation** (denied with the approval message), **accepted-via-elicitation** (passes the gate — proven by the error no longer being an approval error), **declined-via-elicitation** (blocked).
- Full suite green under `-race`; gofmt, vet, govulncheck clean; reference docs regenerated.

Docs: USAGE in-conversation-approval section, OPERATIONS `self_approve` opt-in + `approval_via_elicitation`.