### PR TITLE
feat(ca): ssh-agent CA custody backend (#122)

### DIFF
--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -653,10 +653,12 @@ func cmdHostRemove(args []string) {
 // (key_version, tenant_id, client_id, client_secret_env) are never stripped
 // from entries broker-ctl does not touch.
 type caKeyEntry struct {
-	Type     string `json:"type"`
-	Path     string `json:"path,omitempty"`
-	VaultURL string `json:"vault_url,omitempty"`
-	KeyName  string `json:"key_name,omitempty"`
+	Type          string `json:"type"`
+	Path          string `json:"path,omitempty"`
+	Socket        string `json:"socket,omitempty"`
+	PublicKeyPath string `json:"public_key_path,omitempty"`
+	VaultURL      string `json:"vault_url,omitempty"`
+	KeyName       string `json:"key_name,omitempty"`
 }
 
 func cmdCAKeys(args []string) {
@@ -680,13 +682,15 @@ func cmdCAKeys(args []string) {
 func cmdCAKeysAdd(args []string) {
 	fs := flag.NewFlagSet("ca-keys add", flag.ExitOnError)
 	name := fs.String("name", "", "entry name: _default or a group name (required)")
-	keyType := fs.String("type", "", "backend type: pem|akv (required)")
+	keyType := fs.String("type", "", "backend type: pem|akv|agent (required)")
 	path := fs.String("path", "", "PEM file path (type=pem)")
+	socket := fs.String("socket", "", "ssh-agent socket (type=agent; empty = $SSH_AUTH_SOCK)")
+	pubKeyPath := fs.String("public-key-path", "", "CA public key file pinning the agent key (type=agent)")
 	vaultURL := fs.String("vault-url", "", "AKV vault URL (type=akv)")
 	keyName := fs.String("key-name", "", "AKV key name (type=akv)")
 	force := fs.Bool("force", false, "overwrite if already exists")
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage:\n  broker-ctl ca-keys add --name <n> --type pem --path <f>\n  broker-ctl ca-keys add --name <n> --type akv --vault-url <u> --key-name <k>")
+		fmt.Fprintln(os.Stderr, "Usage:\n  broker-ctl ca-keys add --name <n> --type pem --path <f>\n  broker-ctl ca-keys add --name <n> --type akv --vault-url <u> --key-name <k>\n  broker-ctl ca-keys add --name <n> --type agent --public-key-path <f> [--socket <s>]")
 		fs.PrintDefaults()
 	}
 	must(fs.Parse(args))
@@ -704,13 +708,20 @@ func cmdCAKeysAdd(args []string) {
 		if *vaultURL == "" || *keyName == "" {
 			fatalf("--vault-url and --key-name are required for type=akv")
 		}
+	case "agent":
+		if *pubKeyPath == "" {
+			fatalf("--public-key-path is required for type=agent")
+		}
 	default:
-		fatalf("unsupported type %q: use pem or akv", *keyType)
+		fatalf("unsupported type %q: use pem, akv, or agent", *keyType)
 	}
 
 	// The new entry contains exactly the fields provided via flags (omitempty
 	// drops the rest); existing entries are left untouched as raw JSON.
-	entryJSON, err := json.Marshal(caKeyEntry{Type: *keyType, Path: *path, VaultURL: *vaultURL, KeyName: *keyName})
+	entryJSON, err := json.Marshal(caKeyEntry{
+		Type: *keyType, Path: *path, Socket: *socket, PublicKeyPath: *pubKeyPath,
+		VaultURL: *vaultURL, KeyName: *keyName,
+	})
 	if err != nil {
 		fatalf("serialising entry: %v", err)
 	}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -386,9 +386,21 @@ the port in `--addr` (and IPv6 literals).
 broker-ctl ca-keys add --name _default --type pem --path pki/ssh_ca
 broker-ctl ca-keys add --name prod-web --type akv \
   --vault-url https://myvault.vault.azure.net/ --key-name ssh-ca-web
+# ssh-agent — CA key in a YubiKey PIV slot / SoftHSM / TPM (loaded with
+# `ssh-add -s <pkcs11.so>`); the only hardware-custody option that supports Ed25519:
+broker-ctl ca-keys add --name _default --type agent \
+  --public-key-path pki/ssh_ca.pub          # --socket defaults to $SSH_AUTH_SOCK
 broker-ctl ca-keys list
 broker-ctl ca-keys remove prod-web
 ```
+
+The **agent** backend keeps the CA private key in a running ssh-agent (no cgo in
+the signer, no cloud). `public_key_path` pins which agent key is the CA; the
+signer confirms it is present at startup (fail-closed) and re-dials the agent for
+each signature. Caveats: the signer's systemd unit needs the agent socket
+(`SSH_AUTH_SOCK` in the environment, socket readable by the service user); and a
+touch-required policy (`sk-*`, PIV touch) breaks unattended per-operation signing
+— use a presence-optional slot for a service CA.
 
 ### Callers (group RBAC table)
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -315,9 +315,12 @@ means forgetting to list a CN fails open, not closed.
 
 ### 7. CA key custody depends on deployment
 Local/lab mode loads the CA key from a PEM file into process memory (a runtime
-`[WARN]` flags this). Production should use AKV (supported) or another
-HSM/KMS-backed `crypto.Signer`. The seam exists; using PEM in production is an
-operator error the code warns about but cannot prevent.
+`[WARN]` flags this). Production should use a non-PEM backend behind the custody
+seam: **`akv`** (Azure Key Vault; RSA/EC only) or **`agent`** — the CA private
+key in a running ssh-agent backed by a YubiKey PIV slot / SoftHSM / TPM
+(`ssh-add -s`), with no cgo in the signer and support for **Ed25519** CA keys
+(which AKV lacks). The private key never leaves the backend. Using PEM in
+production is an operator error the code warns about but cannot prevent.
 
 ### 8. Secrets in commands: redaction is opt-in and best-effort
 A command is written to the broker and signer audit logs and, for `shell`/`pty`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -88,8 +88,10 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 
 | JSON key | Type | Description |
 |---|---|---|
-| `type` | `string` | "pem" \| "akv" |
+| `type` | `string` | "pem" \| "akv" \| "agent" |
 | `path` | `string` | PEM backend. |
+| `socket` | `string` | ssh-agent backend. Socket empty = $SSH_AUTH_SOCK. PublicKeyPath is the CA public key (.pub / authorized_keys line) used to pin which agent key is the CA. |
+| `public_key_path` | `string` |  |
 | `vault_url` | `string` | Azure Key Vault backend. |
 | `key_name` | `string` |  |
 | `key_version` | `string` | empty = latest version |

--- a/internal/ca/agent.go
+++ b/internal/ca/agent.go
@@ -1,0 +1,115 @@
+package ca
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// agentDialTimeout bounds each connection to the ssh-agent socket.
+const agentDialTimeout = 5 * time.Second
+
+// loadCAFromAgent returns a CA signer whose private key lives in a running
+// ssh-agent — e.g. a YubiKey PIV slot, a SoftHSM token, or a TPM, loaded with
+// `ssh-add -s <pkcs11.so>` (stock OpenSSH, no cgo in this process). The private
+// key never leaves the agent; every signature is a fresh agent round trip. The
+// pinned public key (PublicKeyPath) selects which agent key is the CA, and its
+// presence is verified at startup (fail-fast on a misconfigured or empty agent).
+func loadCAFromAgent(cfg CAKeyConfig) (ssh.Signer, error) {
+	socket := cfg.Socket
+	if socket == "" {
+		socket = os.Getenv("SSH_AUTH_SOCK")
+	}
+	if socket == "" {
+		return nil, fmt.Errorf("agent CA: no socket configured and SSH_AUTH_SOCK is unset")
+	}
+	if cfg.PublicKeyPath == "" {
+		return nil, fmt.Errorf("agent CA: public_key_path is required to pin the CA key in the agent")
+	}
+	pubBytes, err := os.ReadFile(cfg.PublicKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("agent CA: reading public_key_path: %w", err)
+	}
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(pubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("agent CA: parsing public key %s: %w", cfg.PublicKeyPath, err)
+	}
+	s := &agentSigner{socket: socket, pub: pub}
+	// Fail-fast: confirm the pinned key is present in the agent now, so a
+	// misconfiguration surfaces at startup rather than on the first sign.
+	if err := s.withSigner(func(ssh.Signer) error { return nil }); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// agentSigner is an ssh.Signer (and ssh.AlgorithmSigner) that re-dials the
+// ssh-agent for every signature, so a dropped agent connection does not
+// permanently break signing on a long-running signer.
+type agentSigner struct {
+	socket string
+	pub    ssh.PublicKey
+}
+
+func (s *agentSigner) PublicKey() ssh.PublicKey { return s.pub }
+
+func (s *agentSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return s.SignWithAlgorithm(rand, data, "")
+}
+
+// SignWithAlgorithm signs data, requesting algorithm when non-empty (e.g.
+// rsa-sha2-256/512 for an RSA CA; crypto/ssh selects it when signing the cert).
+// Ed25519 keys have a single algorithm and ignore it.
+func (s *agentSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*ssh.Signature, error) {
+	var sig *ssh.Signature
+	err := s.withSigner(func(as ssh.Signer) error {
+		var serr error
+		if algorithm != "" {
+			alg, ok := as.(ssh.AlgorithmSigner)
+			if !ok {
+				return fmt.Errorf("agent CA: agent signer does not support algorithm %q", algorithm)
+			}
+			sig, serr = alg.SignWithAlgorithm(rand, data, algorithm)
+		} else {
+			sig, serr = as.Sign(rand, data)
+		}
+		return serr
+	})
+	return sig, err
+}
+
+// withSigner dials the agent, finds the pinned CA signer, and runs fn with it.
+func (s *agentSigner) withSigner(fn func(ssh.Signer) error) error {
+	conn, err := net.DialTimeout("unix", s.socket, agentDialTimeout)
+	if err != nil {
+		return fmt.Errorf("agent CA: dialing ssh-agent at %s: %w", s.socket, err)
+	}
+	defer conn.Close()
+	signer, err := matchAgentSigner(agent.NewClient(conn), s.pub)
+	if err != nil {
+		return err
+	}
+	return fn(signer)
+}
+
+// matchAgentSigner returns the agent signer whose public key equals pub.
+func matchAgentSigner(ag agent.Agent, pub ssh.PublicKey) (ssh.Signer, error) {
+	signers, err := ag.Signers()
+	if err != nil {
+		return nil, fmt.Errorf("agent CA: listing ssh-agent keys: %w", err)
+	}
+	want := pub.Marshal()
+	for _, sg := range signers {
+		if bytes.Equal(sg.PublicKey().Marshal(), want) {
+			return sg, nil
+		}
+	}
+	return nil, fmt.Errorf("agent CA: pinned public key (%s) not found among %d ssh-agent key(s)",
+		ssh.FingerprintSHA256(pub), len(signers))
+}

--- a/internal/ca/agent_test.go
+++ b/internal/ca/agent_test.go
@@ -1,0 +1,119 @@
+package ca
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// serveKeyring serves an in-memory ssh-agent (keyring) over a unix socket,
+// standing in for a real ssh-agent / hardware token backing the CA key.
+func serveKeyring(t *testing.T, keyring agent.Agent) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "agent.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _ = agent.ServeAgent(keyring, conn) }()
+		}
+	}()
+	return sock
+}
+
+func writePub(t *testing.T, pub ssh.PublicKey) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "ca.pub")
+	if err := os.WriteFile(p, ssh.MarshalAuthorizedKey(pub), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestAgentCASignsCert: an Ed25519 CA key held in an ssh-agent signs a real
+// certificate through the production BuildAndSign path, and the cert verifies
+// against the agent-held CA. This is the Ed25519-in-agent case AKV cannot do.
+func TestAgentCASignsCert(t *testing.T) {
+	t.Parallel()
+	caPub, caPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshCAPub, err := ssh.NewPublicKey(caPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring := agent.NewKeyring()
+	if err := keyring.Add(agent.AddedKey{PrivateKey: &caPriv}); err != nil {
+		t.Fatalf("keyring add: %v", err)
+	}
+	sock := serveKeyring(t, keyring)
+	pubPath := writePub(t, sshCAPub)
+
+	caSigner, err := LoadCA(context.Background(), CAKeyConfig{Type: "agent", Socket: sock, PublicKeyPath: pubPath})
+	if err != nil {
+		t.Fatalf("LoadCA(agent): %v", err)
+	}
+	if !bytes.Equal(caSigner.PublicKey().Marshal(), sshCAPub.Marshal()) {
+		t.Fatal("loaded signer's public key does not match the pinned CA key")
+	}
+
+	userEdPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userPub, err := ssh.NewPublicKey(userEdPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, _, err := BuildAndSign(context.Background(), caSigner, userPub,
+		Constraints{Principal: "host:lab", TTL: time.Minute, KeyID: "k"})
+	if err != nil {
+		t.Fatalf("BuildAndSign with agent CA: %v", err)
+	}
+
+	checker := &ssh.CertChecker{IsUserAuthority: func(a ssh.PublicKey) bool {
+		return bytes.Equal(a.Marshal(), sshCAPub.Marshal())
+	}}
+	if err := checker.CheckCert("host:lab", cert); err != nil {
+		t.Errorf("cert signed by the agent CA failed verification: %v", err)
+	}
+}
+
+// TestAgentCAFailFast: LoadCA reports a misconfigured agent backend at startup.
+func TestAgentCAFailFast(t *testing.T) {
+	caPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	sshCAPub, _ := ssh.NewPublicKey(caPub)
+	pubPath := writePub(t, sshCAPub)
+	sock := serveKeyring(t, agent.NewKeyring()) // empty agent
+
+	// Pinned key absent from the agent.
+	if _, err := LoadCA(context.Background(), CAKeyConfig{Type: "agent", Socket: sock, PublicKeyPath: pubPath}); err == nil {
+		t.Error("LoadCA must fail when the pinned key is absent from the agent")
+	}
+	// Missing public_key_path.
+	if _, err := LoadCA(context.Background(), CAKeyConfig{Type: "agent", Socket: sock}); err == nil {
+		t.Error("LoadCA must fail without public_key_path")
+	}
+	// No socket and no SSH_AUTH_SOCK.
+	t.Setenv("SSH_AUTH_SOCK", "")
+	if _, err := LoadCA(context.Background(), CAKeyConfig{Type: "agent", PublicKeyPath: pubPath}); err == nil {
+		t.Error("LoadCA must fail without a socket")
+	}
+}

--- a/internal/ca/loader.go
+++ b/internal/ca/loader.go
@@ -16,21 +16,30 @@ import (
 // Type selects the backend:
 //
 //   - "pem": loads from a local PEM file (Path). Lab/dev use; emits a runtime
-//     warning. In production, prefer "akv" or another HSM/KMS backend.
+//     warning. In production, prefer "akv", "agent", or another HSM/KMS backend.
 //   - "akv": Azure Key Vault. The private key never leaves AKV; only the public
 //     key is fetched on startup. All signing operations execute inside the service.
+//   - "agent": the private key lives in a running ssh-agent (Socket, or
+//     $SSH_AUTH_SOCK) and is pinned by its public key (PublicKeyPath). Backs a
+//     YubiKey PIV slot / SoftHSM / TPM via `ssh-add -s`, with no cgo in this
+//     process. Unlike AKV it supports **Ed25519** CA keys.
 //
-// AKV only supports RSA (2048/3072/4096) and EC (P-256/P-384/P-521).
-// Ed25519 is not available in AKV; use "pem" for Ed25519 CA keys.
+// AKV only supports RSA (2048/3072/4096) and EC (P-256/P-384/P-521); Ed25519 is
+// not available in AKV, so use "agent" (hardware) or "pem" for an Ed25519 CA.
 //
 // A CAKeyConfig can appear as the global default (key "_default" in ca_keys),
 // or as a per-group override. When ca_key (legacy PEM string) is present and
 // ca_keys is absent, the behaviour is identical to CAKeyConfig{Type:"pem", Path: ca_key}.
 type CAKeyConfig struct {
-	Type string `json:"type"` // "pem" | "akv"
+	Type string `json:"type"` // "pem" | "akv" | "agent"
 
 	// PEM backend.
 	Path string `json:"path,omitempty"`
+
+	// ssh-agent backend. Socket empty = $SSH_AUTH_SOCK. PublicKeyPath is the CA
+	// public key (.pub / authorized_keys line) used to pin which agent key is the CA.
+	Socket        string `json:"socket,omitempty"`
+	PublicKeyPath string `json:"public_key_path,omitempty"`
 
 	// Azure Key Vault backend.
 	VaultURL   string `json:"vault_url,omitempty"`
@@ -54,14 +63,19 @@ type CAKeyConfig struct {
 //
 // For "akv": the AKV client is initialised and the public key is fetched
 // immediately (fail-fast on misconfiguration). The private key never leaves AKV.
+//
+// For "agent": the ssh-agent is dialled and the pinned public key is confirmed
+// present immediately (fail-fast). The private key never leaves the agent.
 func LoadCA(ctx context.Context, cfg CAKeyConfig) (ssh.Signer, error) {
 	switch cfg.Type {
 	case "pem":
 		return loadCAFromFile(cfg.Path)
 	case "akv":
 		return loadCAFromAKV(ctx, cfg)
+	case "agent":
+		return loadCAFromAgent(cfg)
 	default:
-		return nil, fmt.Errorf("unknown CA key type %q: supported types are \"pem\" and \"akv\"", cfg.Type)
+		return nil, fmt.Errorf("unknown CA key type %q: supported types are \"pem\", \"akv\", and \"agent\"", cfg.Type)
 	}
 }
 


### PR DESCRIPTION
Closes #122.

Adds an **`agent`** CA custody backend alongside `pem`|`akv`: the CA private key lives in a running **ssh-agent** — a YubiKey PIV slot, SoftHSM, or TPM loaded with `ssh-add -s <pkcs11.so>` (stock OpenSSH, **no cgo** in the signer, no cloud). It closes a real gap: **AKV cannot hold Ed25519 keys**, so an Ed25519 CA was PEM-only; the agent path supports it.

## Why it's cheap

The custody seam is `ssh.Signer` (not `crypto.Signer`), and agent keys are `ssh.AlgorithmSigner` — so **Ed25519 and rsa-sha2 both work with no signature-format conversion**, unlike the AKV backend.

## What's here

- **`internal/ca/agent.go`** — `loadCAFromAgent` pins the CA key by its public key (`public_key_path`) and confirms it is present in the agent **at startup (fail-closed)**. `agentSigner` **re-dials the agent per signature** (a dropped agent connection doesn't permanently break signing) and implements `ssh.Signer` + `ssh.AlgorithmSigner`.
- **`loader.go`** — third dispatch case + config fields (`socket`, `public_key_path`). The built-in **cgo PKCS#11 backend is deliberately NOT added** (it would break the static multi-arch build; `ssh-add -s` subsumes it).
- **`broker-ctl ca-keys add --type agent --public-key-path <f> [--socket <s>]`**.
- Docs: OPERATIONS CA keys (usage + the touch-required / systemd `SSH_AUTH_SOCK` caveats), THREAT_MODEL gap #7 (agent joins akv as a production custody backend).

## Tests (fully verified, `-race`)

- `TestAgentCASignsCert`: an **Ed25519** CA in an in-memory ssh-agent (`agent.NewKeyring` served over a unix socket) signs a real certificate through the production `BuildAndSign` path, and the cert **verifies** against the agent-held CA — the Ed25519-in-agent case AKV can't do.
- `TestAgentCAFailFast`: pinned key absent from the agent, missing `public_key_path`, and no socket each error at load.
- `x/crypto/ssh/agent` needs **no new dependency**; govulncheck clean; full suite green (23 packages).

Unlike #121 (blocked on quay.io), this is verified end-to-end in-process.