### PR TITLE
docs: add /cve-fix and /deps workflow skills

### DIFF
--- a/.agents/skills/cve-fix/SKILL.md
+++ b/.agents/skills/cve-fix/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: cve-fix
+description: Unbreak CI when the required govulncheck check goes red on every PR because of a new Go stdlib CVE — bump the go directive in go.mod to the fixed version (single-sourced into all workflows), verify locally, ship as a standalone auto-merged PR, then re-run the blocked PRs' checks. Also handles the dependency-CVE variant. Use when govulncheck fails in CI or locally, a Go security release / stdlib CVE lands, or PRs are suddenly all red on the govulncheck check.
+---
+
+# Fix a govulncheck CVE failure (stdlib or dependency)
+
+`govulncheck` is a **required check** (`.github/workflows/go.yml`) on every PR.
+A new CVE in the **Go stdlib** turns it red on ALL open PRs at once, regardless
+of their diffs — that all-red wall is the signature of this situation, not a
+sign that anyone's change broke something. The fix is one line; ship it first
+and standalone, because it unblocks everything else.
+
+## STEP 1 — Diagnose: reproduce locally and read the report
+
+```
+command -v govulncheck || go install golang.org/x/vuln/cmd/govulncheck@latest
+export PATH="$(go env GOPATH)/bin:$PATH"
+govulncheck ./...
+```
+
+From the report note: the vuln id (`GO-YYYY-NNNN`), the affected package, and
+the **"Fixed in"** version. Distinguish the two cases:
+
+- **Module `std` / "Standard library"** → the fix is the go.mod toolchain bump
+  (STEP 2). Example (2026-07-09): `GO-2026-5856` in `crypto/tls`, fixed in
+  go1.26.5 → PR #116 bumped `go 1.26.4` → `1.26.5`.
+- **A dependency module** → `go get <module>@<fixed-version> && go mod tidy`
+  instead; if no fixed release exists yet, check whether our code actually
+  calls the vulnerable symbols (govulncheck already filters by reachability —
+  a finding means they ARE reached) and treat it as a real issue, not a bump.
+
+If govulncheck is red for a non-CVE reason (network, tool install), that is an
+environment problem — fix the environment, don't touch go.mod.
+
+## STEP 2 — The fix: bump the `go` directive in go.mod
+
+The Go version is **single-sourced in `go.mod`**: every workflow
+(`go.yml` build + govulncheck, `docs.yml` check, `release.yml` both jobs) uses
+`go-version-file: go.mod`, so this one line updates the toolchain everywhere.
+Do NOT touch the workflows.
+
+```
+# go.mod:  go 1.X.Y  →  the "Fixed in" version from the report
+```
+
+Branch first (`fix/go-1.X.Y-<vuln-id>`), then edit. Keep the PR to exactly
+this: the go.mod line (plus go.sum/tidy fallout for the dependency case) and a
+`### Internal` bullet under `## [Unreleased]` in `docs/CHANGELOG.md`
+("toolchain to go1.X.Y for GO-YYYY-NNNN"). No drive-bys — this PR must merge
+fast.
+
+## STEP 3 — Verify with the NEW toolchain
+
+```
+GOTOOLCHAIN=go1.X.Y go build ./... && GOTOOLCHAIN=go1.X.Y go vet ./...
+GOTOOLCHAIN=go1.X.Y go test -race ./...
+GOTOOLCHAIN=go1.X.Y govulncheck ./...          # must come back clean
+```
+
+`GOTOOLCHAIN` downloads the patched toolchain if it isn't installed. Then the
+full gate as usual (`export PATH="$PWD/.venv/bin:$(go env GOPATH)/bin:$PATH"`
+and `/usr/bin/make verify` — plain `make` is a broken zsh stub on this
+machine).
+
+## STEP 4 — PR, auto-merge, unblock the rest
+
+- Commit: `fix: bump Go to 1.X.Y for GO-YYYY-NNNN (<package>)` — body: what the
+  CVE is, reachability note, what was verified. No attribution trailers.
+- No issue is required first — this is a CI break; the PR body carries the vuln
+  id. If a tracking issue or Dependabot alert exists, reference it (closing
+  keyword only if this PR fully resolves it).
+- `gh pr create` → `gh pr merge <n> --squash --auto --delete-branch`. If the
+  auto-mode guardrail denies the self-merge, ask the user to authorize — this
+  is the one PR where a quick "merge it" matters, say so.
+- **After it lands on `main`**: the other open PRs stay red until their checks
+  re-run against the new merge ref — `gh run rerun <run-id> --failed` (or ask
+  Dependabot PRs to `@dependabot rebase`). Confirm at least one goes green.
+- If several PRs each carried the same bump, they de-dupe cleanly on merge —
+  identical one-line change, no conflict.
+
+## Guardrails
+
+- The bump goes UP to the fixed version — never sideways or down, and never
+  pin `GOTOOLCHAIN` in the repo to mask the failure.
+- Never make govulncheck pass by removing it from `make verify`/CI or by
+  filtering its output.
+- One CVE fix per PR; nothing else rides along.

--- a/.agents/skills/deps/SKILL.md
+++ b/.agents/skills/deps/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: deps
+description: Triage and land the open Dependabot PRs — verify each bump is what it claims (diff scope, release notes, breaking changes vs our actual usage), let the required checks gate it, and auto-merge one at a time. Use when the user asks to review/merge dependency updates or Dependabot PRs, or when Dependabot PRs are piling up.
+---
+
+# Land the Dependabot PRs
+
+Dependabot (`.github/dependabot.yml`) opens weekly PRs for two ecosystems:
+**gomod** (minor/patch batched into one `go-minor-patch` group PR; majors
+individual) and **github-actions**. They pass through the same required checks
+as any PR (`build`/`govulncheck`/`check`). This skill is the review judgment in
+between: confirm the bump is safe for THIS repo, then land them one at a time.
+
+## STEP 1 — Inventory
+
+```
+gh pr list --author "app/dependabot" --json number,title,headRefName,statusCheckRollup
+```
+
+**Authenticity check**: the author must be exactly `app/dependabot` — a PR
+merely titled like a bump but from another author is a red flag, not a
+dependency update; stop and tell the user.
+
+Order: land CI-green PRs first; a red one gets diagnosed, not forced (STEP 4).
+
+## STEP 2 — Review each PR (this is the actual review, don't skip it)
+
+For every PR, in this order:
+
+1. **Diff scope** — `gh pr diff <n>`: a gomod PR may touch ONLY
+   `go.mod`/`go.sum` (and vendored files if we ever vendor); an actions PR may
+   touch ONLY `uses:` lines/hashes under `.github/workflows/`. Anything else
+   (code, configs, scripts) → do not merge; escalate to the user.
+2. **What changed upstream** — the PR body carries release notes/changelog/
+   commits. For a **major** bump, actually read them for breaking changes and
+   check against OUR usage:
+   - actions: `grep -rn "<action-name>" .github/workflows/` — renamed/removed
+     inputs, changed defaults, node-runtime requirements, new permissions.
+     (Example class: `actions/checkout` v5→v7, `docker/login-action` v3→v4 —
+     majors were input-compatible for our usage, but that is checked, not
+     assumed.)
+   - gomod: `grep -rn "<module-path>" --include="*.go"` for the APIs we import;
+     read the module's release notes for behavior changes in those.
+3. **Security-sensitive deps get extra eyes** — bumps touching crypto, ssh,
+   OAuth/JWT, or the MCP SDK affect the product's security surface: skim the
+   upstream diff for the parts we depend on, and prefer `make verify` locally
+   on the PR branch (`gh pr checkout <n>`), not just CI.
+
+For the batched minor/patch gomod group, review the list as a whole; the
+required checks plus a scan of the module list is proportionate.
+
+## STEP 3 — Land, one at a time
+
+```
+gh pr merge <n> --squash --auto --delete-branch
+```
+
+- One at a time: after each merge Dependabot rebases the remaining PRs itself
+  (or comment `@dependabot rebase` to force it). Don't edit Dependabot branches
+  by hand — use `@dependabot rebase` / `@dependabot recreate`.
+- If the auto-mode guardrail denies the merge, collect the reviewed PR numbers
+  and ask the user to authorize them in one go.
+- No changelog entry for routine bumps — dependency updates surface in the
+  release notes via the git log cross-check in /release. A major bump that
+  changes behavior users can see DOES get an `[Unreleased]` bullet.
+
+## STEP 4 — A red Dependabot PR
+
+- `govulncheck` red on ALL PRs at once → that's a stdlib CVE, not this bump:
+  run /cve-fix first, then `@dependabot rebase` and re-check.
+- Red only on this PR → the bump likely breaks us: reproduce locally on the PR
+  branch, decide fix-forward (rare; that becomes an /issue) vs. reject. To
+  reject: comment `@dependabot ignore this major version` (or
+  `this minor version` / `this dependency`) so it stops reopening, close the
+  PR, and tell the user what was ignored and why — ignoring a security update
+  is the user's call, never yours.
+
+## Guardrails
+
+- Never merge with red required checks; never `--admin`.
+- Never merge a "dependency PR" whose diff exceeds its manifest scope or whose
+  author isn't `app/dependabot`.
+- Version pins/hashes only move forward; never downgrade to dodge a failure.
+- Ignoring or deferring a security-relevant bump requires the user's explicit
+  decision.


### PR DESCRIPTION
Follow-up to #147 (the two remaining workflow skills the user opted into):

- **/cve-fix** — the govulncheck playbook: a Go stdlib CVE turns the required check red on every open PR at once; the fix is bumping the `go` directive in go.mod (single-sourced into all workflows via `go-version-file`), verified with the new toolchain (`GOTOOLCHAIN=go1.X.Y` + `make verify`), shipped as a standalone PR, then re-running the blocked PRs' checks. Covers the dependency-CVE variant too. Encodes the real GO-2026-5856 / #116 experience.
- **/deps** — Dependabot triage: author authenticity, diff scope limited to manifests, release notes reviewed against our actual usage (grep workflows / imports), extra scrutiny for security-sensitive modules, one merge at a time (Dependabot rebases the rest), `@dependabot` commands for rebase/recreate/ignore. Rejecting a security bump is explicitly the user's call.

`.agents/skills/` only — no product code.