### PR TITLE
docs: session lifetime is capped at cert expiry (#124), not unbounded by it

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -293,11 +293,13 @@ Use sessions when you need:
 
 > Always close a session when done with `ssh_session_close`. Open sessions hold
 > an SSH connection until they are closed or reaped. The reaper closes a session
-> after `session_idle_seconds` of inactivity or `session_max_seconds` of total
-> lifetime — **not** when the certificate TTL elapses: OpenSSH validates the
-> certificate only at authentication, so an already-established connection
-> survives certificate expiry. Set `session_max_seconds` to the maximum exposure
-> window you are willing to accept.
+> when the certificate that opened it expires, after `session_idle_seconds` of
+> inactivity, or after `session_max_seconds` of total lifetime — whichever comes
+> first (#124). OpenSSH validates the certificate only at authentication, so an
+> established connection would itself outlive certificate expiry; the broker
+> enforces the bound and closes the session at certificate expiry, capping a
+> session's exposure at the certificate TTL (≤ `max_ttl_seconds`). Set
+> `session_max_seconds` to tighten the window further.
 
 ### 3.1 mode=exec (default) — isolated commands, shared connection
 
@@ -621,9 +623,9 @@ retry.
 ### 5.4 Session expired or closed
 
 If `ssh_session_exec` returns an error for a session ID that was previously
-valid, the session was most likely closed by the reaper — after
-`session_idle_seconds` of inactivity or `session_max_seconds` of total lifetime.
-Open a new session.
+valid, the session was most likely closed by the reaper — when the opening
+certificate expired, after `session_idle_seconds` of inactivity, or after
+`session_max_seconds` of total lifetime. Open a new session.
 
 ### 5.5 Newlines in commands
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -107,7 +107,7 @@ Write a file on a Linux host via SSH with an ephemeral credential. Creates or OV
 
 ## `ssh_session_close`
 
-Close a persistent SSH session and release the connection. Always call when done working with a session; an unclosed session keeps its SSH connection until it is reaped by the idle or maximum-lifetime timeout (not by the certificate TTL).
+Close a persistent SSH session and release the connection. Always call when done working with a session; an unclosed session keeps its SSH connection until it is reaped when the opening certificate expires, or by the idle or maximum-lifetime timeout (whichever comes first).
 
 - `session_id` (string) *(required)* — id of the session to close
 
@@ -120,7 +120,7 @@ Execute a command in a session opened with ssh_session_open. Returns stdout, std
 
 ## `ssh_session_open`
 
-Open a persistent SSH session that reuses the connection across commands. Use when you need multiple commands with shared state (e.g. cd to a directory and then operate in it) or interactive programs. For isolated commands prefer ssh_execute (simpler, stronger isolation guarantee). Available modes: exec (default, independent commands), shell (stateful sh: cd and variables persist), pty (shell with TTY for interactive programs). sudo=true ONLY if allow_sudo=true (see ssh_list_servers); if allow_sudo=false DO NOT retry. mode=pty ONLY if allow_pty=true. Every ssh_session_exec is preflighted against the current signer policy, so policy reloads revalidate target and bastion access, end-user groups, sudo, sudo_user, PTY, and the host's physical route for already-open sessions. On command-policy hosts, mode=exec is allowed; mode=shell and mode=pty are rejected. Returns session_id for use with ssh_session_exec. IMPORTANT: always close the session with ssh_session_close when done; an open session holds an SSH connection and is otherwise closed only after an idle or maximum-lifetime timeout (it is NOT bound to the certificate TTL).
+Open a persistent SSH session that reuses the connection across commands. Use when you need multiple commands with shared state (e.g. cd to a directory and then operate in it) or interactive programs. For isolated commands prefer ssh_execute (simpler, stronger isolation guarantee). Available modes: exec (default, independent commands), shell (stateful sh: cd and variables persist), pty (shell with TTY for interactive programs). sudo=true ONLY if allow_sudo=true (see ssh_list_servers); if allow_sudo=false DO NOT retry. mode=pty ONLY if allow_pty=true. Every ssh_session_exec is preflighted against the current signer policy, so policy reloads revalidate target and bastion access, end-user groups, sudo, sudo_user, PTY, and the host's physical route for already-open sessions. On command-policy hosts, mode=exec is allowed; mode=shell and mode=pty are rejected. Returns session_id for use with ssh_session_exec. IMPORTANT: always close the session with ssh_session_close when done; an open session holds an SSH connection and is otherwise closed when the certificate that opened it expires, or after an idle or maximum-lifetime timeout (whichever comes first).
 
 - `mode` (string) — exec (default): isolated commands with no shared state. shell: persistent sh, cd and environment variables survive across ssh_session_exec calls. pty: shell with pseudo-terminal for interactive programs (editors, less, etc.); requires allow_pty=true. If allow_pty=false DO NOT use pty.
 - `server` (string) *(required)* — logical name of the target host (see ssh_list_servers)

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -284,7 +284,7 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 			"Every ssh_session_exec is preflighted against the current signer policy, so policy reloads revalidate target and bastion access, end-user groups, sudo, sudo_user, PTY, and the host's physical route for already-open sessions. " +
 			"On command-policy hosts, mode=exec is allowed; mode=shell and mode=pty are rejected. " +
 			"Returns session_id for use with ssh_session_exec. " +
-			"IMPORTANT: always close the session with ssh_session_close when done; an open session holds an SSH connection and is otherwise closed only after an idle or maximum-lifetime timeout (it is NOT bound to the certificate TTL).",
+			"IMPORTANT: always close the session with ssh_session_close when done; an open session holds an SSH connection and is otherwise closed when the certificate that opened it expires, or after an idle or maximum-lifetime timeout (whichever comes first).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionOpenInput) (*mcp.CallToolResult, sessionOpenOutput, error) {
 		if err := validateInput(map[string]string{"server": in.Server, "mode": in.Mode, "sudo_user": in.SudoUser}); err != nil {
 			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, sessionOpenOutput{}, nil
@@ -322,7 +322,7 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 	mcp.AddTool(srv, &mcp.Tool{
 		Name: "ssh_session_close",
 		Description: "Close a persistent SSH session and release the connection. " +
-			"Always call when done working with a session; an unclosed session keeps its SSH connection until it is reaped by the idle or maximum-lifetime timeout (not by the certificate TTL).",
+			"Always call when done working with a session; an unclosed session keeps its SSH connection until it is reaped when the opening certificate expires, or by the idle or maximum-lifetime timeout (whichever comes first).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionCloseInput) (*mcp.CallToolResult, okOutput, error) {
 		if err := validateInput(map[string]string{"session_id": in.SessionID}); err != nil {
 			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, okOutput{}, nil


### PR DESCRIPTION
## Summary

Three docs — two of them **fed to the MCP client as tool descriptions** — asserted the pre-#124 behavior that a persistent SSH session is *not* bound to the certificate TTL and "survives certificate expiry". #124 changed that: the broker's reaper closes a session once the certificate that opened it expires (`internal/broker/session.go` `certNotAfter`, set on every `OpenSession`, reaped at `now.After(certNotAfter)`), so the effective lifetime is `min(idle, session_max_seconds, cert TTL)`.

Because the tool descriptions ship to the model, the model was being told a larger exposure bound than the broker actually enforces.

## Fix

- `internal/mcpserver/tools.go` — corrected the `ssh_session_open` and `ssh_session_close` description strings.
- `docs/reference/mcp-tools.md` — regenerated (`make docs-gen`).
- `docs/USAGE.md` — corrected the §2.6 session note and the §5.4 "session expired" note.

The `#124` feature itself is enumerated in the CHANGELOG under a separate finding (#153); this PR is the doc-drift correction only, so it adds no changelog bullet.

## Verification

`make verify` — build, vet, race tests, govulncheck (0 vulnerabilities), docgen (no residual drift), example configs, and the strict mkdocs site build all pass.

Closes #152
