### PR TITLE
fix(k8s): drop client namespace on cluster-scoped resources so the canonical matches execution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **k8s cluster-scoped scope fidelity**: a client-supplied namespace on a
+  cluster-scoped resource (`nodes`, `namespaces`, `persistentvolumes`) is now
+  dropped before the canonical action `<verb> <resource> <ns>/<name>` is built,
+  so the policy decision, the Ed25519-signed audit record, and the human
+  approval reflect the true cluster-wide scope. Previously the namespace rode
+  into the canonical — making a destructive action (e.g. `delete nodes`) look
+  namespace-scoped to the approver and letting a namespaced deny rule be evaded
+  — while execution silently ignored it. Normalized symmetrically on the broker
+  and the signer, so the anti-mismatch guarantee still holds.
+
 ## [v1.38.0] - 2026-07-04
 
 Security & correctness audit pass, plus an explicit audit-log recovery command.

--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -97,6 +97,14 @@ func (e *Engine) K8sExecute(ctx context.Context, c Caller, cluster string, actio
 		return nil, err
 	}
 	action.Group = def.Group
+	// A cluster-scoped resource takes no namespace: drop any client-supplied one
+	// so the canonical the broker signs, audits, and shows the approver matches
+	// execution (resourcePath omits the namespace for these) and the signer's
+	// recomputed canonical. Mirrors the group normalization; symmetric with
+	// resolveK8s so the anti-mismatch check still agrees.
+	if !def.Namespaced {
+		action.Namespace = ""
+	}
 	canonical := action.Canonical()
 
 	in := signer.Intent{

--- a/internal/broker/k8s_test.go
+++ b/internal/broker/k8s_test.go
@@ -171,6 +171,37 @@ func TestK8sExecuteGroupNormalization(t *testing.T) {
 	}
 }
 
+func TestK8sExecuteClusterScopedNamespaceDropped(t *testing.T) {
+	// A cluster-scoped resource (nodes) takes no namespace. A client-supplied
+	// namespace must be dropped so the canonical the signer authorises, the
+	// audit records, and the approver sees reflects the TRUE cluster-wide scope
+	// — not a namespaced-looking action that runs cluster-wide anyway (blast-
+	// radius misrepresentation + namespaced-deny evasion). resourcePath already
+	// omits the namespace for these; this keeps the canonical honest.
+	sgn := &fakeK8sSigner{allow: map[string]bool{"delete nodes -/node-1": true}}
+	e, api := newK8sEngine(t, sgn)
+
+	if _, err := e.K8sExecute(context.Background(), Caller{ID: "alice", Groups: []string{"platform"}},
+		"prod-k8s", signer.K8sAction{Verb: "delete", Resource: "nodes", Namespace: "kube-system", Name: "node-1"},
+		nil, false, K8sExecuteOpts{}); err != nil {
+		t.Fatalf("K8sExecute: %v", err)
+	}
+	if sgn.last.Command != "delete nodes -/node-1" {
+		t.Errorf("client namespace on a cluster-scoped resource must be dropped from the canonical: got %q", sgn.last.Command)
+	}
+	if sgn.last.K8s.Namespace != "" {
+		t.Errorf("namespace must be cleared on the signed action: got %q", sgn.last.K8s.Namespace)
+	}
+	if api.lastURL != "/api/v1/nodes/node-1" {
+		t.Errorf("execution must be cluster-wide: API path = %q", api.lastURL)
+	}
+	for _, line := range readAuditLog(t, e) {
+		if strings.Contains(line, "kube-system") {
+			t.Errorf("audit must not misrepresent scope with the dropped namespace: %s", line)
+		}
+	}
+}
+
 func TestK8sExecuteDenied(t *testing.T) {
 	sgn := &fakeK8sSigner{allow: map[string]bool{}}
 	e, _ := newK8sEngine(t, sgn)

--- a/internal/signer/k8spolicy.go
+++ b/internal/signer/k8spolicy.go
@@ -390,6 +390,15 @@ func (ct ClusterTable) resolveK8s(in Intent, grants GrantProvider) (Decision, co
 	}
 	action := *in.K8s
 	action.Group = def.Group
+	// A cluster-scoped resource takes no namespace: drop any client-supplied one
+	// so the canonical (the policy key, the signed audit, and the approval the
+	// human sees) reflects the TRUE scope, matching execution — resourcePath
+	// omits the namespace for these, so an unnormalized "kube-system/node-1"
+	// would be audited/approved as namespace-scoped yet run cluster-wide. Mirrors
+	// the group normalization above and keeps both sides' canonicals in agreement.
+	if !def.Namespaced {
+		action.Namespace = ""
+	}
 	// Anti-mismatch: the policy decides on, the audit records, and the approver
 	// sees in.Command — it must be exactly the normalized canonical form of the
 	// structured action, or a malicious broker could show the human one action

--- a/internal/signer/k8spolicy_test.go
+++ b/internal/signer/k8spolicy_test.go
@@ -169,6 +169,40 @@ func TestResolveK8sDecisions(t *testing.T) {
 	}
 }
 
+func TestResolveK8sClusterScopedNamespaceNormalized(t *testing.T) {
+	t.Parallel()
+	// A rule on a cluster-scoped resource (nodes): its canonical namespace is
+	// always "-". The signer must strip any client-supplied namespace before it
+	// decides/audits/approves, so the approver sees the true cluster-wide scope
+	// and a namespaced deny cannot be dodged by presenting a bogus namespace.
+	ct := compileOne(t, testCluster(t, []K8sRule{
+		{Verbs: []string{"delete"}, Resources: []string{"nodes"}, Effect: "allow"},
+	}))
+
+	// The true cluster-scoped form (no namespace) is authorised.
+	if _, _, err := ct.resolveK8s(k8sIntent(K8sAction{Verb: "delete", Resource: "nodes", Name: "node-1"}), nil); err != nil {
+		t.Fatalf("cluster-scoped delete must be allowed: %v", err)
+	}
+
+	// A struct namespace on a cluster-scoped resource is normalized away before
+	// the canonical is recomputed, so it agrees with the normalized command a
+	// fixed broker sends. Without the normalization this mismatches and errors.
+	in := k8sIntent(K8sAction{Verb: "delete", Resource: "nodes", Name: "node-1"}) // Command = "delete nodes -/node-1"
+	in.K8s = &K8sAction{Verb: "delete", Resource: "nodes", Namespace: "kube-system", Name: "node-1"}
+	if _, _, err := ct.resolveK8s(in, nil); err != nil {
+		t.Fatalf("signer must normalize the cluster-scoped namespace to '-': %v", err)
+	}
+
+	// A broker that presents a namespaced cluster-scoped command — trying to make
+	// the audit/approval show a narrower scope than what runs, or to dodge a
+	// namespaced deny — is rejected by the anti-mismatch guard (the recomputed
+	// canonical is namespace-stripped and no longer matches).
+	bad := k8sIntent(K8sAction{Verb: "delete", Resource: "nodes", Namespace: "kube-system", Name: "node-1"})
+	if _, _, err := ct.resolveK8s(bad, nil); err == nil {
+		t.Fatal("a namespaced cluster-scoped command must be rejected (namespace is not part of its canonical)")
+	}
+}
+
 func TestResolveK8sRejectsSSHKnobsAndMismatch(t *testing.T) {
 	t.Parallel()
 	ct := compileOne(t, testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}}))


### PR DESCRIPTION
## Summary

On the Kubernetes credential-broker path, a client-supplied **namespace on a cluster-scoped resource** (`nodes`, `namespaces`, `persistentvolumes`) was embedded in the canonical action string `<verb> <resource[.group]> <ns>/<name>` — which drives the **policy decision**, the **Ed25519-signed audit record**, and the **human approval** — but was silently dropped at execution (`resourcePath` in `internal/k8s/client.go` only appends the namespace when `def.Namespaced`).

Consequences:
- **Blast-radius misrepresentation.** `delete nodes kube-system/node-1` was audited and shown to the approver as a namespace-scoped action, yet executed as the cluster-wide `DELETE /api/v1/nodes/node-1`. This defeats the stated goal of the anti-mismatch control ("the approver + audit see exactly what runs").
- **Namespaced-deny evasion.** A deny rule scoping a cluster-scoped resource by its canonical `-` namespace (e.g. `deny delete nodes -/*`) could be dodged by presenting a bogus namespace, provided an allow rule matched the altered canonical.

Both the broker and the signer failed to normalize identically, so the anti-mismatch recompute still agreed and never caught it.

## Fix

Normalize `action.Namespace = ""` when the resolved resource is **not** `Namespaced`, **before** the canonical is built — symmetrically in `resolveK8s` (signer) and `K8sExecute` (broker), mirroring the existing `action.Group = def.Group` normalization. The canonical now always reads `-/name` for cluster-scoped resources regardless of client input, so the policy/audit/approval reflect the true scope and both sides still agree. Execution is unchanged (`resourcePath` already ignored the namespace).

## Tests

- `internal/broker`: `TestK8sExecuteClusterScopedNamespaceDropped` — the namespace is dropped from the signed canonical, the API call is cluster-wide, and the audit does not carry the spurious namespace.
- `internal/signer`: `TestResolveK8sClusterScopedNamespaceNormalized` — the signer normalizes a struct namespace to `-` and rejects a namespaced cluster-scoped command via the anti-mismatch guard.

## Verification

`make verify` — gofmt, go vet, build, race tests, govulncheck (0 vulnerabilities), docgen (no drift), example-config tests, and the strict mkdocs site build all pass.

Closes #149
