### PR TITLE
fix(audit): don't splice the caller identity into the broker k8s audit Command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,13 @@
   command from `/v1/approvals` verbatim, so a secret passed inline in a
   `require_approval` command leaked in cleartext to the chat channel even with
   `redact` enabled (the Teams/webhook sink and the signed audit masked it).
+- **Broker k8s audit no longer embeds the caller in the Command token stream**:
+  the k8s execution audit records the caller identity only in the structured
+  `caller` field, not as a ` user=` token in the space-delimited `command`
+  stream. The caller id (the OIDC user-claim value) is not charset-validated at
+  the broker, so a whitespace-bearing identity could otherwise have forged
+  tokens into a hash-chained entry (the class the signer already guards, #67).
+  Defense in depth; the identity is unchanged and still audited.
 
 ### Fixed
 - **k8s cluster-scoped scope fidelity**: a client-supplied namespace on a

--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -196,10 +196,14 @@ func (e *Engine) auditK8s(c Caller, cluster, canonical string, serial uint64, ou
 	if ok {
 		host = ci.APIServer
 	}
+	// The caller identity rides in the structured Caller field (JSON-encoded, not
+	// splice-able), NOT as a " user=" token inside the space-delimited Command
+	// stream: c.ID is the OIDC user-claim value and is not charset-validated here,
+	// so splicing it in would let a whitespace-bearing identity forge tokens
+	// (outcome=…, action=…) into a hash-chained entry — the audit token-forgery
+	// class the signer already guards (cf. #67). The SSH path is symmetric: the
+	// caller lives in Caller, never in the Command stream.
 	cmd := "target=k8s action=" + canonical
-	if c.ID != "" {
-		cmd += " user=" + c.ID
-	}
 	ent := audit.Entry{
 		Caller:     c.ID,
 		Host:       host,

--- a/internal/broker/k8s_test.go
+++ b/internal/broker/k8s_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/ed25519"
+	"encoding/json"
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
@@ -280,6 +281,47 @@ func TestK8sExecuteApplyAuditsBodyHash(t *testing.T) {
 	}
 	if !found {
 		t.Error("apply audit entry must record body_sha256")
+	}
+}
+
+func TestK8sExecuteAuditDoesNotSpliceCallerIntoCommand(t *testing.T) {
+	// c.ID is the OIDC user-claim value and is not charset-validated at the
+	// broker. It must never be spliced into the space-delimited audit Command
+	// stream, or a whitespace-bearing identity could forge tokens into a
+	// hash-chained entry (the class the signer guards, cf. #67). It rides in the
+	// structured caller field instead.
+	sgn := &fakeK8sSigner{allow: map[string]bool{"get pods prod/web-1": true}}
+	e, _ := newK8sEngine(t, sgn)
+
+	forged := "alice outcome=executed action=delete pods"
+	if _, err := e.K8sExecute(context.Background(), Caller{ID: forged, Groups: []string{"platform"}},
+		"prod-k8s", signer.K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"},
+		nil, false, K8sExecuteOpts{}); err != nil {
+		t.Fatalf("K8sExecute: %v", err)
+	}
+	var checked bool
+	for _, line := range readAuditLog(t, e) {
+		var ent struct {
+			Caller  string `json:"caller"`
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal([]byte(line), &ent); err != nil {
+			t.Fatalf("audit line not JSON: %v", err)
+		}
+		if !strings.HasPrefix(ent.Command, "target=k8s") {
+			continue
+		}
+		checked = true
+		if ent.Command != "target=k8s action=get pods prod/web-1" {
+			t.Errorf("caller identity spliced into the audit Command: %q", ent.Command)
+		}
+		// The identity is preserved, safely, in the structured caller field.
+		if ent.Caller != forged {
+			t.Errorf("caller field = %q, want the raw identity %q", ent.Caller, forged)
+		}
+	}
+	if !checked {
+		t.Fatal("no k8s audit entry found")
 	}
 }
 


### PR DESCRIPTION
## Summary

The broker's k8s execution audit built a space-delimited Command stream (`target=k8s action=<canonical> user=<c.ID>`) and spliced `c.ID` — the OIDC user-claim value, **not** charset-validated at the broker — as a ` user=` token (`internal/broker/k8s.go`). A whitespace-bearing identity (e.g. a `user_claim` mapped to a user-influenced claim) could forge tokens (`outcome=`, `action=`) into the hash-chained entry — the audit token-forgery class the signer already guards (#67). The signer validates its symmetric `end_user`/`caller` with `HasUnsafeTokenChar`; the broker did not.

The SSH path never had this: it keeps the caller in the structured `Caller` field, never in the `Command` stream.

## Fix

Drop the ` user=` token from the k8s audit Command. The caller identity still rides in the structured `caller` field (JSON-encoded, not splice-able) — unchanged and still audited. Added `TestK8sExecuteAuditDoesNotSpliceCallerIntoCommand`.

## Verification

`make verify` — gofmt, vet, build, race tests, govulncheck (0 vulns), docgen (no drift), example configs, strict mkdocs site all pass.

Closes #151
