### PR TITLE
chore(signer,broker): dedupe elevation quoting and RBAC group intersection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,16 @@
   A change to how entries are written that would break verification now fails a
   unit test next to the writer instead of surfacing later on an operator's
   machine; `broker-ctl` became a thin consumer with byte-identical output.
+- **De-duplicated security-sensitive helpers across broker↔signer (#179)** —
+  shell-quoting (`ShellQuote`), the elevated-command builder
+  (`BuildElevatedCommand`) and the RBAC group intersection (`GroupsIntersect`)
+  existed twice, once in `internal/signer` and once copied into `internal/broker`
+  (behind an incorrect "circular dependency" comment). They are now single,
+  exported implementations in `internal/signer`, used by both — so the `sudo`
+  command line that ends up in a CA-signed force-command and the one sent on the
+  session/file-transfer channel can no longer silently diverge. The retained
+  quoting implementation preserves input bytes exactly (the broker's rune-copy
+  variant would have mangled invalid UTF-8); no behavior change for valid input.
 
 ## [v1.38.0] - 2026-07-04
 

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -775,7 +775,7 @@ func (e *Engine) ServerInfos(c Caller) []ServerInfo {
 		e.mu.RLock()
 		infos = make([]ServerInfo, 0, len(e.hosts))
 		for name, h := range e.hosts {
-			if c.Groups != nil && !groupsIntersect(h.Groups, c.Groups) {
+			if c.Groups != nil && !signer.GroupsIntersect(h.Groups, c.Groups) {
 				continue
 			}
 			infos = append(infos, ServerInfo{Name: name, AllowSudo: h.AllowSudo, AllowPTY: h.AllowPTY, AllowFileTransfer: h.AllowFileTransfer, Jump: h.Jump})
@@ -784,7 +784,7 @@ func (e *Engine) ServerInfos(c Caller) []ServerInfo {
 	} else {
 		infos = make([]ServerInfo, 0, len(e.cfg.Hosts))
 		for name, hc := range e.cfg.Hosts {
-			if c.Groups != nil && !groupsIntersect(hc.Groups, c.Groups) {
+			if c.Groups != nil && !signer.GroupsIntersect(hc.Groups, c.Groups) {
 				continue
 			}
 			infos = append(infos, ServerInfo{Name: name, AllowSudo: hc.AllowSudo, AllowPTY: hc.AllowPTY, AllowFileTransfer: hc.AllowFileTransfer, Jump: hc.Jump})
@@ -792,20 +792,6 @@ func (e *Engine) ServerInfos(c Caller) []ServerInfo {
 	}
 	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
 	return infos
-}
-
-// groupsIntersect reports whether the two group lists share at least one
-// element. A host with no groups is never visible to a group-restricted user
-// (same semantics as the signer's per-user check).
-func groupsIntersect(hostGroups, userGroups []string) bool {
-	for _, hg := range hostGroups {
-		for _, ug := range userGroups {
-			if hg == ug {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // Servers returns the configured host names (stable order).

--- a/internal/broker/filetransfer.go
+++ b/internal/broker/filetransfer.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/signer"
 )
 
 // DefaultFileTransferMaxBytes caps transfer content when
@@ -70,7 +71,7 @@ func (e *Engine) PutFile(ctx context.Context, c Caller, host, path string, conte
 	if max := e.FileTransferMaxBytes(); len(content) > max {
 		return nil, fmt.Errorf("%w: content is %d bytes, the transfer limit is %d", ErrBadRequest, len(content), max)
 	}
-	q := shellQuoteSession(path)
+	q := signer.ShellQuote(path)
 	command := "cat > " + q
 	if mode != "" {
 		if !modeRe.MatchString(mode) {
@@ -106,7 +107,7 @@ func (e *Engine) GetFile(ctx context.Context, c Caller, host, path string, maxBy
 	if maxBytes > 0 && maxBytes < max {
 		max = maxBytes
 	}
-	command := fmt.Sprintf("head -c %d < %s", max+1, shellQuoteSession(path))
+	command := fmt.Sprintf("head -c %d < %s", max+1, signer.ShellQuote(path))
 	res, err := e.Execute(ctx, c, host, command, ttlSeconds, ExecOptions{FileTransfer: true})
 	if err != nil {
 		return nil, err

--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -42,7 +42,7 @@ func (e *Engine) K8sClusters(c Caller) []ClusterInfo {
 	defer e.mu.RUnlock()
 	out := make([]ClusterInfo, 0, len(e.clusters))
 	for name, ci := range e.clusters {
-		if c.Groups != nil && !groupsIntersect(ci.Groups, c.Groups) {
+		if c.Groups != nil && !signer.GroupsIntersect(ci.Groups, c.Groups) {
 			continue
 		}
 		out = append(out, ClusterInfo{Name: name})

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -452,7 +452,7 @@ func (e *Engine) SessionExec(ctx context.Context, c Caller, sessionID, command s
 	// In exec sessions with elevation, build the elevated command.
 	effectiveCommand := command
 	if s.mode == "exec" && s.elevationPrefix != "" {
-		effectiveCommand = buildElevatedExecCommand(s.elevationPrefix, command)
+		effectiveCommand = signer.BuildElevatedCommand(s.elevationPrefix, command)
 	}
 
 	var res *sshrun.Result
@@ -618,29 +618,6 @@ func (e *Engine) CloseSession(c Caller, sessionID string) error {
 	s.close()
 	e.auditE(audit.Entry{Caller: c.ID, Host: s.host, Serial: s.serial, SessionID: sessionID, Outcome: "session_close"})
 	return nil
-}
-
-// buildElevatedExecCommand wraps command with the elevation prefix for exec
-// sessions (each command is sent separately).
-func buildElevatedExecCommand(prefix, command string) string {
-	return fmt.Sprintf("%s -- /bin/sh -c %s", prefix, shellQuoteSession(command))
-}
-
-// shellQuoteSession is a local copy of shellQuote to avoid a circular
-// dependency with the signer package (which already has the function).
-func shellQuoteSession(s string) string {
-	var b strings.Builder
-	b.Grow(len(s) + 2)
-	b.WriteByte('\'')
-	for _, c := range s {
-		if c == '\'' {
-			b.WriteString(`'\''`)
-		} else {
-			b.WriteRune(c)
-		}
-	}
-	b.WriteByte('\'')
-	return b.String()
 }
 
 func newSessionID() string {

--- a/internal/broker/session_test.go
+++ b/internal/broker/session_test.go
@@ -846,7 +846,7 @@ func TestBuildElevatedExecCommand(t *testing.T) {
 		{"sudo -n", "echo 'hello'", `sudo -n -- /bin/sh -c 'echo '\''hello'\'''`},
 	}
 	for _, c := range cases {
-		got := buildElevatedExecCommand(c.prefix, c.command)
+		got := signer.BuildElevatedCommand(c.prefix, c.command)
 		if got != c.want {
 			t.Errorf("prefix=%q cmd=%q\n  got  %q\n  want %q", c.prefix, c.command, got, c.want)
 		}
@@ -866,7 +866,7 @@ func TestShellQuoteSession(t *testing.T) {
 		{"a'b'c", `'a'\''b'\''c'`},   // multiple embedded quotes
 	}
 	for _, c := range cases {
-		got := shellQuoteSession(c.in)
+		got := signer.ShellQuote(c.in)
 		if got != c.want {
 			t.Errorf("in=%q got=%q want=%q", c.in, got, c.want)
 		}

--- a/internal/signer/k8spolicy.go
+++ b/internal/signer/k8spolicy.go
@@ -338,7 +338,7 @@ func compileAlternates(values []string, field, wildcard string, lit func(string)
 // and matches anyone.
 func (cp ClusterPolicy) bindingFor(endUserGroups []string) (SABinding, error) {
 	for _, b := range cp.SABindings {
-		if len(b.Groups) == 0 || groupsIntersect(b.Groups, endUserGroups) {
+		if len(b.Groups) == 0 || GroupsIntersect(b.Groups, endUserGroups) {
 			return b, nil
 		}
 	}
@@ -409,7 +409,7 @@ func (ct ClusterTable) resolveK8s(in Intent, grants GrantProvider) (Decision, co
 	if !callerAllowed(cp.AllowedCallers, in.Caller) {
 		return Decision{}, commandPolicyResult{}, fmt.Errorf("caller %q not authorised for %q", in.Caller, in.Host)
 	}
-	if in.EndUserGroups != nil && !groupsIntersect(cp.Groups, in.EndUserGroups) {
+	if in.EndUserGroups != nil && !GroupsIntersect(cp.Groups, in.EndUserGroups) {
 		return Decision{}, commandPolicyResult{}, fmt.Errorf("user %q not authorised for %q (groups)", in.EndUser, in.Host)
 	}
 

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -428,7 +428,7 @@ func (p PolicyTable) resolve(in Intent, defaultMaxTTL time.Duration, grants Gran
 	if in.Purpose == PurposeOneshot && in.Role == RoleTarget {
 		cmd := in.Command
 		if elevationPrefix != "" {
-			cmd = buildElevatedCommand(elevationPrefix, in.Command)
+			cmd = BuildElevatedCommand(elevationPrefix, in.Command)
 		}
 		c.ForceCommand = cmd
 		// In one-shot the prefix goes in ForceCommand; it is not returned as prefix.
@@ -509,7 +509,7 @@ func authorizeIntent(hp HostPolicy, in Intent) error {
 	// Per-user RBAC: if the request carries end-user groups (OIDC HTTP frontend),
 	// the host must belong to at least one of them. If EndUserGroups is nil the
 	// filter is not applied (requests without user identity: stdio/mTLS).
-	if in.EndUserGroups != nil && !groupsIntersect(hp.Groups, in.EndUserGroups) {
+	if in.EndUserGroups != nil && !GroupsIntersect(hp.Groups, in.EndUserGroups) {
 		return fmt.Errorf("user %q not authorised for %q (groups)", in.EndUser, in.Host)
 	}
 	if in.Role == RoleBastion && !hp.AllowAsBastion {
@@ -691,17 +691,23 @@ func resolveElevation(hp HostPolicy, in Intent) (string, error) {
 	return fmt.Sprintf("sudo -n -u %s", sudoUser), nil
 }
 
-// buildElevatedCommand wraps command with prefix safely:
-// prefix + " -- /bin/sh -c " + shellQuote(command).
+// BuildElevatedCommand wraps command with prefix safely:
+// prefix + " -- /bin/sh -c " + ShellQuote(command).
 // The double dash separates sudo options from the argument, and /bin/sh -c
 // allows pipelines, redirections, and variables (same as without elevation).
-func buildElevatedCommand(prefix, command string) string {
-	return fmt.Sprintf("%s -- /bin/sh -c %s", prefix, shellQuote(command))
+// Exported so internal/broker's session and file-transfer paths build the
+// elevated command line through the same implementation the signer signs into a
+// force-command — divergence here is a security bug, not a style issue.
+func BuildElevatedCommand(prefix, command string) string {
+	return fmt.Sprintf("%s -- /bin/sh -c %s", prefix, ShellQuote(command))
 }
 
-// shellQuote wraps s in single quotes, escaping any internal single quotes
-// (replacing ' with '\”).
-func shellQuote(s string) string {
+// ShellQuote wraps s in single quotes, escaping any internal single quotes
+// (replacing ' with '\”). It is the single shell-quoting implementation shared
+// by the signer's one-shot force-command and the broker's session/file-transfer
+// paths; strings.ReplaceAll preserves the input bytes exactly (including invalid
+// UTF-8), which a rune-by-rune copy would silently mangle.
+func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
@@ -718,9 +724,10 @@ func sudoUserAllowed(allowed []string, user string) bool {
 	return false
 }
 
-// groupsIntersect reports whether hostGroups and userGroups share at least one
-// group. A host with no groups is not accessible via per-user RBAC.
-func groupsIntersect(hostGroups, userGroups []string) bool {
+// GroupsIntersect reports whether hostGroups and userGroups share at least one
+// group. A host with no groups is not accessible via per-user RBAC. Exported as
+// the single RBAC group-intersection used by both the signer and the broker.
+func GroupsIntersect(hostGroups, userGroups []string) bool {
 	for _, hg := range hostGroups {
 		for _, ug := range userGroups {
 			if hg == ug {

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -437,6 +437,12 @@ func TestHostSetForCallerSharedHost(t *testing.T) {
 	}
 }
 
+// TestShellQuote pins the byte-for-byte output of the single shell-quoting
+// implementation shared by the signer's force-command and the broker's session
+// and file-transfer paths. Single-quoting must neutralise every shell
+// metacharacter (spaces, $, backticks, ;, |, newline) and correctly escape
+// embedded single quotes — divergence here is an injection bug into a CA-signed
+// command line, not a style nit.
 func TestShellQuote(t *testing.T) {
 	t.Parallel()
 	cases := []struct{ in, want string }{
@@ -444,11 +450,34 @@ func TestShellQuote(t *testing.T) {
 		{"it's", `'it'\''s'`},
 		{"a'b'c", `'a'\''b'\''c'`},
 		{"", "''"},
+		{"a b c", "'a b c'"},                   // spaces
+		{"$HOME", "'$HOME'"},                   // variable expansion neutralised
+		{"`id`", "'`id`'"},                     // command substitution neutralised
+		{"a;b", "'a;b'"},                       // command separator
+		{"rm -rf / | cat", "'rm -rf / | cat'"}, // pipe
+		{"a\nb", "'a\nb'"},                     // embedded newline stays literal
+		{"echo café", "'echo café'"},           // multibyte rune preserved byte-for-byte
 	}
 	for _, tc := range cases {
-		got := shellQuote(tc.in)
+		got := ShellQuote(tc.in)
 		if got != tc.want {
-			t.Errorf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+			t.Errorf("ShellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBuildElevatedCommand locks the exact elevated command line the signer
+// signs into a force-command and the broker sends on the session channel.
+func TestBuildElevatedCommand(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ prefix, command, want string }{
+		{"sudo -n", "id", "sudo -n -- /bin/sh -c 'id'"},
+		{"sudo -n -u deploy", "ls /root", "sudo -n -u deploy -- /bin/sh -c 'ls /root'"},
+		{"sudo -n", "echo 'hi'", `sudo -n -- /bin/sh -c 'echo '\''hi'\'''`},
+	}
+	for _, c := range cases {
+		if got := BuildElevatedCommand(c.prefix, c.command); got != c.want {
+			t.Errorf("BuildElevatedCommand(%q, %q) = %q, want %q", c.prefix, c.command, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## What

Two security-sensitive helpers existed twice, broker↔signer:

1. **Elevation quoting** — `internal/signer`'s `buildElevatedCommand` + `shellQuote` were copied into `internal/broker/session.go` as `buildElevatedExecCommand` + `shellQuoteSession`, behind a comment claiming the copy avoided "a circular dependency". That comment was wrong: `internal/broker` already imports `internal/signer` throughout. This code builds the `sudo` line that ends up in a CA-signed `force-command` (one-shot) and on the session exec/file-transfer channel — divergence is a security bug, not a style nit.
2. **RBAC group intersection** — `groupsIntersect` was duplicated verbatim in `internal/signer/signer.go` and `internal/broker/engine.go`.

## Change

One implementation of each, exported from `internal/signer` and used by both:
- `signer.ShellQuote`, `signer.BuildElevatedCommand`, `signer.GroupsIntersect`
- broker `session.go` / `filetransfer.go` / `engine.go` / `k8s.go` call the shared functions; the broker copies and the incorrect circular-dependency comment are gone.

**Which quoting survived matters:** the signer's `strings.ReplaceAll` version preserves input bytes exactly; the broker's rune-by-rune copy would have rewritten invalid UTF-8 to U+FFFD. Kept the byte-preserving one. No behavior change for valid UTF-8 (all existing assertions hold).

## Tests

- Expanded the canonical quoting test in the owning package (`signer_test.go`) with the byte-for-byte edge cases: spaces, `$`, backticks, `;`, `|`, embedded newline, embedded single quotes, multibyte rune — plus a `BuildElevatedCommand` format test.
- Existing broker session/file-transfer tests keep their assertions, now pointed at the shared functions (proving no behavioral change).
- `make verify` green: gofmt, vet, race tests, govulncheck (0), docs `--strict`.

## Acceptance criteria

- [x] A single implementation of each helper (grep-verified); no lowercase copies remain.
- [x] New quoting edge-case tests in the owning package.
- [x] Existing session/signing tests pass (assertions unchanged).
- [x] `make verify` green.

Closes #179