### PR TITLE
feat(oauth): per-agent IdP identity via client_credentials — tests, lab, docs (#121)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -847,6 +847,50 @@ it must be revoked before expiry.
    rather than silently ignored, so a typo cannot quietly leave a setting open.
    `_*` comment keys and the reserved `_default` group are still accepted.
 
+### Per-agent identity: OAuth2 client_credentials
+
+The HTTP frontend authenticates every request with an OIDC bearer token and keys
+audit + per-user RBAC on the token's identity. Give **each AI agent its own IdP
+identity** the way a human gets one — an OAuth2 **client_credentials service
+account**, one client per agent. Its actions are then attributed to it, its RBAC
+groups gate which hosts it reaches, and revoking access is disabling the client
+in the IdP. No infrabroker change is needed — the verifier is claim-agnostic (the
+`ClientCredentials` cases in `internal/oauth/verifier_test.go`); it is IdP
+configuration. Three non-obvious bits (Keycloak; reproducible lab
+`lab/run_oauth_lab.sh`):
+
+- **`"user_claim": "azp"`** in the frontend `oauth` block. In a Keycloak
+  client_credentials token `sub` is the service-account **UUID**; `azp` carries
+  the client id — the stable, human-meaningful identity you want in the audit log
+  and RBAC.
+- **An audience mapper** on the client emitting your `audience` (e.g.
+  `infrabroker`). Keycloak's default `aud` is `account`, which the verifier
+  rejects.
+- **A group-membership mapper** on the service account so the token carries the
+  `groups` claim. With `groups_claim` configured the verifier is fail-closed: a
+  token without it is rejected (it would otherwise bypass per-user RBAC).
+
+```json
+"oauth": {
+  "issuer":       "https://keycloak.example/realms/infrabroker",
+  "audience":     "infrabroker",
+  "user_claim":   "azp",
+  "groups_claim": "groups"
+}
+```
+
+The agent obtains a token with the standard grant and sends it as the MCP bearer;
+keep the client secret in the agent's secret store, never in prompts or tool logs:
+
+```bash
+curl -s https://keycloak.example/realms/infrabroker/protocol/openid-connect/token \
+  -d grant_type=client_credentials -d client_id=agent-ci-runner -d client_secret=<secret>
+```
+
+This is the layer network tools cede: a mesh or LLM gateway can give an agent an
+identity to *reach* endpoints or meter its spend; here that identity is bound to
+**what the agent may execute**, and to every signed audit line.
+
 ---
 
 ## 7. Monitoring

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -123,6 +123,74 @@ func TestVerifyValid(t *testing.T) {
 	}
 }
 
+// TestVerifyClientCredentialsIdentity is the "one identity per agent" case
+// (#121): a Keycloak client_credentials token puts the service-account UUID in
+// `sub` and the client id in `azp`. With user_claim=azp the agent's identity is
+// the stable, human-meaningful client id — not the opaque UUID — so audit and
+// per-agent RBAC key on the agent, exactly like a human end user.
+func TestVerifyClientCredentialsIdentity(t *testing.T) {
+	ts := newOIDCTestServer(t)
+	v := ts.newVerifier(t, Config{Audience: "infrabroker", GroupsClaim: "groups", UserClaim: "azp"})
+
+	claims := baseClaims(ts)
+	claims["sub"] = "b1f2c3d4-5678-90ab-cdef-service-account" // Keycloak: sub = SA UUID
+	claims["azp"] = "agent-ci-runner"                         // the client id
+	claims["groups"] = []string{"ci"}
+	claims["scope"] = "mcp:tools"
+	tok := ts.sign(t, claims)
+
+	ti, err := v.Verify(context.Background(), tok, nil)
+	if err != nil {
+		t.Fatalf("client_credentials token rejected: %v", err)
+	}
+	if ti.UserID != "agent-ci-runner" {
+		t.Errorf("UserID = %q, want the client id agent-ci-runner (not the sub UUID)", ti.UserID)
+	}
+	g, _ := ti.Extra[ExtraGroupsKey].([]string)
+	if len(g) != 1 || g[0] != "ci" {
+		t.Errorf("groups = %v, want [ci]", g)
+	}
+}
+
+// TestVerifyClientCredentialsDefaultSubIsUUID shows why user_claim=azp is
+// needed: with the default (sub) the identity is the opaque service-account
+// UUID, useless for audit/RBAC.
+func TestVerifyClientCredentialsDefaultSubIsUUID(t *testing.T) {
+	ts := newOIDCTestServer(t)
+	v := ts.newVerifier(t, Config{Audience: "infrabroker", GroupsClaim: "groups"}) // default user_claim=sub
+
+	claims := baseClaims(ts)
+	claims["sub"] = "b1f2c3d4-5678-90ab-cdef-service-account"
+	claims["azp"] = "agent-ci-runner"
+	claims["groups"] = []string{"ci"}
+	tok := ts.sign(t, claims)
+
+	ti, err := v.Verify(context.Background(), tok, nil)
+	if err != nil {
+		t.Fatalf("token rejected: %v", err)
+	}
+	if ti.UserID != "b1f2c3d4-5678-90ab-cdef-service-account" {
+		t.Errorf("UserID = %q, want the sub UUID — motivating user_claim=azp", ti.UserID)
+	}
+}
+
+// TestVerifyClientCredentialsMissingGroupsRejected is why the lab configures a
+// group-membership mapper on the service account: without it the token has no
+// groups claim, per-user RBAC is fail-closed, and the token is rejected.
+func TestVerifyClientCredentialsMissingGroupsRejected(t *testing.T) {
+	ts := newOIDCTestServer(t)
+	v := ts.newVerifier(t, Config{Audience: "infrabroker", GroupsClaim: "groups", UserClaim: "azp"})
+
+	claims := baseClaims(ts)
+	claims["azp"] = "agent-ci-runner"
+	// No "groups" claim (no group-membership mapper on the service account).
+	tok := ts.sign(t, claims)
+
+	if _, err := v.Verify(context.Background(), tok, nil); err == nil {
+		t.Fatal("a client_credentials token without the groups mapper must be rejected (fail-closed)")
+	}
+}
+
 func TestVerifyWrongAudience(t *testing.T) {
 	ts := newOIDCTestServer(t)
 	v := ts.newVerifier(t, Config{Audience: "infrabroker"})

--- a/lab/run_oauth_lab.sh
+++ b/lab/run_oauth_lab.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Lab e2e de identidad IdP por agente (#121): Keycloak + OAuth2 client_credentials.
+#
+# Levanta Keycloak en Docker, crea un realm con un cliente de service account
+# (client_credentials) y los TRES mappers no obvios, obtiene un access token y
+# demuestra que el token queda listo para el frontend HTTP de infrabroker:
+#
+#   1. sub = UUID del service account, azp = client id  → por eso user_claim=azp
+#      (la identidad de auditoría/RBAC es el id del cliente, no el UUID opaco).
+#   2. aud = "infrabroker" (audience mapper). Sin él Keycloak emite aud="account"
+#      y el verifier lo rechaza.
+#   3. groups presente (group-membership mapper sobre el service account). Sin él
+#      el groups_claim del verifier es fail-closed y rechaza el token.
+#
+# Requisitos: docker, curl, jq. No necesita compilar infrabroker: el verifier ya
+# es claim-agnostic (ver internal/oauth/verifier_test.go, casos ClientCredentials).
+# Al final imprime el bloque "oauth" que pondrías en la config de mcp-broker-http.
+set -euo pipefail
+
+KC_IMAGE="quay.io/keycloak/keycloak:26.0"
+KC_NAME="infrabroker-oauth-lab"
+KC_PORT=8080
+KC_URL="http://localhost:${KC_PORT}"
+REALM="infrabroker"
+CLIENT="agent-ci-runner"        # the client id → the agent's identity (via azp)
+AUDIENCE="infrabroker"          # this resource server (the verifier's expected aud)
+GROUP="ci"                      # RBAC group the agent belongs to
+ADMIN=admin
+ADMIN_PW=admin
+KCADM="/opt/keycloak/bin/kcadm.sh"
+
+for bin in docker curl jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "falta '$bin'"; exit 1; }
+done
+
+cleanup() { docker rm -f "$KC_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== 1. Keycloak ($KC_IMAGE) en :$KC_PORT =="
+docker rm -f "$KC_NAME" >/dev/null 2>&1 || true
+docker run -d --name "$KC_NAME" -p "${KC_PORT}:8080" \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME="$ADMIN" -e KC_BOOTSTRAP_ADMIN_PASSWORD="$ADMIN_PW" \
+  "$KC_IMAGE" start-dev >/dev/null
+
+echo -n "   esperando a Keycloak"
+for _ in $(seq 1 60); do
+  if curl -fsS "${KC_URL}/realms/master/.well-known/openid-configuration" >/dev/null 2>&1; then
+    echo " listo"; break
+  fi
+  echo -n "."; sleep 2
+done
+curl -fsS "${KC_URL}/realms/master/.well-known/openid-configuration" >/dev/null 2>&1 || { echo " Keycloak no arrancó"; exit 1; }
+
+kc() { docker exec "$KC_NAME" "$KCADM" "$@"; }
+
+echo "== 2. realm + cliente service-account + 3 mappers =="
+kc config credentials --server http://localhost:8080 --realm master --user "$ADMIN" --password "$ADMIN_PW" >/dev/null
+kc create realms -s realm="$REALM" -s enabled=true >/dev/null
+
+# Confidential client with service accounts enabled = the OAuth2 client_credentials grant.
+kc create clients -r "$REALM" \
+  -s clientId="$CLIENT" -s enabled=true -s publicClient=false \
+  -s standardFlowEnabled=false -s directAccessGrantsEnabled=false \
+  -s serviceAccountsEnabled=true >/dev/null
+CID=$(kc get clients -r "$REALM" -q clientId="$CLIENT" --fields id --format csv --noquotes | tr -d '\r')
+SECRET=$(kc get "clients/${CID}/client-secret" -r "$REALM" --fields value --format csv --noquotes | tr -d '\r')
+
+# (2a) Audience mapper — put "infrabroker" in aud (else aud=account → rejected).
+kc create "clients/${CID}/protocol-mappers/models" -r "$REALM" \
+  -s name=audience-infrabroker -s protocol=openid-connect \
+  -s protocolMapper=oidc-audience-mapper \
+  -s 'config."included.custom.audience"='"$AUDIENCE" \
+  -s 'config."access.token.claim"=true' -s 'config."id.token.claim"=false' >/dev/null
+
+# (2b) Group + group-membership mapper — emit the groups claim (else fail-closed).
+kc create groups -r "$REALM" -s name="$GROUP" >/dev/null
+kc create "clients/${CID}/protocol-mappers/models" -r "$REALM" \
+  -s name=groups -s protocol=openid-connect \
+  -s protocolMapper=oidc-group-membership-mapper \
+  -s 'config."claim.name"=groups' -s 'config."full.path"=false' \
+  -s 'config."access.token.claim"=true' -s 'config."id.token.claim"=false' \
+  -s 'config."userinfo.token.claim"=false' >/dev/null
+
+# (2c) Put the client's service-account user in the group.
+SA_UID=$(kc get "clients/${CID}/service-account-user" -r "$REALM" --fields id --format csv --noquotes | tr -d '\r')
+GID=$(kc get groups -r "$REALM" -q search="$GROUP" --fields id --format csv --noquotes | tr -d '\r')
+kc update "users/${SA_UID}/groups/${GID}" -r "$REALM" -n >/dev/null
+
+echo "== 3. token vía client_credentials =="
+TOKEN=$(curl -fsS "${KC_URL}/realms/${REALM}/protocol/openid-connect/token" \
+  -d grant_type=client_credentials -d client_id="$CLIENT" -d client_secret="$SECRET" | jq -r .access_token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || { echo "no se obtuvo token"; exit 1; }
+
+# Decode the JWT payload (base64url) without verifying — this is a demo of claims.
+payload=$(echo "$TOKEN" | cut -d. -f2)
+case $(( ${#payload} % 4 )) in 2) payload="${payload}==";; 3) payload="${payload}=";; esac
+CLAIMS=$(echo "$payload" | tr '_-' '/+' | base64 -d 2>/dev/null | jq .)
+
+echo "$CLAIMS" | jq '{sub, azp, aud, groups, scope}'
+
+echo "== 4. aserciones (los 3 gotchas) =="
+fail=0
+assert() { if eval "$2"; then echo "  ✔ $1"; else echo "  ✘ $1"; fail=1; fi; }
+assert "azp = client id ($CLIENT)  → user_claim=azp"        '[ "$(echo "$CLAIMS" | jq -r .azp)" = "$CLIENT" ]'
+assert "sub ≠ azp (sub es el UUID del service account)"      '[ "$(echo "$CLAIMS" | jq -r .sub)" != "$CLIENT" ]'
+assert "aud contiene \"$AUDIENCE\" (audience mapper)"        'echo "$CLAIMS" | jq -e --arg a "$AUDIENCE" '"'"'([.aud]|flatten)|index($a)'"'"' >/dev/null'
+assert "groups contiene \"$GROUP\" (group mapper)"           'echo "$CLAIMS" | jq -e --arg g "$GROUP" '"'"'(.groups//[])|index($g)'"'"' >/dev/null'
+[ "$fail" = 0 ] || { echo "FALLO: el realm no emite las claims esperadas"; exit 1; }
+
+cat <<EOF
+
+== 5. config para mcp-broker-http ==
+Pon esto en la config del frontend HTTP y el token de arriba será aceptado, con
+la identidad = "$CLIENT" y grupos = ["$GROUP"] (RBAC por-agente, igual que un humano):
+
+  "oauth": {
+    "issuer":       "${KC_URL}/realms/${REALM}",
+    "audience":     "${AUDIENCE}",
+    "user_claim":   "azp",
+    "groups_claim": "groups"
+  }
+
+Obtén un token con:
+  curl -s ${KC_URL}/realms/${REALM}/protocol/openid-connect/token \\
+    -d grant_type=client_credentials -d client_id=${CLIENT} -d client_secret=<secret>
+
+OK: identidad IdP por agente vía client_credentials verificada contra Keycloak real.
+EOF


### PR DESCRIPTION
Closes #121.

Give **each AI agent its own IdP identity** the way a human gets one — an OAuth2 **client_credentials** service account, one client per agent. Its actions are attributed to it, its RBAC groups gate which hosts it reaches, and revoking access is disabling the client. **No broker code change** — the verifier is already claim-agnostic; this PR *proves and documents* it. Direct counter-positioning to network-layer 'agent identity' (they identify the agent to *reach* endpoints; here the identity is bound to *what it may execute* and to every signed audit line).

## What's here

- **Verifier tests** (`internal/oauth/verifier_test.go`, offline fake-issuer fixture):
  - `user_claim=azp` → identity is the **client id**, not the service-account UUID in `sub`;
  - the default (`sub`) yields the opaque UUID — motivating `azp`;
  - a token **without the groups mapper** is rejected (fail-closed).
- **Keycloak lab** (`lab/run_oauth_lab.sh`): a reproducible, pinned-image lab that creates a service-account client with the **three non-obvious bits** and asserts the token claims, then prints the `oauth` block to use:
  1. **`user_claim=azp`** (broker side) — Keycloak's `sub` is the SA UUID; `azp` is the client id.
  2. an **audience mapper** — Keycloak's default `aud=account` is rejected.
  3. a **group-membership mapper** on the service account — else the fail-closed `groups_claim` rejects the token.
- **Docs**: OPERATIONS *Per-agent identity: OAuth2 client_credentials*.

## Verification

- Verifier tests **pass** (they exercise the exact client_credentials claim shapes offline — this is the code proof).
- The lab is **syntax-checked** (`bash -n`). The live Keycloak run is **pending**: quay.io was stalling the Keycloak image pull when this was authored (0-byte pull log after ~8 min, 6.5 s just to ping `quay.io/v2/`). The lab is written per the exact gotchas the verifier tests already cover offline; I'll run it e2e once the image lands (or run `lab/run_oauth_lab.sh` yourself). Same manual-verify posture as #120's Slack adapter.

No Go behavior changed — only tests + a lab script + docs.