### PR TITLE
fix(signer): shell_parse must model the executed force-command — block >&FILE and env-injection (RCE)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,18 @@
   per-agent action budgets; documentation only, no behavior change.
 
 ### Security
+- **Command-firewall allowlist bypass with `shell_parse` (RCE)** — with
+  `command_policy.shell_parse` enabled, the parser that decomposes a command for
+  allowlist matching under-modeled what the baked certificate force-command
+  actually runs. A `>&FILE` / `<&FILE` redirect (a file write in bash/zsh) was
+  misclassified as a safe fd-duplication and stripped, and a standalone
+  environment assignment or `export`/`declare` before an allowed command was
+  invisible to the policy. Either let an anchored allowlist authorize `echo x` /
+  `git fetch origin` while the force-command wrote an arbitrary file or injected
+  `GIT_SSH_COMMAND` / `LD_PRELOAD` / `PATH` — remote code execution on the target
+  host. The parser now requires an fd operand for `>&` / `<&` and rejects
+  environment declarations and standalone assignments (fail-closed). Only hosts
+  with `shell_parse=true` were affected.
 - **Teams Adaptive Card escapes broker-supplied fields** — the default Teams
   notification format (Adaptive Card) renders `Fact.value` as Markdown, so a
   crafted command/host could inject a clickable link or hidden formatting into

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -147,16 +147,34 @@ func extractCommands(command string) ([]string, error) {
 			walkErr = errors.New("arithmetic command not allowed")
 			return false
 		case *syntax.Redirect:
-			// Allow only fd→fd redirections (e.g. 2>&1, 1>&2). A file redirect has
-			// Hdoc or a Word pointing to a filename; we detect the safe case by
-			// checking that the destination is also an fd (DplIn/DplOut).
-			isDupFd := n.Op == syntax.DplOut || n.Op == syntax.DplIn
+			// Allow only fd→fd redirections (e.g. 2>&1, 1>&2, 2>&-). The operator
+			// (>& / <&) is NOT sufficient: ">&FILE" is a file write in bash/zsh, so
+			// the TARGET must also be a bare fd (a number, or "-" to close). Checking
+			// the operator alone let ">&/etc/cron.d/x" pass as an fd dup while the
+			// baked force-command wrote the file (arbitrary write / RCE).
+			isDupFd := (n.Op == syntax.DplOut || n.Op == syntax.DplIn) && isFdRef(n.Word)
 			if !isDupFd {
 				walkErr = fmt.Errorf("file redirect not allowed: %s", n.Op)
 				return false
 			}
+		case *syntax.DeclClause:
+			// export / declare / readonly / typeset mutate the environment of a
+			// FOLLOWING command (GIT_SSH_COMMAND, LD_PRELOAD, PATH, BASH_ENV, …) but
+			// are not a command the allowlist evaluates, while the baked
+			// force-command still runs them. They have no place in a force-command
+			// allowlist, so reject rather than silently drop them.
+			walkErr = errors.New("environment declaration (export/declare/…) not allowed")
+			return false
 		case *syntax.CallExpr:
 			if len(n.Args) == 0 {
+				// A CallExpr with assignments but no command word is a standalone
+				// assignment (FOO=bar): invisible to the allowlist yet baked into the
+				// force-command, where it changes how a following command runs. Reject
+				// it; a truly empty CallExpr is a harmless no-op we skip.
+				if len(n.Assigns) > 0 {
+					walkErr = errors.New("standalone environment assignment not allowed")
+					return false
+				}
 				break
 			}
 			buf.Reset()
@@ -176,6 +194,30 @@ func extractCommands(command string) ([]string, error) {
 		return nil, errors.New("no commands found after shell parse")
 	}
 	return cmds, nil
+}
+
+// isFdRef reports whether w is a bare file-descriptor reference — a decimal fd
+// number, or "-" to close the descriptor — the only safe target for a >& / <&
+// duplication. Any other word (a filename, or an expansion whose value the
+// policy cannot know) means the redirect touches a file and must be rejected; a
+// word that is not a single literal is treated as non-fd (fail-closed).
+func isFdRef(w *syntax.Word) bool {
+	if w == nil || len(w.Parts) != 1 {
+		return false
+	}
+	lit, ok := w.Parts[0].(*syntax.Lit)
+	if !ok {
+		return false
+	}
+	if lit.Value == "-" {
+		return true
+	}
+	for _, r := range lit.Value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return lit.Value != ""
 }
 
 // shellParserPool reuses POSIX-shell parsers across requests with shell_parse

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -295,6 +295,21 @@ func TestCommandPolicyShellParse(t *testing.T) {
 		{"file redirect denied", allowPs, "ps aux > /tmp/out", false, false},
 		// Redirect fd→fd (2>&1) → permitido siempre que el comando pase.
 		{"fd redirect allowed", allowPs, "ps aux 2>&1", true, true},
+		// fd→fd variants must stay allowed: 1>&2 (dup) and 2>&- (close).
+		{"fd dup 1>&2 allowed", allowPs, "ps aux 1>&2", true, true},
+		{"fd close 2>&- allowed", allowPs, "ps aux 2>&-", true, true},
+		// #175 vector 1: >&FILE is a FILE WRITE (bash/zsh), not an fd dup. The
+		// operator alone must not classify it as safe — it must be rejected like
+		// any file redirect, or it bypasses the allowlist and the baked
+		// force-command writes the file (arbitrary write / RCE).
+		{"dup-fd to file denied (>&)", allowPs, "ps aux >& /tmp/out", false, false},
+		{"dup-fd to file denied (<&)", allowPs, "ps aux <& /tmp/in", false, false},
+		// #175 vector 2: environment mutations before an allowed command are
+		// invisible to the allowlist but baked into the force-command, where they
+		// change how the following command runs (GIT_SSH_COMMAND, LD_PRELOAD, …).
+		{"standalone assignment denied", allowPs, "GIT_SSH_COMMAND=x; ps aux", false, false},
+		{"export denied", allowPs, "export LD_PRELOAD=/tmp/e.so; ps aux", false, false},
+		{"declare denied", allowPs, "declare -x PATH=/tmp/evil; ps aux", false, false},
 		// Denylist con shell_parse: kill en pipeline → denegado.
 		{"denylist pipeline kill", denylistParse, "ps aux | kill -9 1", false, true},
 		// Denylist con shell_parse: comando limpio → permitido.


### PR DESCRIPTION
## Summary — HIGH: command-firewall allowlist bypass → RCE (shell_parse)

With `command_policy.shell_parse=true` (the recommended AI-firewall hardening), `PolicySet.Decide` matches the command against `extractCommands`' decomposition (`internal/signer/policyset.go:96-97`), but the certificate **force-command is baked from the original request command** (`internal/signer/signer.go:429`). `extractCommands`' model of *what runs* was narrower than what sshd executes via the login shell, so two construct classes bypassed an anchored allowlist and then executed from the baked force-command:

1. **`>&FILE` file-write redirect.** A redirect was classified as a safe fd-duplication by **operator alone** (`>&`/`<&`), without checking the operand is an fd (`cmdpolicy.go:153`). The redirect lives on the `Stmt`, so printing the bare `CallExpr` dropped it: `echo pwned >& /etc/cron.d/x` → policy sees `echo pwned` (matches `^echo pwned$`) → the force-command runs the original → the shell writes the file → **arbitrary write / RCE**. This contradicted the function's own documented invariant ("file Redirect — arbitrary write … unconditionally rejected").
2. **Env-mutation before an allowed command.** A standalone assignment parses as a zero-`Args` `CallExpr` (skipped) and `export`/`declare`/`readonly` parse as `*syntax.DeclClause` (no case in the walk): `export GIT_SSH_COMMAND='…'; git fetch origin` → policy sees `git fetch origin` → the force-command runs the original → **RCE** via `GIT_SSH_COMMAND` (or `LD_PRELOAD`/`PATH`/`BASH_ENV`, chaining with vector 1 to plant then hijack).

Both only affect hosts with `shell_parse=true` — ironically, exactly the operators who hardened. Verified against the pinned `mvdan.cc/sh/v3 v3.13.1`.

## Fix

Make `extractCommands` fail closed on any construct whose effect it can't faithfully represent to the policy (the policy must see exactly what the force-command runs):
- require an **fd operand** for `>&`/`<&` before treating it as a dup — `isFdRef` accepts a decimal fd or `-` (keeps `2>&1`, `1>&2`, `2>&-`; rejects `>&FILE`);
- reject `*syntax.DeclClause` and a `CallExpr` that carries assignments but no command word (standalone assignment).

Tests cover both attack vectors and confirm the legitimate `fd→fd` forms still pass.

## Verification

`make verify` — gofmt, vet, build, race tests, govulncheck (0 vulns), docgen (no drift), example configs, strict mkdocs site all pass.

Closes #175
