### PR TITLE
feat(broker): warn at startup when remote mode ignores local-mode config

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "BROKER config. Two signing modes: (LOCAL) define ca_key and policy is inline in hosts (principal/source_address/allow_sudo/allow_pty/command_policy); (REMOTE) define the signer block and the CA key + policy live in the cmd/signer service — in that case hosts only need addr/user/host_key/jump and ca_key/principal/source_address are ignored.",
+  "_comment": "BROKER config. Two signing modes: (LOCAL) define ca_key and policy is inline in hosts (principal/source_address/allow_sudo/allow_pty/command_policy); (REMOTE) define the signer block and the CA key + policy live in the cmd/signer service — in that case hosts only need addr/user/host_key/jump and ca_key/principal/source_address are ignored — the broker logs a single startup warning naming any local-mode field (ca_key, command_policies, per-host policy) present in a remote-mode config, so a present-but-inactive policy is never mistaken for an enforced one.",
 
   "_signer_remoto_comment": "REMOTE mode. url points to the SIGNER directly, or to the CONTROL PLANE (cmd/control-plane) if human approval / guardrails are used — same protocol. approval_wait_seconds: if url is a control plane, how long the broker waits for an approval to be resolved (202 response); 0 = do not wait.",
   "_signer_remoto_example": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,15 @@
   keeps the CA private key in a running ssh-agent (YubiKey PIV / SoftHSM / TPM
   via `ssh-add -s`); `public_key_path` pins which agent key is the CA and the
   signer process never holds key bytes. Supports Ed25519 CAs (unlike AKV).
+- **Startup warning for ignored local-mode config (#178)** — when the broker
+  runs in remote mode (a `signer` block is set) but the config also carries
+  local-mode fields — `ca_key`/`ca_keys`, `command_policies`, or per-host policy
+  (`command_policy`, `allow_sudo`, `principal`, …) — it now logs a single
+  aggregated warning naming them (and the host(s) they sit on). Those fields are
+  silently ignored in remote mode (inventory and policy come from the signer);
+  the warning stops an operator from believing a local policy is enforced when
+  it is not (the same error class as the `_default` firewall gap, #82). Warning
+  only — no behavior change to signing or policy resolution.
 
 ### Changed
 - **Per-agent action-budgets framing (#123)** — the README and

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -858,6 +858,14 @@ it must be revoked before expiry.
    (e.g. `sign_caller` instead of `sign_callers`) is rejected at startup/reload
    rather than silently ignored, so a typo cannot quietly leave a setting open.
    `_*` comment keys and the reserved `_default` group are still accepted.
+10. **Remote mode warns about ignored local-mode fields:** unlike a typo, a
+    *known* field the active mode ignores still passes strict validation. When the
+    `signer` block is set (remote mode), a `ca_key`/`ca_keys`, `command_policies`,
+    or any per-host policy field (`command_policy`, `allow_sudo`, `principal`, …)
+    is dead weight — the host inventory and policy come from the signer. The
+    broker logs one aggregated startup warning naming them, so a present-but-
+    inactive policy is never mistaken for an enforced one (the same error class
+    as the `_default` firewall gap, #82).
 
 ### Per-agent identity: OAuth2 client_credentials
 

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -358,8 +358,109 @@ type Engine struct {
 // localCaller is the broker's identity toward a local signer.
 const localCaller = "local"
 
+// hostCommandPolicySet reports whether a per-host command_policy block was
+// actually written (any field set), as opposed to the zero value produced when
+// the key is absent.
+func hostCommandPolicySet(cp signer.CommandPolicy) bool {
+	return cp.Mode != "" || cp.Enforcement != "" || len(cp.Allow) > 0 ||
+		len(cp.Deny) > 0 || len(cp.RequireApproval) > 0 || cp.ShellParse
+}
+
+// ignoredRemoteFieldsWarning returns a single aggregated warning naming the
+// local-mode fields present in a remote-mode config (Signer block set) that the
+// broker silently ignores — the host inventory and all policy come from the
+// signer. It returns "" for local mode (Signer nil) or a clean remote config
+// (nothing ignored). Only fields an operator could mistake for an active local
+// control are reported (CA custody, command policies, per-host policy); the
+// bare host coordinates that remote mode also ignores are not, to keep a pure
+// remote config silent.
+func ignoredRemoteFieldsWarning(cfg *Config) string {
+	if cfg.Signer == nil {
+		return ""
+	}
+	var top []string
+	if cfg.CAKey != "" {
+		top = append(top, "ca_key")
+	}
+	if len(cfg.CAKeys) > 0 {
+		top = append(top, "ca_keys")
+	}
+	if len(cfg.CommandPolicies) > 0 {
+		top = append(top, "command_policies")
+	}
+	if len(cfg.GroupCommandPolicies) > 0 {
+		top = append(top, "group_command_policies")
+	}
+	if cfg.SourceAddress != "" {
+		top = append(top, "source_address")
+	}
+
+	names := make([]string, 0, len(cfg.Hosts))
+	for n := range cfg.Hosts {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var hostNotes []string
+	for _, name := range names {
+		h := cfg.Hosts[name]
+		var f []string
+		if h.Principal != "" {
+			f = append(f, "principal")
+		}
+		if h.SourceAddress != "" {
+			f = append(f, "source_address")
+		}
+		if hostCommandPolicySet(h.CommandPolicy) {
+			f = append(f, "command_policy")
+		}
+		if h.AllowSudo {
+			f = append(f, "allow_sudo")
+		}
+		if len(h.AllowedSudoUsers) > 0 {
+			f = append(f, "allowed_sudo_users")
+		}
+		if h.AllowPTY {
+			f = append(f, "allow_pty")
+		}
+		if h.AllowFileTransfer {
+			f = append(f, "allow_file_transfer")
+		}
+		if h.AllowAsBastion {
+			f = append(f, "allow_as_bastion")
+		}
+		if len(f) > 0 {
+			hostNotes = append(hostNotes, fmt.Sprintf("%s: %s", name, strings.Join(f, ", ")))
+		}
+	}
+
+	if len(top) == 0 && len(hostNotes) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("remote mode (signer block set): ignoring local-mode config —")
+	if len(top) > 0 {
+		fmt.Fprintf(&b, " %s", strings.Join(top, ", "))
+	}
+	if len(hostNotes) > 0 {
+		if len(top) > 0 {
+			b.WriteString(";")
+		}
+		fmt.Fprintf(&b, " policy fields on %d host(s) (%s)", len(hostNotes), strings.Join(hostNotes, "; "))
+	}
+	b.WriteString(". Host inventory and policy come from the signer.")
+	return b.String()
+}
+
 // NewEngine initialises the signer (local or remote) and the audit log.
 func NewEngine(cfg *Config) (*Engine, error) {
+	// A remote-mode config (Signer block set) that also carries local-mode fields
+	// silently ignores them: the host inventory and all policy come from the
+	// signer. Warn once at startup so an operator can never believe a local CA
+	// key or command policy is active when it is not (the #82 error class).
+	if w := ignoredRemoteFieldsWarning(cfg); w != "" {
+		log.Printf("warning: %s", w)
+	}
+
 	maxTTL := time.Duration(cfg.MaxTTLSeconds) * time.Second
 	if maxTTL <= 0 {
 		maxTTL = 5 * time.Minute

--- a/internal/broker/engine_test.go
+++ b/internal/broker/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -365,5 +366,77 @@ func TestHostRefreshStopsOnClose(t *testing.T) {
 			t.Fatalf("refresh goroutine did not stop (goroutines: %d > base %d)", runtime.NumGoroutine(), base)
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestIgnoredRemoteFieldsWarning covers the #178 startup diagnostic: a remote-
+// mode config that also carries local-mode fields must name them; a pure remote
+// or pure local config must stay silent.
+func TestIgnoredRemoteFieldsWarning(t *testing.T) {
+	t.Parallel()
+	remote := func() *Config { return &Config{Signer: &SignerClientConfig{URL: "https://signer:8443"}} }
+	cases := []struct {
+		name      string
+		cfg       *Config
+		wantEmpty bool
+		wantSub   []string // every substring must appear
+	}{
+		{
+			name:      "pure local (no signer) — every field is honoured",
+			cfg:       &Config{CAKey: "pki/ca", Hosts: map[string]HostConfig{"web01": {CommandPolicy: signer.CommandPolicy{Mode: "allowlist"}}}},
+			wantEmpty: true,
+		},
+		{
+			name:      "pure remote — nothing ignored",
+			cfg:       remote(),
+			wantEmpty: true,
+		},
+		{
+			name:    "remote + ca_key",
+			cfg:     func() *Config { c := remote(); c.CAKey = "pki/ca"; return c }(),
+			wantSub: []string{"ca_key", "Host inventory and policy come from the signer"},
+		},
+		{
+			name: "remote + host command_policy names host and field",
+			cfg: func() *Config {
+				c := remote()
+				c.Hosts = map[string]HostConfig{"web01": {CommandPolicy: signer.CommandPolicy{Mode: "allowlist", Allow: []string{"^id$"}}}}
+				return c
+			}(),
+			wantSub: []string{"web01", "command_policy"},
+		},
+		{
+			name: "remote + aggregated top-level and per-host fields",
+			cfg: func() *Config {
+				c := remote()
+				c.CAKey = "pki/ca"
+				c.CommandPolicies = map[string]signer.CommandPolicy{"lib": {Mode: "denylist"}}
+				c.Hosts = map[string]HostConfig{
+					"web01": {AllowSudo: true, CommandPolicy: signer.CommandPolicy{Mode: "allowlist"}},
+					"db01":  {Principal: "ops"},
+				}
+				return c
+			}(),
+			wantSub: []string{"ca_key", "command_policies", "2 host(s)", "web01: command_policy, allow_sudo", "db01: principal"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ignoredRemoteFieldsWarning(c.cfg)
+			if c.wantEmpty {
+				if got != "" {
+					t.Fatalf("want no warning, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("want a warning, got none")
+			}
+			for _, sub := range c.wantSub {
+				if !strings.Contains(got, sub) {
+					t.Errorf("warning missing %q\n  got: %s", sub, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

The broker config has two modes; **remote mode** (a `signer` block is set) silently ignores every local-mode field:
- `ca_key` / `ca_keys`
- `command_policies` / `group_command_policies`
- per-host policy: `command_policy`, `allow_sudo`, `allowed_sudo_users`, `allow_pty`, `allow_file_transfer`, `allow_as_bastion`, `principal`, `source_address`

`confcheck.Strict` rejects *unknown* keys, but these are **known** — present-but-ignored produced no signal. Same trap as #82: an operator writes a `command_policy` into a remote-mode `config.json`, believes the firewall is active, and the enforced policy is whatever the signer has.

## Change

`NewEngine` now emits **one aggregated** startup warning naming the ignored fields (and the hosts carrying per-host policy), e.g.:

```
warning: remote mode (signer block set): ignoring local-mode config — ca_key, command_policies; policy fields on 2 host(s) (db01: principal; web01: command_policy, allow_sudo). Host inventory and policy come from the signer.
```

A pure remote or pure local config stays silent. Warning only — **no change** to signing or policy resolution. Only fields an operator could mistake for an active local control are reported; bare host coordinates (`addr`/`user`/…) are not, to keep pure-remote configs quiet.

## Tests

`TestIgnoredRemoteFieldsWarning` (table): (a) remote + `ca_key` → names `ca_key`; (b) remote + host with `command_policy` → names the host and field; (c) pure remote and pure local → no warning; plus an aggregated top-level + per-host case.

`make verify` green (gofmt, vet, race, govulncheck 0, docs `--strict`). Documented in `config.example.json` `_comment` and `docs/OPERATIONS.md` §6.

## Acceptance criteria

- [x] Unit tests: remote+`ca_key`, remote+host `command_policy`, pure remote, pure local.
- [x] Single aggregated message, emitted on startup (the broker's only config-load path — it has no runtime config reload).
- [x] Notes in `config.example.json` and `docs/OPERATIONS.md`.
- [x] `make verify` green; no functional change to signing or policy resolution.

Closes #178