### PR TITLE
docs: restructure the agent workflow skills (issue, release, issue-analyze)

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: Recurring security & correctness audit of the infrabroker repo. Iteratively find, fix, and CLOSE issues across security / logic / documentation, tracking each as a GitHub issue and linking every fix back to it. Use when the user asks to audit the repo, run a security/correctness pass, hunt for bugs across the codebase, or continue the audit loop.
+description: Recurring security & correctness audit of the infrabroker repo. Iteratively find, fix, and CLOSE issues across security / logic / documentation — each finding tracked as a GitHub issue, each fix landing as an auto-merged PR that closes it. Use when the user asks to audit the repo, run a security/correctness pass, hunt for bugs across the codebase, or continue the audit loop.
 ---
 
 # infrabroker security & correctness audit
@@ -273,10 +273,13 @@ needs Docker, and anything started MUST end with `docker compose down -v`).
 - **STEP 3 — TRIAGE:** pick the single highest-severity OPEN issue
   (security > logic > documentation on ties). Work on exactly ONE.
 
-- **STEP 4 — FIX:** minimal, correct fix. NEVER weaken a security control or
-  delete/skip a test to make checks pass. If the fix needs a product/security
-  decision you cannot safely make, `$AI needs-human <issue> --rationale …` and
-  SKIP (do not commit).
+- **STEP 4 — FIX:** create the fix branch BEFORE touching any file —
+  `git checkout main && git pull --ff-only origin main && git checkout -b
+  fix/audit-<issue>` (editing on `main` and branching afterwards is a recurring
+  slip; branch is the first step, always). Then the minimal, correct fix. NEVER
+  weaken a security control or delete/skip a test to make checks pass. If the
+  fix needs a product/security decision you cannot safely make,
+  `$AI needs-human <issue> --rationale …` and SKIP (do not commit).
 
 - **STEP 5 — VERIFY (all must pass before committing):**
   ```
@@ -290,15 +293,25 @@ needs Docker, and anything started MUST end with `docker compose down -v`).
   required status checks on `main` — a red gate blocks the merge; NEVER use
   `gh pr merge --admin` to bypass it for an audit fix.
 
-- **STEP 6 — COMMIT (linked):** one logical fix per commit. Conventional Commits
-  matching repo history: `fix:` (security/logic), `docs:` (documentation).
-  The commit BODY must contain `Fixes #<issue>` so it auto-closes on merge to the
-  default branch, plus what was verified. Follow the repo's branch → PR → merge
-  convention.
+- **STEP 6 — PR (linked, auto-merge):** one logical fix per commit. Conventional
+  Commits matching repo history: `fix:` (security/logic), `docs:`
+  (documentation); the body states what was verified; no attribution trailers.
+  Unless the change is invisible to users, add a bullet under `## [Unreleased]`
+  in `docs/CHANGELOG.md` (create the section if missing — /release folds it
+  into the next version). Push the branch and open a PR whose BODY contains
+  `Closes #<issue>` so the squash-merge closes the finding. **GitHub ignores
+  negation**: never write a close/fix/resolve keyword next to a `#N` you do not
+  want closed — reference those as "Part of #N" / "tracked in #N". Then enable
+  auto-merge per the repo's standing mechanism:
+  `gh pr merge <n> --squash --auto --delete-branch` — the required checks gate
+  the merge. If the harness's auto-mode guardrail denies the agent merging its
+  own PR, STOP and ask the user to authorize it (e.g. "merge #NN"); never work
+  around the denial.
 
 - **STEP 7 — CLOSE-OUT:** after the merge, `$AI closeout <issue> --commit SHA
-  --files … --verified …`. Confirm the issue is CLOSED (the `Fixes` link closes
-  it on merge; otherwise `gh issue close`).
+  --files … --verified …`. Confirm the issue is CLOSED (the `Closes #N` in the
+  PR body closes it when the squash lands on `main`; otherwise `gh issue
+  close`). Return to a clean, synced `main` before the next iteration.
 
 - **STEP 8 — re-audit:** return to STEP 1.
 
@@ -314,7 +327,7 @@ On termination, print `$AI report` and relay it to the user.
 ## Guardrails (HARD RULES)
 
 - Read-only during AUDIT; modify files only during FIX.
-- One issue per commit; no drive-by changes.
+- One issue per commit and per PR; no drive-by changes.
 - **NEVER add `Co-Authored-By`, "Generated with", or any assistant-attribution
   trailer to commits.**
 - Never commit secrets, keys, real configs (`signer.json`, `config.json`,

--- a/.agents/skills/issue-analyze/SKILL.md
+++ b/.agents/skills/issue-analyze/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: issue-analyze
+description: Analyze a GitHub issue and its comment thread, verify the technical claims against the code, and draft a maintainer reply that follows the conversation — the draft is shown for approval and NEVER posted without explicit confirmation. Use when the user asks to analyze an issue, propose/draft an answer or reply to an issue or comment thread, or figure out what to respond.
+---
+
+# Analyze an issue & draft the maintainer's reply
+
+Produce a reply the maintainer can post as-is on an issue of
+`luisgf/infrabroker`. The deliverable is a DRAFT plus the analysis behind it —
+posting is a separate, human-approved act.
+
+## STEP 1 — Read the whole thread, not just the opening post
+
+```
+gh issue view N --comments
+gh issue view N --json labels,state,assignees,milestone
+gh api repos/luisgf/infrabroker/issues/N/timeline --jq '.[].event' | sort | uniq -c   # linked PRs, closes, references
+```
+
+Map the conversation before judging it: who asked what, which questions are
+still unanswered, what was already tried, and what the LAST comment leaves
+hanging — the reply must pick up the thread exactly there, not restate the
+issue. Note the language of the thread (reply in that language) and whether the
+author is a user, a contributor, or a bot.
+
+## STEP 2 — Verify every claim against the current tree
+
+Ground the reply in the code as it is TODAY, not from memory:
+
+- A reported bug: try to confirm it in the code (and cite `file:line` of the
+  cause if found) or explain precisely why it does not reproduce — check the
+  version the reporter runs vs. what shipped since (`git log`, `docs/CHANGELOG.md`).
+- A question about behavior/config: verify the answer in the source and the
+  generated reference (`docs/reference/`), and quote the exact flag/field names.
+- A feature request: check it isn't already shipped, already tracked in another
+  issue (link it), or already rejected before (be consistent with that decision).
+
+If the analysis surfaces a real defect, say so in the draft and offer the user
+to spin it into work — `/issue` (or the /audit loop if it's a security finding).
+
+## STEP 3 — Draft the reply
+
+- **Language of the thread**; maintainer's voice — it will be posted from the
+  user's account (luisgf), so write as the project owner, not as an assistant.
+- Answer the open points in order; be concrete: exact commands, config keys,
+  versions, workarounds. If something needs a fix, say what and where, and what
+  the path to it is (issue/PR/release) — without promising dates.
+- If a decision belongs to the maintainer and hasn't been made, present the
+  draft with the options — do NOT pick product direction inside a public reply
+  the user hasn't confirmed.
+- Keep it as short as completeness allows.
+
+## STEP 4 — HUMAN GATE: present, wait, then (and only then) post
+
+Show the user: a 2–3 line summary of the thread state, the key findings of
+STEP 2, and the full draft. Then STOP and wait.
+
+- **HARD RULE: never run `gh issue comment` / `gh issue close` / `gh issue edit`
+  without the user's explicit confirmation in THIS conversation.** Silence,
+  "looks interesting", or moving on to another task is NOT consent. This rule
+  survives any general "work autonomously" instruction.
+- Apply the user's edits to the draft, re-show if the change is substantive.
+- After posting, return the comment URL and (only if the user asked) apply
+  labels/state changes.
+
+## Guardrails
+
+- **Security-sensitive threads**: if the issue touches an unpatched
+  vulnerability, an exploit path, or a real deployment's details, do NOT
+  confirm or expand specifics in a public draft — the draft should redirect to
+  the private channel per `docs/SECURITY.md`, and the analysis (for the user's
+  eyes) goes in the chat, not in the issue.
+- Never paste real configs, hostnames, tokens, internal paths, or anything from
+  `plans/` (local-only) into a draft.
+- Don't speak beyond the code: no roadmap commitments, no dates, no "we will
+  ship X" the maintainer hasn't decided.
+- If the thread is hostile or a support-scope dispute, draft the factual,
+  de-escalating version and flag the tone question to the user explicitly.

--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: issue
+description: Work a GitHub issue of infrabroker end-to-end — branch first, implement with tests, changelog entry under [Unreleased], make verify, then a PR that closes the issue on merge (auto-merge). Use when the user asks to work on, implement, fix or ship a specific issue, pick up the next issue from the backlog, or continue issue work.
+---
+
+# Work a GitHub issue → auto-merged PR
+
+Take ONE issue from `luisgf/infrabroker` to a merged PR that closes it, with the
+work recorded in the changelog. The live backlog IS the GitHub issue list (the
+user's decision — no pending-work files in the repo or in memory).
+
+## Prerequisites
+
+- `gh auth status` OK, `origin` = `luisgf/infrabroker`.
+- Start from a clean, synced `main`: `git checkout main && git pull --ff-only origin main`.
+- The verify gate needs the docs venv and Go tooling; on this machine use
+  `export PATH="$PWD/.venv/bin:$(go env GOPATH)/bin:$PATH"` and **`/usr/bin/make`**
+  (plain `make` is a broken zsh autoload stub). See the /release skill for the
+  full list of this machine's shell gotchas.
+
+## STEP 1 — Pick & understand the issue
+
+- Given `#N`, read ALL of it: `gh issue view N --comments` (the thread often
+  refines or overrides the opening post; the LAST decisions win).
+- No number given? `gh issue list --state open` (the `audit-bot` ones belong to
+  the /audit loop), propose the most valuable unblocked one with a one-line
+  rationale, and confirm before starting.
+- **Do not assume product/security decisions.** If the issue leaves open a
+  choice with real trade-offs (validation model, RBAC scope, crypto/custody,
+  anything the owner must decide), ask FIRST — binary options with trade-offs,
+  not implementation details.
+- Architecture-shaping work (multiple packages touched, new component or
+  surface): plan first and validate the design with the user before writing
+  code — this is the user's standing preference.
+
+## STEP 2 — Branch BEFORE editing (recurring slip — first command, always)
+
+```
+git checkout -b <type>/<slug>     # feat/…, fix/…, docs/…, chore/… per repo history
+```
+
+Editing on a fresh checkout of `main` and branching afterwards has burned this
+repo twice; `main` is push-protected so the mistake surfaces late. Branch is the
+FIRST step of every issue, before any file changes.
+
+## STEP 3 — Implement
+
+- Minimal, correct change scoped to the issue — no drive-bys (spin a new issue
+  for anything unrelated you find).
+- Tests lock in the behavior: security- and logic-relevant changes ALWAYS get
+  one. Follow `docs/CODING_STYLE.md` and the surrounding code's idiom.
+- NEVER weaken a security control, relax a validation, or delete/skip a test to
+  make something pass.
+
+## STEP 4 — Changelog (the work must be recorded)
+
+Add a bullet to `docs/CHANGELOG.md` under `## [Unreleased]` at the top — create
+that section if it does not exist (it won't right after a release; /release
+folds it into each version's section when cutting):
+
+```
+## [Unreleased]
+
+### Added | ### Changed | ### Fixed | ### Internal
+- **<feature/fix name>** — user-facing, honest description of the impact,
+  matching the voice of the released entries below.
+```
+
+Pick the subsection by nature of the change, not by commit type. Purely internal
+work still gets a line under `### Internal` — /release decides what surfaces.
+
+## STEP 5 — Verify (green before any commit)
+
+```
+export PATH="$PWD/.venv/bin:$(go env GOPATH)/bin:$PATH"
+/usr/bin/make verify
+```
+
+gofmt + vet + build + race tests (+ govulncheck when on PATH) + the docs gate.
+If it regenerated `docs/reference/`, COMMIT those files with the change. Fix
+forward; never commit a red tree.
+
+## STEP 6 — PR with `Closes #N`, then auto-merge
+
+- ONE logical commit, Conventional Commits matching repo history
+  (`feat:`/`fix:`/`docs:`/`chore:`). **No `Co-Authored-By` / "Generated with" /
+  any assistant-attribution trailer** (standing user rule).
+- Push and open the PR:
+
+  ```
+  git push -u origin <branch>
+  gh pr create --base main --title "<type>: <summary>" --body "…
+
+  Closes #N"
+  ```
+
+- **Issue-linking keywords — GitHub ignores negation.** ANY
+  `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved #N` in the PR
+  body or commits closes issue N on merge, even inside "does **not** close #N"
+  (this bit us: a Phase-0 PR closed its parent). Rules:
+  - The PR fully resolves the issue → `Closes #N`.
+  - Partial/phased work → `Part of #N` or `tracked in #N`, NEVER a closing
+    keyword next to that `#N`.
+- Enable auto-merge (the user's standing mechanism — repo has
+  `allow_auto_merge`, branch protection requires `build`/`govulncheck`/`check`):
+
+  ```
+  gh pr merge <n> --squash --auto --delete-branch
+  ```
+
+  If the harness's auto-mode guardrail denies the agent merging its own PR,
+  STOP and ask the user to authorize it (e.g. "merge #NN") or to run the
+  command — never work around the denial (no `--admin`, no direct pushes to
+  `main`).
+
+## STEP 7 — Confirm & report
+
+- Checks green, PR `MERGED`, branch deleted.
+- `Closes #N` → the issue must now be CLOSED; `Part of #N` → it must still be
+  OPEN (reopen and neutralize the wording if a keyword slipped through).
+- `git checkout main && git pull --ff-only origin main`; leave the tree clean.
+- Report: what changed, what was verified (the actual gate output, not "should
+  pass"), PR and issue links.
+
+## Guardrails (hard rules)
+
+- One issue per PR; no unrelated changes riding along.
+- Never commit secrets, keys, real configs (`signer.json`, `config.json`,
+  `broker-ctl.json`, `*.env`), `plans/` (local-only), `dist*/` artifacts, or
+  `.claude/settings.local.json`.
+- A red required check blocks the merge — that is the protection working; fix
+  forward instead of bypassing.
+- If mid-implementation the issue turns out to need a human product/security
+  decision, stop and ask; don't guess and ship.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: publish
-description: Cut and publish a new infrabroker release end-to-end — semver bump, CHANGELOG, server.json + HANDOFF, make verify, release PR, annotated tag, and the CI-driven GitHub release + multi-arch ghcr image + MCP Registry publish. Use when the user asks to publish, cut/ship/tag a release, bump the version and release, or make a new version.
+name: release
+description: Cut and publish a new infrabroker release end-to-end — semver bump, CHANGELOG (folding the [Unreleased] section), server.json + HANDOFF, make verify, release PR, annotated tag, and the CI-driven GitHub release + multi-arch ghcr image + MCP Registry publish. Use when the user asks to release, publish, cut/ship/tag a release, bump the version and release, or make a new version.
 ---
 
-# Publish an infrabroker release
+# Cut an infrabroker release
 
 The deterministic mechanics live in the repo: `.github/workflows/release.yml`
 (triggered by a `v*.*.*` tag) runs goreleaser and the `mcp-registry` job, and
@@ -11,11 +11,13 @@ The deterministic mechanics live in the repo: `.github/workflows/release.yml`
 pick the right version, prepare the release commit, drive it through review, tag
 it, and confirm every published surface came out right.
 
-**The publish pipeline, end to end:**
+**The release pipeline, end to end:**
 
-1. Prepare a release commit — `docs/CHANGELOG.md`, `server.json`, `docs/HANDOFF.md`.
+1. Prepare a release commit — `docs/CHANGELOG.md` (fold `[Unreleased]` into the
+   new version), `server.json`, `docs/HANDOFF.md`.
 2. `make verify` green.
-3. Branch → PR → **human review + merge to `main`**.
+3. Branch → PR → **human review + merge to `main`** (the /issue auto-merge
+   convention does NOT apply to release PRs).
 4. Annotated tag `vX.Y.Z` on the merged commit → `git push origin vX.Y.Z`.
 5. `release.yml` fires (you do NOT run goreleaser or mcp-publisher locally):
    - job **`release`** → goreleaser: GitHub release, 4 per-platform archives +
@@ -65,6 +67,9 @@ git describe --tags --abbrev=0            # last released tag, e.g. v1.38.0
 git log --oneline <last-tag>..HEAD        # what shipped since
 ```
 
+The `## [Unreleased]` section of `docs/CHANGELOG.md` — accumulated by `/issue`
+and `/audit` as their PRs merged — plus that git log are what drive the bump:
+
 - **MAJOR** (`X`+1): a breaking change (a `!` commit type, or a documented
   incompatible change).
 - **MINOR** (`Y`+1): any new user-facing feature (`feat:`) — a new command, tool,
@@ -78,19 +83,20 @@ reversible.
 
 ## STEP 2 — Prepare the release files
 
-- **`docs/CHANGELOG.md`** — prepend a new section at the top (above the previous
-  version), dated with the real current date:
+- **`docs/CHANGELOG.md`** — fold the pending work into the release:
 
-  ```
-  ## [vX.Y.Z] - YYYY-MM-DD
+  1. Rename `## [Unreleased]` to `## [vX.Y.Z] - YYYY-MM-DD` (real current date)
+     and add a one-line theme of the release under the heading.
+  2. **Cross-check against `git log <last-tag>..HEAD`**: anything that landed
+     WITHOUT a changelog entry (dependabot bumps, direct commits, drive-bys)
+     gets a bullet now; anything listed that did not actually ship gets removed.
+  3. If there is no `[Unreleased]` section (nothing merged through /issue since
+     the last cut), build the section from the git log instead.
 
-  <one-line theme of the release>
-
-  ### Added / ### Changed / ### Fixed / ### Internal
-  - user-facing, honest bullets; describe impact, don't over-claim.
-  ```
-
-  Summarize the `git log` since the last tag. Match the existing entries' voice.
+  Keep the existing entries' voice: `### Added / ### Changed / ### Fixed /
+  ### Internal`, user-facing, honest bullets — describe impact, don't
+  over-claim. Do NOT leave an empty `[Unreleased]` behind; /issue recreates it
+  on the next merge.
 
 - **`server.json`** — bump BOTH:
   - `"version": "X.Y.Z"`
@@ -137,11 +143,12 @@ assistant-attribution trailer.** Wait for the required checks — **`build`,
 `check`, `govulncheck`** — to pass; `deploy`/`wiki-mirror` show `skipping` on a
 PR, which is expected. Never `gh pr merge --admin` past a red gate.
 
-**MERGE IS A HUMAN GATE.** The auto-mode guardrail blocks the agent from merging
-a PR it authored this session without explicit human review (two-party review).
-Ask the user to review and merge, or to explicitly authorize the merge (e.g.
-"merge #NN") — then `gh pr merge <NN> --merge --delete-branch`. Do NOT work
-around it (no manual `git push`/`git merge` to `main`).
+**MERGE IS A HUMAN GATE — release PRs are NOT auto-merged.** Unlike /issue and
+/audit fix PRs, a release PR pins the version that gets tagged, published to
+ghcr and to the MCP Registry; it gets human review. Ask the user to review and
+merge, or to explicitly authorize the merge (e.g. "merge #NN") — then
+`gh pr merge <NN> --merge --delete-branch`. Do NOT work around the auto-mode
+guardrail (no manual `git push`/`git merge` to `main`).
 
 ## STEP 5 — Tag & publish (human-authorized, irreversible)
 


### PR DESCRIPTION
One skill per workflow, all wired to the repo's auto-merge convention:

- **/issue** (new) — work a GitHub issue end-to-end: branch before editing, tests, changelog bullet under `[Unreleased]`, `make verify`, PR that references the issue so it closes on merge, auto-merge, closure confirmed. Product/security decisions are asked, never assumed.
- **/release** (renamed from /publish) — unchanged pipeline, plus: folds the `[Unreleased]` section accumulated by /issue and /audit into the version being cut, cross-checked against the git log. The release PR keeps the human-review gate (no auto-merge), as does the tag push.
- **/issue-analyze** (new) — reads a whole issue thread, verifies every claim against the current tree, drafts a maintainer reply in the thread's language. Hard gate: never posts without explicit confirmation.
- **/audit** — each fix now lands as its own auto-merged PR (branch before editing, closing reference in the PR body, changelog entry); close-out follows the merge.

No product code touched — `.agents/skills/` only.