### PR TITLE
docs(threat-model): correct the bridge approver-attribution claim

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -99,8 +99,10 @@ without it. A compromised broker or control plane cannot forge certificates.
   design: (1) *who may approve* moves partly from the mTLS `approval.callers`
   allowlist to **chat channel membership** run by an external SaaS — anyone who
   can click a button in that channel can approve; (2) approver attribution is
-  **bridge-asserted** — the audit records the bridge CN plus the platform user
-  id as metadata, not a cryptographically verified approver; (3) the CN-level
+  **bridge-asserted** — the signed audit records the bridge's approver CN; the
+  platform user id who clicked is written only to the bridge's own process log
+  (operational, not tamper-evident), so the decision is not tied to a
+  cryptographically verified approver; (3) the CN-level
   four-eyes guard still holds (the bridge CN differs from any broker CN), but
   per-human approver certs collapse into that one CN. The control plane's
   consumed-once and four-eyes guards are unchanged. For a single operator,


### PR DESCRIPTION
The approval-bridge section claimed the signed audit records "the bridge CN plus the platform user id". In the shipped code the platform user id (Slack `cb.User.ID`) is written only to the bridge's local process log (`internal/bridge/bridge.go`); the relay payload carries no user field (`cpclient.go`) and the control plane records `ApprovedBy` = the bridge mTLS CN only. So the signed, hash-chained audit does not contain it. Corrected to say it lives in the bridge process log (operational, not tamper-evident).

Verified: strict mkdocs site build, docgen (no drift).

Closes #155