### PR TITLE
chore: re-establish CODING_STYLE §6 (80-line limit) + unify toolError

### DIFF
--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -210,6 +210,8 @@ func cmdHost(args []string) {
 }
 
 func cmdHostAdd(args []string) {
+	// codingstyle:long-function: one CLI command — flag parsing, validation and
+	// the config mutation are a single cohesive unit.
 	fs := flag.NewFlagSet("host add", flag.ExitOnError)
 	name := fs.String("name", "", "logical host name (required)")
 	addr := fs.String("addr", "", "host:port of the SSH server (required)")
@@ -1527,6 +1529,8 @@ func cmdAuditTail(args []string) {
 }
 
 func cmdAuditShow(args []string) {
+	// codingstyle:long-function: one CLI command — flag parsing plus a single
+	// filtering-and-printing loop over the log.
 	fs := flag.NewFlagSet("audit show", flag.ExitOnError)
 	logPath := fs.String("log", "", "path to audit log file (required)")
 	host := fs.String("host", "", "filter by host (substring match)")
@@ -1688,6 +1692,8 @@ func cmdAuditVerify(args []string) {
 // hash chain continues cleanly and the signer can start. It is a no-op unless
 // --apply is passed.
 func cmdAuditRepair(args []string) {
+	// codingstyle:long-function: one CLI recovery command — the detect → preview
+	// → apply flow is cohesive and reads worse split across helpers.
 	fs := flag.NewFlagSet("audit repair", flag.ExitOnError)
 	logPath := fs.String("log", "", "path to audit log file (required)")
 	keyPath := fs.String("key", "", "audit seed file: also verify the kept prefix's Ed25519 signatures before repairing (optional)")

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -499,6 +499,9 @@ func (s *server) requireApproval(w http.ResponseWriter, brokerCN string, req sig
 // handleResult serves the broker's polling for an approval request. When
 // approved, it forwards to the signer with approved=true and returns the cert.
 func (s *server) handleResult(w http.ResponseWriter, r *http.Request) {
+	// codingstyle:long-function: one HTTP handler for the approval-result
+	// callback (authorize poller → consume decision → respond); the ordering is
+	// clearer inline than split across helpers.
 	pollerCN, ok := s.signCaller(w, r)
 	if !ok {
 		return

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -510,6 +510,9 @@ func (s *server) reload() (int, error) {
 }
 
 func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
+	// codingstyle:long-function: the /v1/sign endpoint reads as one
+	// request→authorize→sign→respond flow; the security-critical ordering is
+	// clearer inline than split across helpers.
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -133,6 +133,19 @@
   session/file-transfer channel can no longer silently diverge. The retained
   quoting implementation preserves input bytes exactly (the broker's rune-copy
   variant would have mangled invalid UTF-8); no behavior change for valid input.
+- **Re-established the 80-line function limit (CODING_STYLE §6, #181)** — the
+  documented length check counted `func`-to-`func`, mis-attributing package-level
+  code to the preceding function (it reported impossibilities like a 327-line
+  `decideOne`). Replaced it with a brace-accurate check (`func` line → closing
+  `}`) that also skips `main()` and an explicit `// codingstyle:long-function:
+  <reason>` in-body marker. Refactored the genuinely over-long functions by
+  extracting cohesive helpers — `Register`/`RegisterK8s` (one function per MCP
+  tool), `OpenSession` (`openShellForMode`, `startSessionRecording`), `NewEngine`
+  (`initRemoteMode`, `openAuditLog`) — and marked the few cohesive/critical ones
+  (the `/v1/sign` handler, the marker-framed `ShellSession.Exec`, CLI commands)
+  with a reasoned exception. Also unified `mcpserver`'s tool-error construction
+  on the `toolError` helper. Pure refactor: tests unchanged, docgen output and
+  the MCP tool surface byte-identical.
 
 ## [v1.38.0] - 2026-07-04
 

--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -139,22 +139,42 @@ func buildSigner(...) (signer.Signer, hostFetcher, error) { ... }
 ## 6. Function length — 80 lines max
 
 No function body should exceed **80 lines** (blank lines and comments
-included). When a function grows past this limit:
+included), measured from the `func` line to its closing brace. When a function
+grows past this limit:
 
 1. Identify a cohesive sub-task within the function.
 2. Extract it into a named helper with a descriptive name.
 3. The helper must be independently testable or at least independently
    readable.
 
-Check with:
+Check with (prints every offender; empty output = clean):
 ```bash
-awk '/^func /{if(fname!="" && lines>80) printf "%s: %s (%d lines)\n",FILENAME,fname,lines
-             fname=$0; fstart=NR; lines=0} {lines++}
-     END     {if(fname!="" && lines>80) printf "%s: %s (%d lines)\n",FILENAME,fname,lines
-}' $(find . -name "*.go" -not -name "*_test.go" -not -path "*/vendor/*")
+awk '/^func /{name=$0; start=NR; infunc=1; exempt=($0 ~ /^func main\(/)}
+     infunc && /codingstyle:long-function/{exempt=1}
+     infunc && /^}/{if(!exempt && NR-start+1>80) printf "%s:%d: %s (%d lines)\n",FILENAME,start,name,NR-start+1; infunc=0}
+    ' $(find . -name "*.go" -not -name "*_test.go" -not -path "*/vendor/*")
 ```
 
-**Allowed exceptions:** `main()` startup functions and generated code.
+The check counts each top-level function from its `func` line to the `}` in
+column 0 that closes it, so package-level code after a function is no longer
+misattributed to it (the previous func-to-func heuristic over-counted).
+
+**Exceptions.** `main()` startup functions and generated code are always
+exempt. Any *other* function that genuinely must exceed the limit — a cohesive
+flow with no natural seam (e.g. a single HTTP handler, a marker-framed protocol,
+one CLI command) — carries an explicit marker comment **in its body**, which the
+check skips:
+
+```go
+func (s *server) handleSign(...) {
+	// codingstyle:long-function: the /v1/sign endpoint reads as one
+	// request→authorize→sign→respond flow; splitting it obscures the ordering.
+	...
+}
+```
+
+Prefer extraction; reach for the marker only when splitting would hurt
+readability, and always state the reason. A marker without a reason is a smell.
 
 ---
 

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -483,29 +483,9 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		ownIdentity = cn
 	}
 
-	seed, err := os.ReadFile(cfg.AuditKey)
-	if err != nil {
-		return nil, fmt.Errorf("reading audit key: %w", err)
-	}
-	if len(seed) < ed25519.SeedSize {
-		return nil, fmt.Errorf("audit key too short")
-	}
-	al, err := audit.Open(cfg.AuditLog, ed25519.NewKeyFromSeed(seed[:ed25519.SeedSize]))
+	al, redactor, err := openAuditLog(cfg)
 	if err != nil {
 		return nil, err
-	}
-
-	// An invalid redact pattern is a startup error (fail-closed), not a
-	// silently smaller rule set.
-	var redactor *redact.Redactor
-	if cfg.Redact != nil {
-		redactor, err = redact.New(cfg.Redact)
-		if err != nil {
-			return nil, fmt.Errorf("compiling redact config: %w", err)
-		}
-		if redactor != nil {
-			al.SetRedactor(redactor)
-		}
 	}
 
 	idle := time.Duration(cfg.SessionIdleSeconds) * time.Second
@@ -528,51 +508,91 @@ func NewEngine(cfg *Config) (*Engine, error) {
 	monitor.SetGaugeFunc("broker_sessions_active",
 		"Persistent SSH sessions currently open.", e.sessions.count)
 
-	// Remote mode: initial host load and start the refresh goroutine.
-	if fetcher != nil {
-		h, err := fetcher.FetchHosts(context.Background(), "")
-		if err != nil {
-			al.Close()
-			return nil, fmt.Errorf("initial host load from signer: %w", err)
-		}
-		e.hosts = h
-		log.Printf("hosts loaded from signer: %d entries", len(h))
-
-		// Optional k8s target: load the cluster list too. A signer with no
-		// clusters returns an empty map (the endpoint always exists), so a
-		// fetch error is a real failure, not a missing feature.
-		if cf, ok := fetcher.(clusterFetcher); ok {
-			cl, err := cf.FetchClusters(context.Background(), "")
-			if err != nil {
-				al.Close()
-				return nil, fmt.Errorf("initial cluster load from signer: %w", err)
-			}
-			e.clusterFetcher = cf
-			e.clusters = cl
-			if len(cl) > 0 {
-				log.Printf("k8s clusters loaded from signer: %d entries", len(cl))
-			}
-		}
-
-		refresh := time.Duration(cfg.HostsRefreshSeconds) * time.Second
-		if refresh <= 0 {
-			refresh = 5 * time.Minute
-		}
-		e.startHostRefresh(refresh)
-
-		// Kill switch (#117): poll the freeze set and force-close matching
-		// sessions. Shares refreshStop, so Close stops it too.
-		if rf, ok := fetcher.(revocationFetcher); ok {
-			e.revFetcher = rf
-			revPoll := time.Duration(cfg.RevocationPollSeconds) * time.Second
-			if revPoll <= 0 {
-				revPoll = 10 * time.Second
-			}
-			e.startRevocationPoll(revPoll)
-		}
+	// Remote mode: initial host/cluster load, then the refresh + kill-switch polls.
+	if err := e.initRemoteMode(fetcher); err != nil {
+		return nil, err
 	}
 
 	return e, nil
+}
+
+// initRemoteMode performs remote-mode startup: the initial host (and optional
+// cluster) load from the signer, then the background host-refresh and kill-switch
+// revocation-poll goroutines. On an initial-load failure it closes the audit log
+// and returns the error. A no-op in local mode (fetcher nil).
+func (e *Engine) initRemoteMode(fetcher hostFetcher) error {
+	if fetcher == nil {
+		return nil
+	}
+	h, err := fetcher.FetchHosts(context.Background(), "")
+	if err != nil {
+		e.auditLog.Close()
+		return fmt.Errorf("initial host load from signer: %w", err)
+	}
+	e.hosts = h
+	log.Printf("hosts loaded from signer: %d entries", len(h))
+
+	// Optional k8s target: load the cluster list too. A signer with no clusters
+	// returns an empty map (the endpoint always exists), so a fetch error is a
+	// real failure, not a missing feature.
+	if cf, ok := fetcher.(clusterFetcher); ok {
+		cl, err := cf.FetchClusters(context.Background(), "")
+		if err != nil {
+			e.auditLog.Close()
+			return fmt.Errorf("initial cluster load from signer: %w", err)
+		}
+		e.clusterFetcher = cf
+		e.clusters = cl
+		if len(cl) > 0 {
+			log.Printf("k8s clusters loaded from signer: %d entries", len(cl))
+		}
+	}
+
+	refresh := time.Duration(e.cfg.HostsRefreshSeconds) * time.Second
+	if refresh <= 0 {
+		refresh = 5 * time.Minute
+	}
+	e.startHostRefresh(refresh)
+
+	// Kill switch (#117): poll the freeze set and force-close matching sessions.
+	// Shares refreshStop, so Close stops it too.
+	if rf, ok := fetcher.(revocationFetcher); ok {
+		e.revFetcher = rf
+		revPoll := time.Duration(e.cfg.RevocationPollSeconds) * time.Second
+		if revPoll <= 0 {
+			revPoll = 10 * time.Second
+		}
+		e.startRevocationPoll(revPoll)
+	}
+	return nil
+}
+
+// openAuditLog opens the audit log with the Ed25519 seed key and installs the
+// optional secret redactor. An invalid redact pattern is a startup error
+// (fail-closed), not a silently smaller rule set.
+func openAuditLog(cfg *Config) (*audit.Log, *redact.Redactor, error) {
+	seed, err := os.ReadFile(cfg.AuditKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading audit key: %w", err)
+	}
+	if len(seed) < ed25519.SeedSize {
+		return nil, nil, fmt.Errorf("audit key too short")
+	}
+	al, err := audit.Open(cfg.AuditLog, ed25519.NewKeyFromSeed(seed[:ed25519.SeedSize]))
+	if err != nil {
+		return nil, nil, err
+	}
+	var redactor *redact.Redactor
+	if cfg.Redact != nil {
+		redactor, err = redact.New(cfg.Redact)
+		if err != nil {
+			return nil, nil, fmt.Errorf("compiling redact config: %w", err)
+		}
+		if redactor != nil {
+			al.SetRedactor(redactor)
+		}
+	}
+	return al, redactor, nil
 }
 
 // clientCertCN reads the CommonName from a PEM-encoded client certificate — the

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -335,36 +335,8 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 		connectivitySig: connectivitySig,
 	}
 
-	switch mode {
-	case "shell":
-		// shellCmd: if elevated, launch the shell directly under sudo.
-		shellCmd := "/bin/sh"
-		if elevPrefix != "" {
-			shellCmd = elevPrefix + " -- /bin/sh"
-		}
-		sh, err := sshrun.OpenShell(ctx, conn.Client, shellCmd)
-		if err != nil {
-			conn.Close()
-			e.auditE(audit.Entry{Caller: c.ID, Host: host, Serial: serial, Outcome: "error", Err: err.Error()})
-			return nil, fmt.Errorf("opening shell: %w", err)
-		}
-		s.shell = sh
-		// In an elevated shell the prefix is in the process; do not reapply per command.
-		s.elevationPrefix = ""
-
-	case "pty":
-		shellCmd := "/bin/sh"
-		if elevPrefix != "" {
-			shellCmd = elevPrefix + " -- /bin/sh"
-		}
-		sh, err := sshrun.OpenShellPTY(ctx, conn.Client, shellCmd, sshrun.ExecOptions{PTY: true})
-		if err != nil {
-			conn.Close()
-			e.auditE(audit.Entry{Caller: c.ID, Host: host, Serial: serial, Outcome: "error", Err: err.Error()})
-			return nil, fmt.Errorf("opening PTY shell: %w", err)
-		}
-		s.shell = sh
-		s.elevationPrefix = ""
+	if err := e.openShellForMode(ctx, s); err != nil {
+		return nil, err
 	}
 
 	if err := e.sessions.add(s); err != nil {
@@ -374,29 +346,7 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 	}
 
 	// Start recording for shell/pty sessions when a recording directory is set.
-	if e.cfg.SessionRecordingDir != "" && s.shell != nil {
-		castPath := filepath.Join(e.cfg.SessionRecordingDir, s.id+".cast")
-		rec, err := recording.Open(castPath, recording.Meta{
-			SessionID: s.id,
-			Caller:    c.ID,
-			Host:      host,
-			Serial:    serial,
-			PTY:       opts.PTY,
-			Term:      "xterm-256color",
-			Width:     220,
-			Height:    40,
-			StartedAt: s.created,
-		})
-		if err != nil {
-			log.Printf("warning: could not open recording file %s: %v", castPath, err)
-		} else {
-			if e.redactor != nil {
-				rec.SetRedactor(e.redactor)
-			}
-			s.recorder = rec
-			s.shell.SetRecorder(rec)
-		}
-	}
+	e.startSessionRecording(s)
 
 	e.auditE(audit.Entry{
 		Caller:    c.ID,
@@ -409,6 +359,76 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 		PTY:       opts.PTY,
 	})
 	return &SessionResult{SessionID: s.id, Serial: serial}, nil
+}
+
+// openShellForMode opens the shell/pty channel for a shell or pty session and
+// wires it onto s; for mode=exec it is a no-op. On failure it closes the
+// connection, audits the error, and returns it. Must be called after s.conn,
+// s.mode and s.elevationPrefix are set.
+func (e *Engine) openShellForMode(ctx context.Context, s *liveSession) error {
+	switch s.mode {
+	case "shell":
+		// shellCmd: if elevated, launch the shell directly under sudo.
+		shellCmd := "/bin/sh"
+		if s.elevationPrefix != "" {
+			shellCmd = s.elevationPrefix + " -- /bin/sh"
+		}
+		sh, err := sshrun.OpenShell(ctx, s.conn.Client, shellCmd)
+		if err != nil {
+			s.conn.Close()
+			e.auditE(audit.Entry{Caller: s.caller, Host: s.host, Serial: s.serial, Outcome: "error", Err: err.Error()})
+			return fmt.Errorf("opening shell: %w", err)
+		}
+		s.shell = sh
+		// In an elevated shell the prefix is in the process; do not reapply per command.
+		s.elevationPrefix = ""
+
+	case "pty":
+		shellCmd := "/bin/sh"
+		if s.elevationPrefix != "" {
+			shellCmd = s.elevationPrefix + " -- /bin/sh"
+		}
+		sh, err := sshrun.OpenShellPTY(ctx, s.conn.Client, shellCmd, sshrun.ExecOptions{PTY: true})
+		if err != nil {
+			s.conn.Close()
+			e.auditE(audit.Entry{Caller: s.caller, Host: s.host, Serial: s.serial, Outcome: "error", Err: err.Error()})
+			return fmt.Errorf("opening PTY shell: %w", err)
+		}
+		s.shell = sh
+		s.elevationPrefix = ""
+	}
+	return nil
+}
+
+// startSessionRecording opens an ASCIIcast recorder for a shell/pty session
+// when a recording directory is configured, wiring it (and any redactor) onto s.
+// A no-op for exec sessions (no shell) or when recording is disabled; a failure
+// to open the file is logged, not fatal.
+func (e *Engine) startSessionRecording(s *liveSession) {
+	if e.cfg.SessionRecordingDir == "" || s.shell == nil {
+		return
+	}
+	castPath := filepath.Join(e.cfg.SessionRecordingDir, s.id+".cast")
+	rec, err := recording.Open(castPath, recording.Meta{
+		SessionID: s.id,
+		Caller:    s.caller,
+		Host:      s.host,
+		Serial:    s.serial,
+		PTY:       s.pty,
+		Term:      "xterm-256color",
+		Width:     220,
+		Height:    40,
+		StartedAt: s.created,
+	})
+	if err != nil {
+		log.Printf("warning: could not open recording file %s: %v", castPath, err)
+		return
+	}
+	if e.redactor != nil {
+		rec.SetRedactor(e.redactor)
+	}
+	s.recorder = rec
+	s.shell.SetRecorder(rec)
 }
 
 // SessionExec executes command in an existing session, reusing the connection.

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -197,6 +197,18 @@ type sessionOpenOutput struct {
 // Register adds the 7 broker tools to the MCP server. callerFn provides the
 // caller identity for each invocation (audit and signer RBAC).
 func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitApprovals bool) {
+	registerExecute(srv, eng, callerFn, elicitApprovals)
+	registerListServers(srv, eng, callerFn)
+	registerSessionOpen(srv, eng, callerFn)
+	registerSessionExec(srv, eng, callerFn)
+	registerSessionClose(srv, eng, callerFn)
+	registerPutFile(srv, eng, callerFn)
+	registerGetFile(srv, eng, callerFn)
+}
+
+// registerExecute registers ssh_execute: one command on a host with an ephemeral
+// credential; with elicitApprovals it asks the human in the MCP client (#118).
+func registerExecute(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitApprovals bool) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ssh_execute",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
@@ -242,7 +254,10 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 		out := executeOutput{Stdout: res.Stdout, Stderr: res.Stderr, ExitCode: res.ExitCode, Serial: res.Serial, Warnings: res.Warnings}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderResult(out)}}}, out, nil
 	})
+}
 
+// registerListServers registers ssh_list_servers (read-only host capabilities).
+func registerListServers(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ssh_list_servers",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
@@ -272,7 +287,10 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 		out := listOutput{Servers: entries}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}}}, out, nil
 	})
+}
 
+// registerSessionOpen registers ssh_session_open (persistent connection).
+func registerSessionOpen(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name: "ssh_session_open",
 		Description: "Open a persistent SSH session that reuses the connection across commands. " +
@@ -287,17 +305,20 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 			"IMPORTANT: always close the session with ssh_session_close when done; an open session holds an SSH connection and is otherwise closed when the certificate that opened it expires, or after an idle or maximum-lifetime timeout (whichever comes first).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionOpenInput) (*mcp.CallToolResult, sessionOpenOutput, error) {
 		if err := validateInput(map[string]string{"server": in.Server, "mode": in.Mode, "sudo_user": in.SudoUser}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, sessionOpenOutput{}, nil
+			return toolError(err), sessionOpenOutput{}, nil
 		}
 		opts := broker.ExecOptions{Sudo: in.Sudo, SudoUser: in.SudoUser}
 		r, err := eng.OpenSession(ctx, callerFn(ctx), in.Server, in.Mode, in.TTLSeconds, opts)
 		if err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, sessionOpenOutput{}, nil
+			return toolError(err), sessionOpenOutput{}, nil
 		}
 		out := sessionOpenOutput{SessionID: r.SessionID, Serial: r.Serial}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("session_id=%s serial=%d", r.SessionID, r.Serial)}}}, out, nil
 	})
+}
 
+// registerSessionExec registers ssh_session_exec (preflighted per-command).
+func registerSessionExec(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ssh_session_exec",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
@@ -309,30 +330,36 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 			"Session state (current directory, environment variables) persists across calls when mode=shell or mode=pty.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionExecInput) (*mcp.CallToolResult, executeOutput, error) {
 		if err := validateInput(map[string]string{"session_id": in.SessionID, "command": in.Command}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, executeOutput{}, nil
+			return toolError(err), executeOutput{}, nil
 		}
 		res, err := eng.SessionExec(ctx, callerFn(ctx), in.SessionID, in.Command)
 		if err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, executeOutput{}, nil
+			return toolError(err), executeOutput{}, nil
 		}
 		out := executeOutput{Stdout: res.Stdout, Stderr: res.Stderr, ExitCode: res.ExitCode, Serial: res.Serial, Warnings: res.Warnings}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderResult(out)}}}, out, nil
 	})
+}
 
+// registerSessionClose registers ssh_session_close (release the connection).
+func registerSessionClose(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name: "ssh_session_close",
 		Description: "Close a persistent SSH session and release the connection. " +
 			"Always call when done working with a session; an unclosed session keeps its SSH connection until it is reaped when the opening certificate expires, or by the idle or maximum-lifetime timeout (whichever comes first).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionCloseInput) (*mcp.CallToolResult, okOutput, error) {
 		if err := validateInput(map[string]string{"session_id": in.SessionID}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, okOutput{}, nil
+			return toolError(err), okOutput{}, nil
 		}
 		if err := eng.CloseSession(callerFn(ctx), in.SessionID); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, okOutput{}, nil
+			return toolError(err), okOutput{}, nil
 		}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "closed"}}}, okOutput{OK: true}, nil
 	})
+}
 
+// registerPutFile registers ssh_put_file (write a file; allow_file_transfer).
+func registerPutFile(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ssh_put_file",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
@@ -346,25 +373,28 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 			"The content's sha256 is recorded in the audit log.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in putFileInput) (*mcp.CallToolResult, putFileOutput, error) {
 		if err := validateInput(map[string]string{"server": in.Server, "path": in.Path, "mode": in.Mode}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, putFileOutput{}, nil
+			return toolError(err), putFileOutput{}, nil
 		}
 		content := []byte(in.Content)
 		if in.ContentBase64 {
 			decoded, err := base64.StdEncoding.DecodeString(in.Content)
 			if err != nil {
-				return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: "invalid base64 content: " + err.Error()}}}, putFileOutput{}, nil
+				return toolError(fmt.Errorf("invalid base64 content: %w", err)), putFileOutput{}, nil
 			}
 			content = decoded
 		}
 		res, err := eng.PutFile(ctx, callerFn(ctx), in.Server, in.Path, content, in.Mode, in.TTLSeconds)
 		if err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, putFileOutput{}, nil
+			return toolError(err), putFileOutput{}, nil
 		}
 		out := putFileOutput{BytesWritten: res.Size, SHA256: res.SHA256, Serial: res.Serial, Warnings: res.Warnings}
 		text := fmt.Sprintf("wrote %d bytes to %s (sha256=%s) [serial=%d]", res.Size, in.Path, res.SHA256, res.Serial)
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, out, nil
 	})
+}
 
+// registerGetFile registers ssh_get_file (read a file; allow_file_transfer).
+func registerGetFile(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "ssh_get_file",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
@@ -376,11 +406,11 @@ func Register(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, elicitAp
 			"The content's sha256 is recorded in the audit log.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getFileInput) (*mcp.CallToolResult, getFileOutput, error) {
 		if err := validateInput(map[string]string{"server": in.Server, "path": in.Path}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, getFileOutput{}, nil
+			return toolError(err), getFileOutput{}, nil
 		}
 		res, err := eng.GetFile(ctx, callerFn(ctx), in.Server, in.Path, in.MaxBytes, in.TTLSeconds)
 		if err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, getFileOutput{}, nil
+			return toolError(err), getFileOutput{}, nil
 		}
 		out := getFileOutput{Size: res.Size, SHA256: res.SHA256, Serial: res.Serial, Warnings: res.Warnings}
 		var text string

--- a/internal/mcpserver/tools_k8s.go
+++ b/internal/mcpserver/tools_k8s.go
@@ -76,6 +76,16 @@ type k8sOutput struct {
 // deployment does not offer k8s tools to the model. The docgen tool calls it
 // unconditionally so the reference always documents the full surface.
 func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
+	registerK8sListClusters(srv, eng, callerFn)
+	registerK8sGet(srv, eng, callerFn)
+	registerK8sList(srv, eng, callerFn)
+	registerK8sLogs(srv, eng, callerFn)
+	registerK8sApply(srv, eng, callerFn)
+	registerK8sDelete(srv, eng, callerFn)
+}
+
+// registerK8sListClusters registers k8s_list_clusters (read-only cluster list).
+func registerK8sListClusters(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "k8s_list_clusters",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
@@ -91,7 +101,10 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 		}
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: sb.String()}}}, k8sListClustersOutput{Clusters: entries}, nil
 	})
+}
 
+// registerK8sGet registers k8s_get (read-only single object).
+func registerK8sGet(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "k8s_get",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
@@ -103,7 +116,10 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			Verb: signer.K8sVerbGet, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace, Name: in.Name,
 		}, nil, in.DryRun, broker.K8sExecuteOpts{})
 	})
+}
 
+// registerK8sList registers k8s_list (read-only list with selectors).
+func registerK8sList(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "k8s_list",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
@@ -115,7 +131,7 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 		// string; validate them like every other field (length cap + null-byte
 		// rejection) since runK8s only covers the K8sAction fields.
 		if err := validateInput(map[string]string{"label_selector": in.LabelSelector, "field_selector": in.FieldSelector}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+			return toolError(err), k8sOutput{}, nil
 		}
 		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
 			Verb: signer.K8sVerbList, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace,
@@ -123,7 +139,10 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			LabelSelector: in.LabelSelector, FieldSelector: in.FieldSelector, Limit: in.Limit,
 		}})
 	})
+}
 
+// registerK8sLogs registers k8s_logs (read-only pod logs).
+func registerK8sLogs(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "k8s_logs",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
@@ -133,7 +152,7 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 		// container is model-controlled and reaches the API-server query string;
 		// validate it like every other field (runK8s only covers K8sAction fields).
 		if err := validateInput(map[string]string{"container": in.Container}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+			return toolError(err), k8sOutput{}, nil
 		}
 		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
 			Verb: signer.K8sVerbLogs, Resource: "pods", Namespace: in.Namespace, Name: in.Pod,
@@ -141,7 +160,10 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			Container: in.Container, TailLines: in.TailLines, SinceSeconds: in.SinceSeconds,
 		}})
 	})
+}
 
+// registerK8sApply registers k8s_apply (destructive; may be approval-gated).
+func registerK8sApply(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "k8s_apply",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
@@ -151,13 +173,16 @@ func RegisterK8s(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 			"The manifest's apiVersion/kind/metadata must match the resource/group/namespace/name arguments.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in k8sApplyInput) (*mcp.CallToolResult, k8sOutput, error) {
 		if err := validateInput(map[string]string{"cluster": in.Cluster, "manifest": in.Manifest}); err != nil {
-			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+			return toolError(err), k8sOutput{}, nil
 		}
 		return runK8s(ctx, eng, callerFn, in.Cluster, signer.K8sAction{
 			Verb: signer.K8sVerbApply, Resource: in.Resource, Group: in.Group, Namespace: in.Namespace, Name: in.Name,
 		}, []byte(in.Manifest), in.DryRun, broker.K8sExecuteOpts{})
 	})
+}
 
+// registerK8sDelete registers k8s_delete (destructive; may be approval-gated).
+func registerK8sDelete(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "k8s_delete",
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)},
@@ -178,11 +203,11 @@ func runK8s(ctx context.Context, eng *broker.Engine, callerFn CallerFunc, cluste
 		"cluster": cluster, "resource": action.Resource, "group": action.Group,
 		"namespace": action.Namespace, "name": action.Name,
 	}); err != nil {
-		return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+		return toolError(err), k8sOutput{}, nil
 	}
 	res, err := eng.K8sExecute(ctx, callerFn(ctx), cluster, action, manifest, dryRun, opts)
 	if err != nil {
-		return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}, k8sOutput{}, nil
+		return toolError(err), k8sOutput{}, nil
 	}
 	if res.DryRun != nil {
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: renderDecision(res.DryRun)}}},

--- a/internal/ssh/shell.go
+++ b/internal/ssh/shell.go
@@ -334,6 +334,9 @@ func sendShellLine(out chan<- lineRes, done <-chan struct{}, lr lineRes) bool {
 //
 // In PTY mode Result.Stderr will be empty (streams are merged in Stdout).
 func (s *ShellSession) Exec(ctx context.Context, command string, timeout time.Duration) (*Result, error) {
+	// codingstyle:long-function: marker-framed exec protocol — the
+	// write-command → read-until-marker → parse-exit-code sequence is one
+	// indivisible unit; splitting it would obscure the framing invariants.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 


### PR DESCRIPTION
## What

`docs/CODING_STYLE.md` §6 mandates an 80-line function limit, but the documented `awk` check counted **`func`-to-`func`**, so it attributed all package-level code following a function to that function — reporting impossibilities like a **327-line `decideOne`** or a **264-line `newSessionID`**. The real offenders were hidden behind the noise.

This makes §6 mechanically true again.

## Changes

**1. Fixed the check** (§6): brace-accurate — counts each top-level function from its `func` line to the `}` in column 0. Skips `main()` and any function carrying an explicit in-body marker `// codingstyle:long-function: <reason>`. The exception mechanism is documented in §6.

**2. Refactored the genuinely over-long functions** (extraction of cohesive helpers, zero behavior change):
- `mcpserver.Register` (199→9) and `RegisterK8s` (95→7) — one `register*` function per MCP tool;
- `broker.OpenSession` (119→~65) — `openShellForMode` + `startSessionRecording`;
- `broker.NewEngine` (~115→~72) — `initRemoteMode` + `openAuditLog`.

**3. Marked the cohesive/critical ones** with a reasoned exception instead of splitting security-sensitive flow: the signer's `/v1/sign` `handleSign`, the marker-framed `ShellSession.Exec`, the control-plane `handleResult`, and the `cmdHostAdd`/`cmdAuditShow`/`cmdAuditRepair` CLI commands.

**4. Unified `toolError`** in `mcpserver`: replaced the ~17 inline `IsError: true` constructions with the existing `toolError` helper (only the helper itself now constructs the literal).

## Verification

- The fixed §6 check prints **nothing** (clean) across the repo.
- `make verify` green: gofmt, vet, **race** tests, govulncheck (0), docs `--strict`.
- **docgen output unchanged** and the **MCP tool surface byte-identical** — the tool Names/Descriptions were preserved verbatim, proving the `Register`/`RegisterK8s` split changed no behavior.
- Existing tests pass with no assertion changes.

Per the maintainer's steer on the approach (fix the check + refactor the accidental cases + reasoned exceptions for the cohesive/critical ones).

Closes #181