### PR TITLE
docs(containers): the release archive is a superset of the image (adds approval-bridge)

### DIFF
--- a/docs/CONTAINERS.md
+++ b/docs/CONTAINERS.md
@@ -12,10 +12,12 @@ ghcr.io/luisgf/infrabroker:<X.Y.Z>     # matches each release tag
 ghcr.io/luisgf/infrabroker:latest
 ```
 
-- **Contents:** the six release binaries (`signer`, `broker`, `broker-ctl`,
+- **Contents:** six server/broker binaries (`signer`, `broker`, `broker-ctl`,
   `mcp-broker`, `mcp-broker-http`, `control-plane`) under `/usr/local/bin/`,
-  bit-identical to the release archives (the image copies the prebuilt
-  binaries; nothing is compiled in the Dockerfile).
+  byte-for-byte identical to the ones in the release archives (the image copies
+  the prebuilt binaries; nothing is compiled in the Dockerfile). The release
+  archive additionally ships `approval-bridge`, which the image deliberately
+  omits — it is a standalone daemon, not part of the broker runtime.
 - **Base:** `distroless/static` — CA roots for outbound TLS (signer, OIDC,
   Azure Key Vault), a `nonroot` user (uid 65532), and **no shell or package
   manager**. The SSH client is pure Go; no `openssh` inside.


### PR DESCRIPTION
CONTAINERS.md called the image's six binaries "bit-identical to the release archives", but the goreleaser unified archive now ships seven (`approval-bridge`, #120) while the OCI image intentionally excludes it (`.goreleaser.yaml` `dockers_v2` + the Dockerfile COPY). The wording implied the sets match. Clarified: the six shared binaries are byte-for-byte identical, and the archive additionally ships `approval-bridge`, which the image omits by design.

Verified: strict mkdocs site build.

Closes #159