### PR TITLE
fix(broker): validate max_ttl_seconds at load in local mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,13 @@
   tarball ships it alongside the other binaries — matching the goreleaser
   release archive, which already did. Previously only `go install` or the
   release archive produced it, though `docs/OPERATIONS.md` documents running it.
+- **Local mode rejects an over-cap `max_ttl_seconds` at load (#138)** — the
+  single-binary (local) broker now validates the global `max_ttl_seconds`
+  against the 15m certificate cap at startup, mirroring `cmd/signer`, instead of
+  letting every issuance fail at the first sign request. (The dangling-jump,
+  unknown-group and per-host TTL checks were already enforced at load via
+  `CompileHostPolicies`; this closes the last divergence from the signer's
+  load-time validation.)
 
 ### Internal
 - **Audit chain verification moved into `internal/audit` (#177)** — the

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -719,6 +719,16 @@ func buildSigner(ctx context.Context, cfg *Config, maxTTL time.Duration) (signer
 		}
 		return r, r, nil
 	}
+	// Local mode: validate the config at load, mirroring cmd/signer's buildState,
+	// so a single-binary misconfiguration fails at startup rather than at the first
+	// sign request. CompileHostPolicies (below) already rejects dangling jumps,
+	// unknown groups and per-host max_ttl_seconds over the cap; the global
+	// max_ttl_seconds cap is the one buildState check the broker was missing — the
+	// in-process CA hard-rejects any TTL over 15m (ca.BuildAndSign), so a higher
+	// value would make every local issuance fail at request time.
+	if cfg.MaxTTLSeconds > 900 {
+		return nil, nil, fmt.Errorf("max_ttl_seconds %d exceeds the 900s (15m) certificate cap (local mode)", cfg.MaxTTLSeconds)
+	}
 	// Local mode: load CA key(s) and build the in-process signer.
 	defaultCA, groupCAs, err := ca.LoadGroupCAs(ctx, cfg.CAKey, cfg.CAKeys)
 	if err != nil {

--- a/internal/broker/engine_test.go
+++ b/internal/broker/engine_test.go
@@ -440,3 +440,19 @@ func TestIgnoredRemoteFieldsWarning(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildSignerRejectsExcessiveMaxTTLLocalMode covers the #138 gap: the
+// broker's local mode now rejects a global max_ttl_seconds over the 15m CA cap
+// at load (mirroring cmd/signer's buildState), instead of failing every sign
+// request. The check runs before the CA key is loaded, so no key file is needed.
+func TestBuildSignerRejectsExcessiveMaxTTLLocalMode(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{MaxTTLSeconds: 1200} // local mode (no Signer), 20m > the 15m cap
+	_, _, err := buildSigner(context.Background(), cfg, 20*time.Minute)
+	if err == nil {
+		t.Fatal("local mode with max_ttl_seconds > 900 must be rejected at load")
+	}
+	if !strings.Contains(err.Error(), "max_ttl_seconds") || !strings.Contains(err.Error(), "900") {
+		t.Errorf("error should name the offending field and the cap, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

`cmd/signer`'s `buildState` rejects a global `max_ttl_seconds` above the 15m certificate cap at load. The broker's single-binary **local** mode did not — the misconfiguration surfaced only as a failure on the **first sign request** (the in-process CA hard-rejects any TTL over 15m in `ca.BuildAndSign`).

This adds the same check to `buildSigner`'s local path, before the CA key is loaded, so a single-binary misconfiguration fails at startup.

## Scope note

The issue's premise ("the broker's local mode does not validate") is now largely covered: `LoadConfig` already runs `confcheck.Strict`, and `buildSigner` already runs `signer.CompileHostPolicies`, which rejects **dangling jumps**, unknown group references, bad policy regexes, and **per-host** `max_ttl_seconds` over the cap. The one `buildState` check the broker was still missing is the **global** `max_ttl_seconds` cap — this PR adds exactly that, closing the last divergence from the signer's load-time validation.

## Tests

`TestBuildSignerRejectsExcessiveMaxTTLLocalMode`: local mode + `max_ttl_seconds: 1200` → rejected at load, error names the field and the 900s cap. (Runs before CA-key load, so no key fixture needed.)

`make verify` green: gofmt, vet, race, govulncheck (0), docs `--strict`.

Closes #138