### PR TITLE
fix(build): add approval-bridge to Makefile CMDS so make builds the seventh binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 PKG     := github.com/luisgf/infrabroker/internal/version
 LDFLAGS := -X $(PKG).Version=$(VERSION)
 BINDIR  ?= $(HOME)/bin
-CMDS    := signer broker broker-ctl mcp-broker mcp-broker-http control-plane
+CMDS    := signer broker broker-ctl mcp-broker mcp-broker-http control-plane approval-bridge
 # MkDocs runner: prefer a local mkdocs, else fall back to `python3 -m mkdocs`.
 MKDOCS  ?= $(shell command -v mkdocs 2>/dev/null || echo "python3 -m mkdocs")
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,11 @@
   namespace-scoped to the approver and letting a namespaced deny rule be evaded
   — while execution silently ignored it. Normalized symmetrically on the broker
   and the signer, so the anti-mismatch guarantee still holds.
+- **`make` builds `approval-bridge`**: the seventh binary (`cmd/approval-bridge`,
+  #120) is now part of `make build` / `install` / `dist`, so the installer
+  tarball ships it alongside the other binaries — matching the goreleaser
+  release archive, which already did. Previously only `go install` or the
+  release archive produced it, though `docs/OPERATIONS.md` documents running it.
 
 ## [v1.38.0] - 2026-07-04
 


### PR DESCRIPTION
## Summary

`Makefile:21` `CMDS` listed only six binaries, omitting `cmd/approval-bridge` (added by #120). So `make build`, `make install`, and `make dist` never produced it, and the installer tarball shipped six binaries — even though `docs/OPERATIONS.md` documents running `approval-bridge` and the goreleaser release archive already ships it (`.goreleaser.yaml`).

## Fix

Add `approval-bridge` to `CMDS`. It now builds into the tarball's `bin/` alongside `broker` and `mcp-broker` — built and shipped, run manually. It has no systemd unit (it's a standalone optional daemon), so `install.sh` is unchanged, consistent with how `broker`/`mcp-broker` are handled. The OCI image intentionally still excludes it (`.goreleaser.yaml` `dockers_v2`), so that path stays consistent.

## Verification

`make build` produces all seven binaries with correct version ldflags. `make verify` — fmt, vet, build, race tests, govulncheck (0 vulns), docgen (no drift), example configs, strict mkdocs site — passes.

Closes #154
