### PR TITLE
fix(bridge): redact the command before presenting an approval on the chat platform

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Security
+- **approval-bridge redacts the command before the chat platform**: the
+  `approval-bridge` now masks secrets in an approval's command (using the
+  built-in redaction patterns) before presenting it on Slack, matching the
+  control plane's webhook/Teams notifier. Previously it reposted the original
+  command from `/v1/approvals` verbatim, so a secret passed inline in a
+  `require_approval` command leaked in cleartext to the chat channel even with
+  `redact` enabled (the Teams/webhook sink and the signed audit masked it).
+
 ### Fixed
 - **k8s cluster-scoped scope fidelity**: a client-supplied namespace on a
   cluster-scoped resource (`nodes`, `namespaces`, `persistentvolumes`) is now

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -328,14 +328,19 @@ sessions, to the ASCIIcast recording; the control plane additionally sends it
 in approval notifications (log/webhook/Teams). A credential passed inline —
 `mysql -psecret`, `PGPASSWORD=… pg_dump`, `curl -H "Authorization: Bearer …"` —
 would otherwise persist in plaintext in every one of those sinks.
-- **Mitigation:** the opt-in `redact` config block (all three services) masks
-  secrets at every persistent/outbound sink — audit log free-text fields,
-  session recordings, and the approval notification payload — using built-in
-  patterns plus operator-defined RE2 rules, replacing the secret with
+- **Mitigation:** the opt-in `redact` config block (signer, broker, control
+  plane) masks secrets at every persistent/outbound sink — audit log free-text
+  fields, session recordings, and the approval notification payload — using
+  built-in patterns plus operator-defined RE2 rules, replacing the secret with
   `[REDACTED:<rule>]` **before** the audit entry is signed (verification is
-  unaffected; the original is irrecoverable). Redaction never touches the
-  decision path: the signer, the certificate force-command, and the mTLS
-  approval UI see the original command.
+  unaffected; the original is irrecoverable). The `approval-bridge` reads the
+  original command from the control plane's `/v1/approvals` (an mTLS approver
+  like any other) but masks it with the **built-in default patterns** before
+  presenting it on the chat platform — an off-host sink of the same class as the
+  webhook/Teams notifier — so a chat channel is never sent a secret the Teams
+  notifier would have masked. Redaction never touches the decision path: the
+  signer, the certificate force-command, and the mTLS approval UI (`broker-ctl` /
+  the web UI) see the original command.
 - **Residual risk:** pattern matching is best-effort, not DLP (see
   [SECURITY.md](SECURITY.md#redaction-is-best-effort)) — an unanticipated
   secret format survives, and output recorded in `.cast` files arrives in

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/control"
+	"github.com/luisgf/infrabroker/internal/redact"
 )
 
 // Decision is a human's Allow/Deny for a pending approval, from a platform.
@@ -50,7 +51,8 @@ type Bridge struct {
 	cp       ControlPlane
 	adapter  PlatformAdapter
 	interval time.Duration
-	posted   map[string]bool // approval ids already presented (dedupe)
+	posted   map[string]bool  // approval ids already presented (dedupe)
+	redactor control.Redactor // masks secrets before the off-host chat sink
 }
 
 // New builds a bridge polling every interval (default 5s if <= 0).
@@ -58,7 +60,23 @@ func New(cp ControlPlane, adapter PlatformAdapter, interval time.Duration) *Brid
 	if interval <= 0 {
 		interval = 5 * time.Second
 	}
-	return &Bridge{cp: cp, adapter: adapter, interval: interval, posted: map[string]bool{}}
+	return &Bridge{cp: cp, adapter: adapter, interval: interval, posted: map[string]bool{}, redactor: mustDefaultRedactor()}
+}
+
+// mustDefaultRedactor builds the command redactor applied before an approval is
+// presented on a chat platform. The bridge is a persistent/outbound sink of the
+// same class as the control plane's webhook/Teams notifier (docs/THREAT_MODEL.md
+// section 8): GET /v1/approvals serves the ORIGINAL command because the human
+// mTLS approval UI is entitled to it, so the masking must happen here at the
+// off-host relay, not at that shared endpoint. Built-in defaults only (the
+// bridge has no config file) — best-effort, matching the notifier's default
+// patterns. redact.New(nil) compiles the vetted Defaults and so never errors.
+func mustDefaultRedactor() control.Redactor {
+	r, err := redact.New(nil)
+	if err != nil {
+		panic("bridge: compiling default command redactor: " + err.Error())
+	}
+	return r
 }
 
 // Run polls for pending approvals and relays decisions until ctx is cancelled.
@@ -102,7 +120,10 @@ func (b *Bridge) poll(ctx context.Context) {
 		if b.posted[a.ID] {
 			continue
 		}
-		if err := b.adapter.Post(ctx, a); err != nil {
+		// Mask secrets in the command before it leaves the host for the chat
+		// platform, matching the control plane's webhook/Teams notifier sink
+		// (section 8). The dedupe/relay below key on a.ID, which is untouched.
+		if err := b.adapter.Post(ctx, a.WithRedactedCommand(b.redactor)); err != nil {
 			log.Printf("approval-bridge: presenting %s: %v", a.ID, err)
 			continue // retry on the next tick
 		}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -50,11 +51,22 @@ func (f *fakeCP) Decide(_ context.Context, id string, approve bool) error {
 type fakeAdapter struct {
 	posted    chan string
 	decisions chan Decision
+	mu        sync.Mutex
+	lastCmd   string // the command of the most recently presented approval
 }
 
 func (a *fakeAdapter) Post(_ context.Context, ap control.Approval) error {
+	a.mu.Lock()
+	a.lastCmd = ap.Command
+	a.mu.Unlock()
 	a.posted <- ap.ID
 	return nil
+}
+
+func (a *fakeAdapter) lastCommand() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.lastCmd
 }
 func (a *fakeAdapter) Decisions() <-chan Decision { return a.decisions }
 func (a *fakeAdapter) Name() string               { return "fake" }
@@ -90,6 +102,37 @@ func TestBridgePresentsAndRelays(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("bridge did not relay the decision to the control plane")
+	}
+}
+
+// TestBridgeRedactsCommandBeforePresenting: a secret passed inline in a
+// require_approval command must be masked before it reaches the off-host chat
+// platform, matching the control plane's webhook/Teams notifier sink (section
+// 8). GET /v1/approvals serves the original command for the human mTLS UI, so
+// the redaction has to happen at the bridge.
+func TestBridgeRedactsCommandBeforePresenting(t *testing.T) {
+	t.Parallel()
+	cp := &fakeCP{decided: make(chan [2]any, 1)}
+	ad := &fakeAdapter{posted: make(chan string, 4), decisions: make(chan Decision, 1)}
+	cp.setPending([]control.Approval{{ID: "a1", Host: "db01", Command: "mysql -u root --password=HUNTER2 proddb"}})
+
+	b := New(cp, ad, 20*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = b.Run(ctx); close(done) }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	select {
+	case <-ad.posted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not present the approval")
+	}
+	got := ad.lastCommand()
+	if strings.Contains(got, "HUNTER2") {
+		t.Errorf("inline secret leaked to the platform unredacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED:") {
+		t.Errorf("command was not redacted before presenting: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `approval-bridge` (#120) leaked inline command secrets to the chat platform, bypassing the redaction control that every other outbound sink honors.

The control plane redacts an approval's command before its own notification sinks — `cmd/control-plane/main.go:488-491` builds a `notifyCopy` via `Approval.WithRedactedCommand(s.redactor)` because the notification "persists in the process log or leaves the host (webhook/Teams)". `THREAT_MODEL.md` §8 promises the opt-in `redact` block masks secrets "at every persistent/outbound sink … and the approval notification payload", the only decision-path exceptions being the signer, the force-command, and "the mTLS approval UI".

The bridge is a **new** outbound/persistent sink that wasn't one of those exceptions: it polls `GET /v1/approvals` — which deliberately serves the **original** command for the interactive human mTLS UI (`cmd/control-plane/main.go:670`) — and reposted `ap.Command` verbatim into a Slack channel message (`internal/bridge/slack.go:56`). Net: with `redact` enabled, a secret passed inline in a `require_approval` command was masked in the Teams/webhook notification **and** the signed audit, but sent in cleartext to the Slack channel, where it persists on the SaaS.

## Fix

Mask the command with the built-in default redaction patterns (`redact.New(nil)`) in the bridge's `poll()` loop, via `control.Approval.WithRedactedCommand`, **before** it reaches any `PlatformAdapter`. The bridge is the off-host relay boundary and has no config file, so the defaults are always on — best-effort, matching the notifier's default patterns. Redaction cannot move into the `/v1/approvals` handler because that endpoint also serves the interactive human mTLS approval UI (`broker-ctl approval list`), which §8 entitles to the exact command.

The dedupe map and the decision relay key on the approval **id**, which is untouched; the decision path (signer, force-command, on-host mTLS UI) still sees the original command. `THREAT_MODEL.md` §8 now documents the bridge as a redacted outbound sink.

## Test

`internal/bridge`: `TestBridgeRedactsCommandBeforePresenting` — a command carrying `--password=…` is masked (`[REDACTED:…]`, no cleartext secret) before it reaches the adapter's `Post`.

## Verification

`make verify` — gofmt, vet, build, race tests, govulncheck (0 vulnerabilities), docgen (no drift), example-config tests, and the strict mkdocs site build all pass.

Closes #150
