### PR TITLE
feat(bridge): multi-platform approval bridge, Slack adapter (#120)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,12 +60,21 @@ builds:
     ldflags:
       - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
 
-# One archive per OS/arch with all six binaries (4 assets, not 24): whoever
+  - id: approval-bridge
+    main: ./cmd/approval-bridge
+    binary: approval-bridge
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/luisgf/infrabroker/internal/version.Version={{ .Tag }}
+
+# One archive per OS/arch with all binaries (4 assets, not many): whoever
 # downloads mcp-broker almost always wants broker-ctl too, and the systemd
 # path keeps using the installer tarball.
 archives:
   - id: unified
-    ids: [signer, broker, broker-ctl, mcp-broker, mcp-broker-http, control-plane]
+    ids: [signer, broker, broker-ctl, mcp-broker, mcp-broker-http, control-plane, approval-bridge]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE

--- a/cmd/approval-bridge/main.go
+++ b/cmd/approval-bridge/main.go
@@ -1,0 +1,73 @@
+// Command approval-bridge presents infrabroker approval requests on a chat
+// platform (Slack, via Socket Mode) and relays Allow/Deny back to the control
+// plane (#120). It is outbound-only: it polls the control plane's mTLS approval
+// API and connects out to Slack, so nothing with approval authority becomes
+// internet-facing.
+//
+// It is a convenience, not a new trust root — the control plane still enforces
+// consumed-once and four-eyes. See docs/OPERATIONS.md and docs/THREAT_MODEL.md.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/auth"
+	"github.com/luisgf/infrabroker/internal/bridge"
+	"github.com/luisgf/infrabroker/internal/version"
+)
+
+func main() {
+	cpURL := flag.String("cp-url", envOr("BRIDGE_CP_URL", ""), "control plane host:port (mTLS)")
+	cert := flag.String("cert", envOr("BRIDGE_CERT", "./pki/approver.crt"), "approver client cert (CN must be in the control plane's approval.callers)")
+	key := flag.String("key", envOr("BRIDGE_KEY", "./pki/approver.key"), "approver client key")
+	ca := flag.String("ca", envOr("BRIDGE_CA", "./pki/mtls_ca.crt"), "mTLS CA for the control plane")
+	channel := flag.String("slack-channel", envOr("SLACK_CHANNEL", ""), "Slack channel id to post approvals to")
+	poll := flag.Duration("poll", 5*time.Second, "how often to poll the control plane for pending approvals")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		version.Print(false)
+		return
+	}
+	if *cpURL == "" {
+		log.Fatalf("--cp-url (or BRIDGE_CP_URL) is required")
+	}
+
+	// Secrets come from the environment, never flags: bot token (xoxb-) and the
+	// app-level token (xapp-) that enables Socket Mode.
+	botToken, appToken := os.Getenv("SLACK_BOT_TOKEN"), os.Getenv("SLACK_APP_TOKEN")
+
+	tlsCfg, err := auth.ClientTLSConfig(*cert, *key, *ca)
+	if err != nil {
+		log.Fatalf("approver mTLS: %v", err)
+	}
+	cp := bridge.NewHTTPControlPlane(*cpURL, tlsCfg)
+
+	adapter, err := bridge.NewSlackAdapter(botToken, appToken, *channel)
+	if err != nil {
+		log.Fatalf("slack: %v", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	log.Printf("approval-bridge: polling %s every %s, presenting on slack", *cpURL, *poll)
+	if err := bridge.New(cp, adapter, *poll).Run(ctx); err != nil && err != context.Canceled {
+		log.Fatalf("approval-bridge: %v", err)
+	}
+	log.Printf("approval-bridge: stopped")
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -417,14 +417,23 @@ repeated unapproved anomaly remains anomalous. **Caveat:** for trusted
 forwarders the `end_user` half is still broker-asserted, so behavior is
 detection, not containment — see THREAT_MODEL.md.
 
-**Extensible notification & approval (v1.8.0 + Phase 2 pending).**
+**Extensible notification & approval (v1.8.0 + `cmd/approval-bridge`, #120).**
 `TeamsNotifier` (`internal/control/teams.go`) implements the `Notifier`
 interface; `notifier: "teams"` sends an Adaptive Card v1.4 (Power Automate
-Workflow) or legacy MessageCard. Bidirectional approval from Teams (pressing
-"Approve" in the card) requires the Phase 2 `cmd/approval-bridge` (not
-implemented): Teams cannot present a client certificate, and Incoming Webhooks do
-not support `Action.Submit`/`HttpPOST`. `approval_url_template` is the
-forward-compatible hook for it.
+Workflow) or legacy MessageCard.
+
+Interactive **Allow/Deny inside the chat** is `cmd/approval-bridge` — a
+multi-platform bridge (`internal/bridge`) built around a `PlatformAdapter`
+interface. It is **outbound-only**: it polls the control plane's mTLS
+`GET /v1/approvals`, presents each pending request via the adapter, and relays
+the human's click to `POST /v1/approvals/{id}` with its **own approver CN** —
+so the control plane's consumed-once and four-eyes guards are unchanged. The
+**Slack** adapter uses Socket Mode (an outbound WebSocket, no inbound endpoint).
+A **Teams** in-card button would need a Bot Framework bot with a public inbound
+endpoint (Teams can't present a client cert and Incoming Webhooks don't support
+`Action.Submit`), which reintroduces the friction Socket Mode avoids, so it is a
+deferred adapter; meanwhile Teams approval already works today via the card's
+`approval_url_template` link to the web UI `/ui/approvals/{id}`.
 
 ### Multi-CA & Azure Key Vault (v1.11.0)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -551,6 +551,47 @@ the approval lifecycle: a pending request must be decided before that TTL elapse
 from creation, and an approved request must be collected by the broker before the
 same TTL elapses from the decision. Approved requests are consumed once.
 
+### Approve from chat: the approval bridge (Slack)
+
+`cmd/approval-bridge` posts pending approvals to a chat platform with **Allow /
+Deny buttons** and relays the decision back — approvers act without leaving chat
+or opening the web UI. It is **outbound-only** (polls the control plane's mTLS
+`GET /v1/approvals`, connects out to the platform), so nothing with approval
+authority becomes internet-facing, and it decides with its **own approver CN**,
+leaving the control plane's consumed-once and four-eyes guards unchanged.
+
+**Slack (Socket Mode):**
+
+1. Create a Slack app; enable **Socket Mode** and generate an **app-level token**
+   (`xapp-…`, scope `connections:write`).
+2. Add bot scope `chat:write`, install to the workspace, take the **bot token**
+   (`xoxb-…`), and invite the bot to the approvals channel.
+3. Give the bridge an **approver mTLS cert** whose CN is in the control plane's
+   `approval.callers` — a dedicated CN, distinct from any broker.
+4. Run it (tokens via env, never flags):
+
+```bash
+SLACK_BOT_TOKEN=xoxb-… SLACK_APP_TOKEN=xapp-… \
+  approval-bridge --cp-url 127.0.0.1:7443 \
+    --cert pki/approver.crt --key pki/approver.key --ca pki/mtls_ca.crt \
+    --slack-channel C0123456789
+```
+
+**Teams:** an in-card Allow/Deny button is a **deferred** adapter — Teams needs a
+Bot Framework bot with a *public inbound* endpoint (it can't present a client
+cert and Incoming Webhooks don't support `Action.Submit`), which reintroduces the
+friction Slack's outbound-only Socket Mode avoids. Meanwhile **Teams approval
+works today**: set `notifier: "teams"` and point `approval_url_template` at
+`https://<control-plane>/ui/approvals/{id}` — the card's "View request" link
+lands the approver on the mTLS web UI to decide.
+
+> **Trust note.** The bridge decides with one approver CN, so "who may approve"
+> moves partly to **chat channel membership**, and approver attribution in the
+> audit is **bridge-asserted** (bridge CN + platform user id) — see
+> [THREAT_MODEL](THREAT_MODEL.md). For a single operator, the in-conversation
+> elicitation approval (above) avoids the bridge; for per-human attribution,
+> approve via `broker-ctl` or the web UI (per-human mTLS certs).
+
 ### Action budgets: rate limits + behavior guardrails
 
 Beyond *what* an agent may run (the command policy) and *whether* a human must

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -94,6 +94,18 @@ without it. A compromised broker or control plane cannot forge certificates.
   forwarder. A direct broker cannot self-approve, and the originator of a
   request cannot decide its own approval (four-eyes, even if its CN is an
   approver). Each approval is consumed once.
+- **Approval-bridge trust (`cmd/approval-bridge`, #120).** The chat bridge
+  decides with a **single approver CN**, so its residual dilutions are, by
+  design: (1) *who may approve* moves partly from the mTLS `approval.callers`
+  allowlist to **chat channel membership** run by an external SaaS — anyone who
+  can click a button in that channel can approve; (2) approver attribution is
+  **bridge-asserted** — the audit records the bridge CN plus the platform user
+  id as metadata, not a cryptographically verified approver; (3) the CN-level
+  four-eyes guard still holds (the bridge CN differs from any broker CN), but
+  per-human approver certs collapse into that one CN. The control plane's
+  consumed-once and four-eyes guards are unchanged. For a single operator,
+  #118's in-chat elicitation avoids the bridge entirely; for stronger
+  attribution, approve via `broker-ctl` / the web UI (per-human mTLS certs).
 - **Audit log** is append-only, SHA-256 hash-chained, and Ed25519-signed per
   entry; any deletion/reordering/modification is detectable by replaying the
   chain. The chain stays continuous **across log rotation** — each rotated-to

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/slack-go/slack v0.27.0
 	golang.org/x/crypto v0.53.0
 	modernc.org/sqlite v1.53.0
 	mvdan.cc/sh/v3 v3.13.1
@@ -22,6 +23,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -34,6 +36,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
@@ -62,6 +66,8 @@ github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/slack-go/slack v0.27.0 h1:VWOpUzOK6UAPCCQlFxl79jhv8a/b+GOSJMnWziDJ8B8=
+github.com/slack-go/slack v0.27.0/go.mod h1:UEe+jmo9WLlwHB04qsOrTDvqM7Aa4rQL3O5wF3n0hx4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -1,0 +1,116 @@
+// Package bridge turns a chat platform into an approval surface for the control
+// plane (#120). It polls the control plane's GET /v1/approvals for pending
+// requests, presents each to humans through a PlatformAdapter, and relays their
+// Allow/Deny back to POST /v1/approvals/{id} with the bridge's own mTLS approver
+// identity. Everything is outbound (poll the control plane, connect out to the
+// platform), so nothing with approval authority becomes internet-facing.
+//
+// The bridge is a convenience, not a new trust root: the control plane still
+// enforces consumed-once and the four-eyes guard (a request's originator CN
+// cannot decide it). Approver attribution through the bridge is bridge-asserted
+// — see docs/THREAT_MODEL.md.
+package bridge
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/control"
+)
+
+// Decision is a human's Allow/Deny for a pending approval, from a platform.
+type Decision struct {
+	ID      string // approval request id
+	Approve bool
+	By      string // platform user id, recorded as attribution metadata only
+}
+
+// PlatformAdapter presents approval requests on a chat platform and streams the
+// humans' decisions. Implementations are outbound-only (e.g. Slack Socket Mode).
+type PlatformAdapter interface {
+	// Post presents a pending approval to the approvers.
+	Post(ctx context.Context, a control.Approval) error
+	// Decisions streams decisions as humans act; closed when the adapter stops.
+	Decisions() <-chan Decision
+	// Name identifies the platform (for logs).
+	Name() string
+}
+
+// ControlPlane is the slice of the control-plane approval API the bridge needs.
+type ControlPlane interface {
+	// List returns the currently pending approval requests.
+	List(ctx context.Context) ([]control.Approval, error)
+	// Decide resolves a request as approved or denied.
+	Decide(ctx context.Context, id string, approve bool) error
+}
+
+// Bridge relays between a control plane and a platform adapter.
+type Bridge struct {
+	cp       ControlPlane
+	adapter  PlatformAdapter
+	interval time.Duration
+	posted   map[string]bool // approval ids already presented (dedupe)
+}
+
+// New builds a bridge polling every interval (default 5s if <= 0).
+func New(cp ControlPlane, adapter PlatformAdapter, interval time.Duration) *Bridge {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	return &Bridge{cp: cp, adapter: adapter, interval: interval, posted: map[string]bool{}}
+}
+
+// Run polls for pending approvals and relays decisions until ctx is cancelled.
+// It is single-goroutine: poll ticks and adapter decisions are handled in the
+// same select, so the dedupe map needs no lock.
+func (b *Bridge) Run(ctx context.Context) error {
+	t := time.NewTicker(b.interval)
+	defer t.Stop()
+	b.poll(ctx) // present immediately rather than waiting a full interval
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			b.poll(ctx)
+		case d, ok := <-b.adapter.Decisions():
+			if !ok {
+				return nil // adapter stopped
+			}
+			if err := b.cp.Decide(ctx, d.ID, d.Approve); err != nil {
+				log.Printf("approval-bridge: deciding %s: %v", d.ID, err)
+				continue
+			}
+			delete(b.posted, d.ID)
+			log.Printf("approval-bridge: %s decided approve=%v (by %s via %s)", d.ID, d.Approve, d.By, b.adapter.Name())
+		}
+	}
+}
+
+// poll presents pending approvals not yet seen and forgets ids that are no
+// longer pending (decided or expired elsewhere), keeping the dedupe map bounded.
+func (b *Bridge) poll(ctx context.Context) {
+	pending, err := b.cp.List(ctx)
+	if err != nil {
+		log.Printf("approval-bridge: listing approvals: %v", err)
+		return
+	}
+	live := make(map[string]bool, len(pending))
+	for _, a := range pending {
+		live[a.ID] = true
+		if b.posted[a.ID] {
+			continue
+		}
+		if err := b.adapter.Post(ctx, a); err != nil {
+			log.Printf("approval-bridge: presenting %s: %v", a.ID, err)
+			continue // retry on the next tick
+		}
+		b.posted[a.ID] = true
+	}
+	for id := range b.posted {
+		if !live[id] {
+			delete(b.posted, id)
+		}
+	}
+}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -1,0 +1,132 @@
+package bridge
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/control"
+)
+
+// fakeCP is a scriptable ControlPlane. List returns whatever pending is set to;
+// Decide records calls and signals on decided.
+type fakeCP struct {
+	mu      sync.Mutex
+	pending []control.Approval
+	decided chan [2]any // {id, approve}
+}
+
+func (f *fakeCP) setPending(a []control.Approval) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending = a
+}
+
+func (f *fakeCP) List(context.Context) ([]control.Approval, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]control.Approval, len(f.pending))
+	copy(out, f.pending)
+	return out, nil
+}
+
+func (f *fakeCP) Decide(_ context.Context, id string, approve bool) error {
+	f.decided <- [2]any{id, approve}
+	// A decided request is no longer pending.
+	f.mu.Lock()
+	kept := f.pending[:0]
+	for _, a := range f.pending {
+		if a.ID != id {
+			kept = append(kept, a)
+		}
+	}
+	f.pending = kept
+	f.mu.Unlock()
+	return nil
+}
+
+// fakeAdapter records posts and lets the test inject decisions.
+type fakeAdapter struct {
+	posted    chan string
+	decisions chan Decision
+}
+
+func (a *fakeAdapter) Post(_ context.Context, ap control.Approval) error {
+	a.posted <- ap.ID
+	return nil
+}
+func (a *fakeAdapter) Decisions() <-chan Decision { return a.decisions }
+func (a *fakeAdapter) Name() string               { return "fake" }
+
+func TestBridgePresentsAndRelays(t *testing.T) {
+	t.Parallel()
+	cp := &fakeCP{decided: make(chan [2]any, 1)}
+	ad := &fakeAdapter{posted: make(chan string, 4), decisions: make(chan Decision, 1)}
+	cp.setPending([]control.Approval{{ID: "a1", Host: "web01", Command: "systemctl restart nginx"}})
+
+	b := New(cp, ad, 20*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = b.Run(ctx); close(done) }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	// The pending request is presented on the platform.
+	select {
+	case id := <-ad.posted:
+		if id != "a1" {
+			t.Fatalf("posted %q, want a1", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not present the pending approval")
+	}
+
+	// A human approves on the platform; the bridge relays it to the control plane.
+	ad.decisions <- Decision{ID: "a1", Approve: true, By: "U123"}
+	select {
+	case got := <-cp.decided:
+		if got[0] != "a1" || got[1] != true {
+			t.Fatalf("Decide got %v, want [a1 true]", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not relay the decision to the control plane")
+	}
+}
+
+// TestBridgeDedupesAndForgets: a still-pending request is presented once (not
+// re-posted every poll), and once it is gone the id is forgotten.
+func TestBridgeDedupesAndForgets(t *testing.T) {
+	t.Parallel()
+	cp := &fakeCP{decided: make(chan [2]any, 1)}
+	ad := &fakeAdapter{posted: make(chan string, 8), decisions: make(chan Decision, 1)}
+	cp.setPending([]control.Approval{{ID: "a1"}})
+
+	b := New(cp, ad, 10*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = b.Run(ctx); close(done) }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	<-ad.posted // first presentation
+	// Let several polls elapse; a still-pending request must NOT be re-posted.
+	time.Sleep(60 * time.Millisecond)
+	select {
+	case id := <-ad.posted:
+		t.Fatalf("re-posted %q; a pending request must be presented once", id)
+	default:
+	}
+
+	// It disappears (decided elsewhere) then reappears with the same id: because
+	// the bridge forgot it, it is presented again.
+	cp.setPending(nil)
+	time.Sleep(30 * time.Millisecond)
+	cp.setPending([]control.Approval{{ID: "a1"}})
+	select {
+	case id := <-ad.posted:
+		if id != "a1" {
+			t.Fatalf("re-presented %q, want a1", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a reappeared request should be presented again after being forgotten")
+	}
+}

--- a/internal/bridge/cpclient.go
+++ b/internal/bridge/cpclient.go
@@ -1,0 +1,81 @@
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/control"
+)
+
+// HTTPControlPlane is the ControlPlane backed by the control plane's mTLS
+// approval API. The client certificate CN must be an approver (in the control
+// plane's approval.callers).
+type HTTPControlPlane struct {
+	base   string
+	client *http.Client
+}
+
+// NewHTTPControlPlane dials host ("host:port") over mTLS with tlsCfg.
+func NewHTTPControlPlane(host string, tlsCfg *tls.Config) *HTTPControlPlane {
+	return newControlPlane("https://"+host, &http.Client{Timeout: 15 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsCfg}})
+}
+
+// newControlPlane is the transport-agnostic constructor (used by tests).
+func newControlPlane(base string, client *http.Client) *HTTPControlPlane {
+	return &HTTPControlPlane{base: base, client: client}
+}
+
+// List calls GET /v1/approvals and returns the pending requests.
+func (c *HTTPControlPlane) List(ctx context.Context) ([]control.Approval, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/v1/approvals", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET /v1/approvals: %w", err)
+	}
+	defer resp.Body.Close()
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("control plane returned %d listing approvals: %s", resp.StatusCode, bytes.TrimSpace(rb))
+	}
+	var out []control.Approval
+	if err := json.Unmarshal(rb, &out); err != nil {
+		return nil, fmt.Errorf("decoding approvals: %w", err)
+	}
+	return out, nil
+}
+
+// Decide calls POST /v1/approvals/{id} to approve or deny. The control plane
+// derives the approver from the mTLS CN and enforces the four-eyes guard, so a
+// decision on the bridge's own originated request (there are none) would be
+// rejected there, not here.
+func (c *HTTPControlPlane) Decide(ctx context.Context, id string, approve bool) error {
+	payload, _ := json.Marshal(map[string]any{"approve": approve})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v1/approvals/"+url.PathEscape(id), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST /v1/approvals/%s: %w", id, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("control plane returned %d deciding %s: %s", resp.StatusCode, id, bytes.TrimSpace(rb))
+	}
+	return nil
+}

--- a/internal/bridge/cpclient_test.go
+++ b/internal/bridge/cpclient_test.go
@@ -1,0 +1,72 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPControlPlaneListAndDecide(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotDecidePath  string
+		gotContentType string
+		gotBody        map[string]any
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/approvals":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "a1", "host": "web01", "command": "systemctl restart nginx"},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/approvals/a1":
+			gotDecidePath = r.URL.Path
+			gotContentType = r.Header.Get("Content-Type")
+			rb, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(rb, &gotBody)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cp := newControlPlane(srv.URL, srv.Client())
+
+	pending, err := cp.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != "a1" || pending[0].Host != "web01" {
+		t.Fatalf("List = %+v, want one a1/web01", pending)
+	}
+
+	if err := cp.Decide(context.Background(), "a1", true); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if gotDecidePath != "/v1/approvals/a1" {
+		t.Errorf("Decide path = %q", gotDecidePath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Decide Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotBody["approve"] != true {
+		t.Errorf("Decide body = %v, want approve:true", gotBody)
+	}
+}
+
+func TestHTTPControlPlaneDecideSurfacesError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "self-approval not allowed", http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	cp := newControlPlane(srv.URL, srv.Client())
+	if err := cp.Decide(context.Background(), "a1", true); err == nil {
+		t.Fatal("Decide must return an error on a non-200 from the control plane")
+	}
+}

--- a/internal/bridge/slack.go
+++ b/internal/bridge/slack.go
@@ -1,0 +1,109 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
+
+	"github.com/luisgf/infrabroker/internal/control"
+)
+
+// Slack button action ids; the button value carries the approval request id.
+const (
+	actionApprove = "infrabroker_approve"
+	actionDeny    = "infrabroker_deny"
+)
+
+// SlackAdapter presents approvals in a Slack channel and receives Allow/Deny
+// button clicks over Socket Mode — an outbound WebSocket, so the bridge needs no
+// inbound endpoint, no public URL, and no signing-secret verification path.
+type SlackAdapter struct {
+	api       *slack.Client
+	sm        *socketmode.Client
+	channel   string
+	decisions chan Decision
+}
+
+// NewSlackAdapter connects with a bot token (xoxb-) and an app-level token
+// (xapp-, for Socket Mode) and posts to channel. It starts the Socket Mode loop.
+func NewSlackAdapter(botToken, appToken, channel string) (*SlackAdapter, error) {
+	if botToken == "" || appToken == "" || channel == "" {
+		return nil, fmt.Errorf("slack adapter needs a bot token, an app-level token, and a channel")
+	}
+	api := slack.New(botToken, slack.OptionAppLevelToken(appToken))
+	a := &SlackAdapter{
+		api:       api,
+		sm:        socketmode.New(api),
+		channel:   channel,
+		decisions: make(chan Decision, 32),
+	}
+	go a.listen()
+	return a, nil
+}
+
+// Name identifies the platform.
+func (a *SlackAdapter) Name() string { return "slack" }
+
+// Decisions streams button clicks as decisions.
+func (a *SlackAdapter) Decisions() <-chan Decision { return a.decisions }
+
+// Post renders the approval as a Block Kit message with Approve / Deny buttons
+// whose value carries the request id.
+func (a *SlackAdapter) Post(ctx context.Context, ap control.Approval) error {
+	summary := fmt.Sprintf("*Approval requested* — run `%s` on `%s`", ap.Command, ap.Host)
+	detail := fmt.Sprintf("caller `%s`", ap.Caller)
+	if ap.EndUser != "" {
+		detail += fmt.Sprintf(" · user `%s`", ap.EndUser)
+	}
+	if ap.Sudo {
+		detail += " · sudo"
+	}
+	if ap.Rule != "" {
+		detail += fmt.Sprintf(" · rule `%s`", ap.Rule)
+	}
+	section := slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, summary+"\n"+detail, false, false), nil, nil)
+	approve := slack.NewButtonBlockElement(actionApprove, ap.ID, slack.NewTextBlockObject(slack.PlainTextType, "Approve", false, false))
+	approve.Style = slack.StylePrimary
+	deny := slack.NewButtonBlockElement(actionDeny, ap.ID, slack.NewTextBlockObject(slack.PlainTextType, "Deny", false, false))
+	deny.Style = slack.StyleDanger
+	actions := slack.NewActionBlock("infrabroker_"+ap.ID, approve, deny)
+	_, _, err := a.api.PostMessageContext(ctx, a.channel, slack.MsgOptionBlocks(section, actions))
+	return err
+}
+
+// listen runs the Socket Mode loop, turning button clicks into Decisions. The
+// interaction is acknowledged immediately (Slack requires an ack within 3s); the
+// bridge relays the decision to the control plane asynchronously.
+func (a *SlackAdapter) listen() {
+	go func() {
+		if err := a.sm.Run(); err != nil {
+			log.Printf("approval-bridge: slack socket mode stopped: %v", err)
+		}
+	}()
+	for evt := range a.sm.Events {
+		if evt.Type != socketmode.EventTypeInteractive {
+			continue
+		}
+		cb, ok := evt.Data.(slack.InteractionCallback)
+		if !ok {
+			continue
+		}
+		if evt.Request != nil {
+			_ = a.sm.Ack(*evt.Request)
+		}
+		if cb.Type != slack.InteractionTypeBlockActions {
+			continue
+		}
+		for _, action := range cb.ActionCallback.BlockActions {
+			switch action.ActionID {
+			case actionApprove:
+				a.decisions <- Decision{ID: action.Value, Approve: true, By: cb.User.ID}
+			case actionDeny:
+				a.decisions <- Decision{ID: action.Value, Approve: false, By: cb.User.ID}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #120.

`cmd/approval-bridge` presents pending approvals in chat with **Allow / Deny buttons** and relays the decision to the control plane — approvers act without leaving chat or opening the web UI. Re-scoped (with the maintainer) from Slack-only to **multi-platform**.

## Design

- **`internal/bridge`** — a platform-agnostic core around a `PlatformAdapter` interface. **Outbound-only**: it polls the control plane's mTLS `GET /v1/approvals`, presents each pending request, and relays the human's click to `POST /v1/approvals/{id}` with its **own approver CN** — so the control plane's **consumed-once and four-eyes guards are unchanged**. Dedupes (a pending request is presented once) and forgets ids that stop being pending.
- **Slack adapter** (`slack-go`, isolated to the bridge binary) — **Socket Mode**, an outbound WebSocket, so no inbound endpoint / public URL / signing-secret path. Block Kit card with Approve/Deny; the button value carries the request id.

## Teams

The in-card Allow/Deny button is a **deferred adapter**: Teams needs a Bot Framework bot with a *public inbound* endpoint (it can't present a client cert and Incoming Webhooks don't support `Action.Submit`), which reintroduces exactly the friction Slack's outbound Socket Mode avoids. **Teams approval works today** via the existing card's `approval_url_template` link to the web UI `/ui/approvals/{id}` — documented as the Teams path.

## Threat-model additions (in the diff)

The bridge decides with a single approver CN, so, by design: *who may approve* moves partly to **chat channel membership** (external SaaS); approver attribution is **bridge-asserted** (bridge CN + platform user id, not a verified approver cert); the CN-level four-eyes guard holds but per-human certs collapse into one CN. For a single operator, #118's in-chat elicitation avoids the bridge; for per-human attribution, approve via `broker-ctl` / the web UI.

## Tests & verification

- `-race`: the relay/dedupe core (fake control plane + adapter) and the HTTP control-plane client (`List`/`Decide` contract — right path, `application/json`, `{approve}` body — and error surfacing) over `httptest`.
- The Slack adapter **compiles against slack-go v0.27** (API-correct) but the live Socket Mode round-trip is **verified manually** (needs a Slack app + workspace) — called out honestly.
- `slack-go` adds **no cgo** (static multi-arch builds intact); **govulncheck clean**; full suite green (23 packages); goreleaser ships the new binary.

Docs: OPERATIONS setup + Teams path, ARCHITECTURE (bridge now exists), THREAT_MODEL.