### PR TITLE
feat(broker-ctl): doctor --security production-hardening preflight

### DIFF
--- a/cmd/broker-ctl/doctor.go
+++ b/cmd/broker-ctl/doctor.go
@@ -1,0 +1,284 @@
+package main
+
+// broker-ctl doctor --security is an offline production-hardening preflight. It
+// reads the local config files — no keys, no network — and checks them against
+// the deploy/README.md production checklist, printing PASS / WARN / FAIL with a
+// one-line fix for each finding. Exit code 1 if any FAIL. The partial structs
+// below decode only the checked fields; unknown keys (and `_comment` keys) are
+// ignored, so the check never fails on the rest of a real config.
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+const (
+	docPASS = "PASS"
+	docWARN = "WARN"
+	docFAIL = "FAIL"
+)
+
+// doctorFinding is one checklist result. fix is the one-line remediation (empty
+// for PASS).
+type doctorFinding struct {
+	level string
+	check string
+	fix   string
+}
+
+type doctorCAKey struct {
+	Type string `json:"type"`
+}
+
+type doctorCaller struct {
+	AllowedGroups []string `json:"allowed_groups"`
+}
+
+type doctorSigner struct {
+	Callers             map[string]json.RawMessage `json:"callers"`
+	SignRateLimitPerMin int                        `json:"sign_rate_limit_per_min"`
+	CAKey               string                     `json:"ca_key"`
+	CAKeys              map[string]doctorCAKey     `json:"ca_keys"`
+	StateDB             string                     `json:"state_db"`
+	MonitorListen       string                     `json:"monitor_listen"`
+	Redact              *json.RawMessage           `json:"redact"`
+}
+
+type doctorBroker struct {
+	Signer        *json.RawMessage `json:"signer"`
+	Redact        *json.RawMessage `json:"redact"`
+	MonitorListen string           `json:"monitor_listen"`
+}
+
+type doctorApproval struct {
+	Callers []string `json:"callers"`
+}
+
+type doctorControlPlane struct {
+	SignCallers   []string         `json:"sign_callers"`
+	Approval      *doctorApproval  `json:"approval"`
+	StateDB       string           `json:"state_db"`
+	MonitorListen string           `json:"monitor_listen"`
+	Redact        *json.RawMessage `json:"redact"`
+}
+
+func cmdDoctor(args []string) {
+	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
+	security := fs.Bool("security", false, "run the security / production-hardening preflight")
+	signerPath := fs.String("signer", "", "path to signer.json")
+	brokerPath := fs.String("broker", "", "path to the broker config.json")
+	cpPath := fs.String("control-plane", "", "path to control-plane.json")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl doctor --security [--signer f] [--broker f] [--control-plane f]")
+		fmt.Fprintln(os.Stderr, "\nOffline production-hardening preflight against the config files (no keys, no network).")
+		fmt.Fprintln(os.Stderr, "Exit code 1 if any check FAILs.")
+		fs.PrintDefaults()
+	}
+	must(fs.Parse(args))
+	if !*security {
+		fs.Usage()
+		os.Exit(2)
+	}
+	if *signerPath == "" && *brokerPath == "" && *cpPath == "" {
+		fatalf("provide at least one of --signer, --broker, --control-plane")
+	}
+
+	var findings []doctorFinding
+	if *signerPath != "" {
+		findings = append(findings, checkSignerConfig(*signerPath)...)
+	}
+	if *brokerPath != "" {
+		findings = append(findings, checkBrokerConfig(*brokerPath)...)
+	}
+	if *cpPath != "" {
+		findings = append(findings, checkControlPlaneConfig(*cpPath)...)
+	}
+	if printDoctorFindings(findings) > 0 {
+		os.Exit(1)
+	}
+}
+
+// loadDoctorJSON reads path and decodes only the fields present in v, ignoring
+// unknown keys. Comments are the legacy `_comment` string keys, which are just
+// ignored object members — no stripping needed.
+func loadDoctorJSON(path string, v any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
+func checkSignerConfig(path string) []doctorFinding {
+	var sc doctorSigner
+	if err := loadDoctorJSON(path, &sc); err != nil {
+		return []doctorFinding{{docFAIL, "signer.json readable/parseable", fmt.Sprintf("could not read %s: %v", path, err)}}
+	}
+	var f []doctorFinding
+	add := func(level, check, fix string) { f = append(f, doctorFinding{level, check, fix}) }
+
+	// callers._default default-deny for unknown broker CNs.
+	if len(sc.Callers) == 0 {
+		add(docWARN, "callers RBAC configured", "no `callers` block — every authenticated broker CN can request/sign ALL hosts. Add `callers` with a `_default: {\"allowed_groups\": []}` entry to default-deny unlisted CNs.")
+	} else if raw, ok := sc.Callers["_default"]; !ok {
+		add(docFAIL, "callers._default default-deny", "`callers` is set but has no `_default` — an unlisted broker CN sees and signs ALL hosts. Add `\"_default\": {\"allowed_groups\": []}`.")
+	} else {
+		var d doctorCaller
+		_ = json.Unmarshal(raw, &d)
+		if len(d.AllowedGroups) == 0 {
+			add(docPASS, "callers._default default-deny", "")
+		} else {
+			add(docWARN, "callers._default default-deny", fmt.Sprintf("`_default` grants groups %v to every unlisted CN — that is not default-deny. Set `allowed_groups` to [] unless intentional.", d.AllowedGroups))
+		}
+	}
+
+	// CA custody.
+	caType := ""
+	if d, ok := sc.CAKeys["_default"]; ok {
+		caType = d.Type
+	} else if sc.CAKey != "" {
+		caType = "pem" // legacy ca_key is a local PEM path
+	}
+	switch caType {
+	case "":
+		add(docWARN, "CA custody configured", "no `ca_key`/`ca_keys` — the signer has no CA to sign with.")
+	case "pem":
+		add(docFAIL, "CA custody not local PEM", "CA custody is `pem` (a local key file). Use `akv` (Azure Key Vault) or `agent` (ssh-agent/hardware) in production; `pem` is lab-only.")
+	default:
+		add(docPASS, "CA custody not local PEM", "")
+	}
+
+	f = append(f,
+		rateLimitFinding(sc.SignRateLimitPerMin),
+		stateDBFinding(sc.StateDB, "signer"),
+		redactFinding(sc.Redact != nil, "signer.json"),
+		monitorFinding(sc.MonitorListen, "signer"),
+	)
+	return f
+}
+
+func checkBrokerConfig(path string) []doctorFinding {
+	var bc doctorBroker
+	if err := loadDoctorJSON(path, &bc); err != nil {
+		return []doctorFinding{{docFAIL, "config.json readable/parseable", fmt.Sprintf("could not read %s: %v", path, err)}}
+	}
+	return []doctorFinding{
+		redactFinding(bc.Redact != nil, "config.json"),
+		monitorFinding(bc.MonitorListen, "broker"),
+	}
+}
+
+func checkControlPlaneConfig(path string) []doctorFinding {
+	var cp doctorControlPlane
+	if err := loadDoctorJSON(path, &cp); err != nil {
+		return []doctorFinding{{docFAIL, "control-plane.json readable/parseable", fmt.Sprintf("could not read %s: %v", path, err)}}
+	}
+	approvers := 0
+	if cp.Approval != nil {
+		approvers = len(cp.Approval.Callers)
+	}
+	var f []doctorFinding
+	switch {
+	case approvers > 0 && len(cp.SignCallers) == 0:
+		f = append(f, doctorFinding{docFAIL, "sign_callers restricts the signing path", "`approval.callers` is set but `sign_callers` is empty — an approver certificate (signed by the same client_ca) could originate signing requests. List the broker CNs in `sign_callers`."})
+	case approvers > 0:
+		f = append(f, doctorFinding{docPASS, "sign_callers restricts the signing path", ""})
+	default:
+		f = append(f, doctorFinding{docPASS, "broker/approver separation (no approvers configured)", ""})
+	}
+	f = append(f, stateDBFinding(cp.StateDB, "control-plane"))
+	f = append(f, redactFinding(cp.Redact != nil, "control-plane.json"))
+	f = append(f, monitorFinding(cp.MonitorListen, "control-plane"))
+	return f
+}
+
+func rateLimitFinding(perMin int) doctorFinding {
+	if perMin <= 0 {
+		return doctorFinding{docWARN, "sign_rate_limit_per_min set", "not set — no per-caller signing cap (gap #4). Size `sign_rate_limit_per_min` to the busiest legitimate broker's rate."}
+	}
+	return doctorFinding{docPASS, "sign_rate_limit_per_min set", ""}
+}
+
+func stateDBFinding(path, svc string) doctorFinding {
+	if strings.TrimSpace(path) == "" {
+		return doctorFinding{docWARN, svc + " state_db set", "not set — runtime grants/waivers/freezes are in-memory and lost on restart (a freeze silently unfreezes). Set `state_db` to a persistent path."}
+	}
+	return doctorFinding{docPASS, svc + " state_db set", ""}
+}
+
+func redactFinding(present bool, file string) doctorFinding {
+	if !present {
+		return doctorFinding{docWARN, file + " redact enabled", "no `redact` block — secrets in commands are stored verbatim in audit logs/recordings/notifications. Add `\"redact\": {}` for the built-in patterns."}
+	}
+	return doctorFinding{docPASS, file + " redact enabled", ""}
+}
+
+func monitorFinding(addr, svc string) doctorFinding {
+	if strings.TrimSpace(addr) == "" {
+		return doctorFinding{docPASS, svc + " monitor_listen not public (disabled)", ""}
+	}
+	if listenIsPublic(addr) {
+		return doctorFinding{docFAIL, svc + " monitor_listen not public", fmt.Sprintf("`monitor_listen` %q is public — /metrics and /healthz are unauthenticated. Bind to 127.0.0.1 or a private scrape interface.", addr)}
+	}
+	return doctorFinding{docPASS, svc + " monitor_listen not public", ""}
+}
+
+// listenIsPublic reports whether a listen address is reachable from outside the
+// host: an unspecified bind (0.0.0.0/::/empty host) or a globally-routable IP.
+// Loopback, RFC1918/ULA private, and link-local addresses are treated as safe.
+func listenIsPublic(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if host == "" {
+		return true // ":9160" binds every interface
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return !strings.EqualFold(host, "localhost")
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return false
+	}
+	return true // unspecified (0.0.0.0/::) or a specific global address
+}
+
+// printDoctorFindings prints the findings grouped by level and returns the FAIL
+// count. FAILs first (with fixes), then WARNs, then a PASS count.
+func printDoctorFindings(findings []doctorFinding) int {
+	var fails, warns, passes int
+	for _, f := range findings {
+		switch f.level {
+		case docFAIL:
+			fails++
+		case docWARN:
+			warns++
+		default:
+			passes++
+		}
+	}
+	for _, lvl := range []string{docFAIL, docWARN} {
+		for _, f := range findings {
+			if f.level == lvl {
+				fmt.Printf("[%s] %s\n", f.level, f.check)
+				if f.fix != "" {
+					fmt.Printf("       fix: %s\n", f.fix)
+				}
+			}
+		}
+	}
+	fmt.Printf("\n%d PASS, %d WARN, %d FAIL\n", passes, warns, fails)
+	if fails == 0 && warns == 0 {
+		fmt.Println("security preflight clean.")
+	} else if fails == 0 {
+		fmt.Println("no failures; review the warnings above.")
+	} else {
+		fmt.Println("FAILED: fix the items above before running in production.")
+	}
+	return fails
+}

--- a/cmd/broker-ctl/doctor_test.go
+++ b/cmd/broker-ctl/doctor_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListenIsPublic(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"", true},                  // empty host after split failure → treated as bare host "" → public
+		{":9160", true},             // all interfaces
+		{"0.0.0.0:9160", true},      // unspecified
+		{"[::]:9160", true},         // unspecified v6
+		{"127.0.0.1:9160", false},   // loopback
+		{"[::1]:9160", false},       // loopback v6
+		{"localhost:9160", false},   // hostname loopback
+		{"10.0.0.5:9160", false},    // RFC1918 private
+		{"192.168.1.9:9160", false}, // private
+		{"172.16.4.4:9160", false},  // private
+		{"8.8.8.8:9160", true},      // global
+		{"203.0.113.7:9160", true},  // global
+	}
+	for _, c := range cases {
+		if got := listenIsPublic(c.addr); got != c.want {
+			t.Errorf("listenIsPublic(%q) = %v, want %v", c.addr, got, c.want)
+		}
+	}
+}
+
+// writeTmp writes content to a temp file and returns its path.
+func writeTmp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// findByCheck returns the finding whose check contains sub, or a zero finding.
+func findByCheck(f []doctorFinding, sub string) doctorFinding {
+	for _, x := range f {
+		if strings.Contains(x.check, sub) {
+			return x
+		}
+	}
+	return doctorFinding{}
+}
+
+func TestCheckSignerConfig(t *testing.T) {
+	t.Parallel()
+
+	// A hardened signer config: default-deny, rate limit, KMS custody, state_db,
+	// redact, private monitor. No FAIL, no WARN.
+	good := writeTmp(t, "signer.json", `{
+		"callers": {"broker-1": {"allowed_groups": ["web"]}, "_default": {"allowed_groups": []}},
+		"sign_rate_limit_per_min": 120,
+		"ca_keys": {"_default": {"type": "akv", "vault_url": "x", "key_name": "y"}},
+		"state_db": "/var/lib/x/state.db",
+		"redact": {},
+		"monitor_listen": "127.0.0.1:9160"
+	}`)
+	f := checkSignerConfig(good)
+	for _, x := range f {
+		if x.level == docFAIL || x.level == docWARN {
+			t.Errorf("hardened config produced %s on %q (fix: %s)", x.level, x.check, x.fix)
+		}
+	}
+
+	// An open lab config: callers without _default, pem custody, public monitor,
+	// no rate limit/state_db/redact.
+	bad := writeTmp(t, "bad.json", `{
+		"callers": {"broker-1": {"allowed_groups": ["web"]}},
+		"ca_key": "pki/ssh_ca",
+		"monitor_listen": "0.0.0.0:9160"
+	}`)
+	fb := checkSignerConfig(bad)
+	if got := findByCheck(fb, "_default"); got.level != docFAIL {
+		t.Errorf("callers without _default must FAIL, got %q", got.level)
+	}
+	if got := findByCheck(fb, "CA custody"); got.level != docFAIL {
+		t.Errorf("pem custody must FAIL, got %q", got.level)
+	}
+	if got := findByCheck(fb, "monitor_listen"); got.level != docFAIL {
+		t.Errorf("public monitor must FAIL, got %q", got.level)
+	}
+	if got := findByCheck(fb, "rate_limit"); got.level != docWARN {
+		t.Errorf("missing rate limit must WARN, got %q", got.level)
+	}
+}
+
+func TestCheckControlPlaneConfig(t *testing.T) {
+	t.Parallel()
+
+	// Approvers present but no sign_callers → an approver could sign. FAIL.
+	danger := writeTmp(t, "cp.json", `{
+		"approval": {"callers": ["broker-admin"]},
+		"sign_callers": []
+	}`)
+	if got := findByCheck(checkControlPlaneConfig(danger), "sign_callers"); got.level != docFAIL {
+		t.Errorf("approvers without sign_callers must FAIL, got %q", got.level)
+	}
+
+	// Approvers present with an explicit sign_callers allowlist → PASS.
+	safe := writeTmp(t, "cp2.json", `{
+		"approval": {"callers": ["broker-admin"]},
+		"sign_callers": ["broker-1"],
+		"state_db": "/var/lib/x/cp.db",
+		"redact": {},
+		"monitor_listen": "127.0.0.1:9170"
+	}`)
+	fs := checkControlPlaneConfig(safe)
+	if got := findByCheck(fs, "sign_callers"); got.level != docPASS {
+		t.Errorf("approvers with sign_callers must PASS, got %q", got.level)
+	}
+	for _, x := range fs {
+		if x.level == docFAIL {
+			t.Errorf("hardened control-plane produced FAIL on %q", x.check)
+		}
+	}
+}

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -96,6 +96,8 @@ func main() {
 		cmdRevocations(args[1:])
 	case "session":
 		cmdSession(args[1:])
+	case "doctor":
+		cmdDoctor(args[1:])
 	case "version":
 		cmdVersion(args[1:])
 	case "help":
@@ -172,6 +174,7 @@ Commands:
   broker-ctl unfreeze      (--caller cn|--end-user u|--session-id id|--serial n)  Release a frozen subject (mTLS)
   broker-ctl revocations   [--json]                         List currently frozen subjects (mTLS)
   broker-ctl session kill  <session-id> [--reason r]        Force-close a live session (freezes its session_id, mTLS)
+  broker-ctl doctor --security [--signer f --broker f --control-plane f]  Offline production-hardening preflight over the config files (no keys/network)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -361,6 +361,16 @@ func buildState(ctx context.Context, cfg *Config, grants signer.GrantProvider) (
 	if cfg.MaxTTLSeconds > 900 {
 		return nil, fmt.Errorf("max_ttl_seconds %d exceeds the 900s (15m) certificate cap", cfg.MaxTTLSeconds)
 	}
+	// Production-hardening nudges for the two most common fail-open omissions
+	// (broker-ctl doctor --security checks the full deploy/README checklist).
+	if len(cfg.Callers) > 0 {
+		if _, ok := cfg.Callers["_default"]; !ok {
+			log.Printf("warning: callers is set but has no _default — unlisted broker CNs can request all hosts; add \"_default\": {\"allowed_groups\": []} for default-deny (see: broker-ctl doctor --security)")
+		}
+	}
+	if cfg.SignRateLimitPerMin <= 0 {
+		log.Printf("warning: sign_rate_limit_per_min is not set — no per-caller signing cap (see: broker-ctl doctor --security)")
+	}
 	// Compile + validate the host policies before touching anything so an invalid
 	// reload (bad command_policy regex, unknown mode, dangling jump, unknown group
 	// policy reference) is rejected up front and the previous good state is

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -127,6 +127,15 @@ AZURE_CLIENT_SECRET=...
 
 ## Production checklist
 
+The config-file items below are automated by **`broker-ctl doctor --security`**
+— an offline preflight (no keys, no network) that prints PASS/WARN/FAIL with a
+one-line fix each and exits non-zero on any FAIL:
+
+```bash
+broker-ctl doctor --security \
+  --signer signer.json --broker config.json --control-plane control-plane.json
+```
+
 - [ ] `signer.json` `callers` has `"_default": {"allowed_groups": []}` — default-deny for unknown broker CNs.
 - [ ] `sign_rate_limit_per_min` set (size to the busiest legitimate broker).
 - [ ] CA custody is `akv` (or another KMS); `pem` only in a lab.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,15 @@
   IPs make `source_address` pinning precise. States exactly which controls are
   host-enforced (one-shot `force-command`) versus broker-enforced (session
   command filtering, gap #1).
+- **`broker-ctl doctor --security` preflight (#134)** — an offline
+  production-hardening check (no keys, no network) that reads the local config
+  files and reports PASS/WARN/FAIL with a one-line fix for each item of the
+  `deploy/README.md` checklist: `callers._default` default-deny,
+  `sign_rate_limit_per_min`, CA custody not local-PEM, `state_db`, `redact`,
+  `monitor_listen` not public, and the control-plane `sign_callers` allowlist
+  when approvers exist. Exits non-zero on any FAIL. The signer additionally logs
+  a startup warning when `callers` has no `_default` or the sign rate limit is
+  unset — the two most common fail-open omissions.
 
 ### Changed
 - **Per-agent action-budgets framing (#123)** — the README and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,6 +40,7 @@ Commands:
   broker-ctl unfreeze      (--caller cn|--end-user u|--session-id id|--serial n)  Release a frozen subject (mTLS)
   broker-ctl revocations   [--json]                         List currently frozen subjects (mTLS)
   broker-ctl session kill  <session-id> [--reason r]        Force-close a live session (freezes its session_id, mTLS)
+  broker-ctl doctor --security [--signer f --broker f --control-plane f]  Offline production-hardening preflight over the config files (no keys/network)
   broker-ctl version       [--verbose]                      Print the build version
 
 Global options:


### PR DESCRIPTION
## What

`broker-ctl doctor --security` — an **offline** preflight (no keys, no network) that reads the local config files and checks them against the `deploy/README.md` production checklist, printing **PASS / WARN / FAIL** with a one-line fix each, and exiting non-zero on any FAIL.

```
broker-ctl doctor --security --signer signer.json --broker config.json --control-plane control-plane.json
```

Checks:
- **signer**: `callers._default` default-deny, `sign_rate_limit_per_min`, CA custody not local-PEM (`akv`/`agent`), `state_db`, `redact`, `monitor_listen` not public
- **broker**: `redact`, `monitor_listen` not public
- **control-plane**: `sign_callers` allowlist **when approvers exist** (else an approver cert could originate signing requests), `state_db`, `redact`, `monitor_listen` not public

Severity split: security holes (open RBAC, PEM custody in prod, public monitor, approver-can-sign) are **FAIL**; hardening/durability gaps (rate limit, `state_db`, `redact`) are **WARN**.

The partial config structs decode only the checked fields, so the check ignores the rest of a real config and the legacy `_comment` keys — no strict-schema coupling.

**Paired startup warning:** the signer now logs a warning at load when `callers` has no `_default` or `sign_rate_limit_per_min` is unset (the two most common fail-open omissions), pointing at the full doctor check.

## Example (against the shipped lab examples)

```
[FAIL] CA custody not local PEM
       fix: CA custody is `pem` … use `akv` or `agent` in production; `pem` is lab-only.
[WARN] signer state_db set …
9 PASS, 2 WARN, 1 FAIL
```

## Tests & verification

- `doctor_test.go`: `listenIsPublic` table (loopback/private/unspecified/global/v6), a hardened signer config (no FAIL/WARN), an open config (FAILs on `_default`/PEM/public monitor, WARNs on rate limit), and the control-plane approver↔`sign_callers` interaction.
- `make verify` green: gofmt, vet, race, govulncheck (0), docs `--strict`; `docs/reference/cli.md` regenerated to include `doctor`.

Closes #134