### PR TITLE
fix(control): escape broker-supplied fields in the Teams Adaptive Card (approver phishing)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,13 @@
   per-agent action budgets; documentation only, no behavior change.
 
 ### Security
+- **Teams Adaptive Card escapes broker-supplied fields** — the default Teams
+  notification format (Adaptive Card) renders `Fact.value` as Markdown, so a
+  crafted command/host could inject a clickable link or hidden formatting into
+  the approver's notification (phishing / command obscuring). The broker-supplied
+  fact values are now Markdown-escaped, matching the `markdown:false` defense the
+  legacy MessageCard path already had (default-path sibling of the earlier
+  MessageCard fix).
 - **Session lifetime capped at the certificate TTL (#124)** — the broker's
   reaper now closes a live session when the certificate that opened it expires,
   bounding a session's exposure to the cert TTL (≤ `max_ttl_seconds`) instead of

--- a/internal/control/teams.go
+++ b/internal/control/teams.go
@@ -117,9 +117,30 @@ func (t *TeamsNotifier) buildWorkflowEnvelope(a Approval) map[string]any {
 	}
 }
 
+// teamsMarkdownEscaper backslash-escapes the characters Teams honours as
+// Markdown in Adaptive Card Fact values, so broker-supplied text (command, host,
+// identities) renders literally instead of as a clickable link or formatting —
+// the same protection the MessageCard path gets from markdown:false (#43). It
+// runs in a single pass, so the backslashes it inserts are not re-escaped.
+var teamsMarkdownEscaper = strings.NewReplacer(
+	"\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_",
+	"[", "\\[", "]", "\\]", "(", "\\(", ")", "\\)",
+	"#", "\\#", "~", "\\~", ">", "\\>", "|", "\\|",
+)
+
 // buildAdaptiveCard constructs the Adaptive Card v1.4 object.
 func (t *TeamsNotifier) buildAdaptiveCard(a Approval) map[string]any {
 	facts := t.approvalFacts(a)
+	// Teams renders Adaptive Card Fact.value as Markdown (unlike the MessageCard
+	// path, which pins markdown:false). Escape the broker-supplied values so a
+	// crafted command/host cannot inject a clickable link or hidden formatting
+	// into the approver's notification (phishing / command obscuring, #43). The
+	// facts slice is freshly built per call, so this does not affect MessageCard.
+	for _, f := range facts {
+		if v, ok := f["value"].(string); ok {
+			f["value"] = teamsMarkdownEscaper.Replace(v)
+		}
+	}
 
 	// Card body: title + description + FactSet.
 	body := []map[string]any{

--- a/internal/control/teams_test.go
+++ b/internal/control/teams_test.go
@@ -142,6 +142,44 @@ func TestTeamsNotifierMessageCardFormato(t *testing.T) {
 	}
 }
 
+// TestTeamsNotifierAdaptiveCardEscapesMarkdown: Teams renders Adaptive Card
+// Fact.value as Markdown, so a crafted command must not inject a clickable link
+// or formatting into the approver's notification (phishing / command obscuring).
+// Sibling of #43, which fixed the MessageCard path with markdown:false.
+func TestTeamsNotifierAdaptiveCardEscapesMarkdown(t *testing.T) {
+	inject := "restart [APPROVED](https://evil.example/pwn) db"
+
+	// Adaptive Card (default): the link syntax must be neutralized, but the
+	// command text still shown (escaped).
+	srv, body := captureWebhook(t)
+	a := sampleApproval()
+	a.Command = inject
+	if err := NewTeamsNotifier(srv.URL, TeamsFormatWorkflow, "").Notify(a); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	adaptive := string(*body)
+	if strings.Contains(adaptive, "](") {
+		t.Errorf("Adaptive Card leaked a Markdown link from the command: %s", adaptive)
+	}
+	if !strings.Contains(adaptive, "APPROVED") {
+		t.Error("the command text should still be shown (escaped), just not as a link")
+	}
+
+	// MessageCard (legacy): unchanged — markdown:false already renders literally,
+	// so it must NOT be escaped (escaping would show stray backslashes).
+	srv2, body2 := captureWebhook(t)
+	if err := NewTeamsNotifier(srv2.URL, TeamsFormatMessageCard, "").Notify(a); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	mc := string(*body2)
+	if !strings.Contains(mc, `"markdown":false`) {
+		t.Error("MessageCard must keep markdown:false")
+	}
+	if !strings.Contains(mc, "](") {
+		t.Error("MessageCard path must render the command literally (raw), not escaped")
+	}
+}
+
 // ── Facts content ─────────────────────────────────────────────────────────────
 
 func TestTeamsNotifierFactsContienenCamposClave(t *testing.T) {


### PR DESCRIPTION
## Summary

`TeamsNotifier`'s default format is the Adaptive Card (`NewTeamsNotifier` selects `workflow` whenever the format is empty). `buildAdaptiveCard` puts the untrusted approval fields — `Command`, `Host`, `EndUser`, `Caller`, `SudoUser` — into `FactSet` `Fact.value` fields, which Microsoft Teams renders as **Markdown**. The legacy MessageCard path defends against exactly this by pinning `"markdown": false` (with a comment describing the threat); the Adaptive Card path — **the default** — had no equivalent defense.

So a crafted `require_approval` command such as `restart [APPROVED](https://evil.example/pwn) db` (or one using `**`/backticks to obscure the real command) renders as a clickable link / formatted text in the approver's Teams notification — phishing / command obscuring, biasing the human approval decision. Redaction (secret patterns only) does not neutralize Markdown metacharacters. This is the default-path sibling of the earlier MessageCard fix.

## Fix

Markdown-escape the broker-supplied fact values on the Adaptive Card path (`buildAdaptiveCard`) with a single-pass backslash escaper. The MessageCard path is untouched — it already renders literally under `markdown:false`, and escaping there would show stray backslashes. The facts slice is built fresh per call, so the two paths don't interfere. Added `TestTeamsNotifierAdaptiveCardEscapesMarkdown`.

## Verification

`make verify` — gofmt, vet, build, race tests, govulncheck (0 vulns), docgen (no drift), example configs, strict mkdocs site all pass.

Closes #173
