### PR TITLE
docs(quickstart): single-binary local-mode quickstart — first ssh_execute in <10 min

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This README is a landing page. The detail lives in focused, single-source docs:
 
 | Document | Contents |
 |---|---|
+| [QUICKSTART.md](docs/QUICKSTART.md) | First `ssh_execute` in under 10 minutes — single-binary local mode, no signer/PKI |
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Diagram, request flow, design decisions, sudo elevation, sessions, multi-CA |
 | [THREAT_MODEL.md](docs/THREAT_MODEL.md) | Actors, trust boundaries, security controls, and explicit non-goals/gaps |
 | [OPERATIONS.md](docs/OPERATIONS.md) | Runbook: startup, adding hosts, hot-reload, `broker-ctl`, PKI rotation, configs |
@@ -173,6 +174,12 @@ claude mcp add infrabroker -- docker run -i --rm -v /secure/path:/config \
 ```
 
 ## Quickstart
+
+**Fastest path (local, single binary):** [QUICKSTART.md](docs/QUICKSTART.md) takes
+you from `git clone` to your first `ssh_execute` in under 10 minutes with one
+binary and one `config.json` — no signer service, no PKI. The steps below set up
+the full **remote** stack (a separated signer); the containerised demo is under
+[Install](#install).
 
 ```bash
 # 1. Build (make injects the version from the git tag into every binary)

--- a/config.minimal.example.json
+++ b/config.minimal.example.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "MINIMAL local-mode config for the single-binary mcp-broker (stdio). In-process signing with a local CA — NO signer service and NO mTLS PKI. This is the on-ramp (see docs/QUICKSTART.md), not the production recommendation: a local PEM CA is lab/dev custody. Graduate to remote mode (config.example.json + signer.example.json) for separated CA custody, human approvals, and RBAC.",
+  "_files_comment": "Paths are relative to the broker's working directory; use absolute paths in a real install. audit_key is a >=32-byte Ed25519 seed: create it once with `head -c 32 /dev/urandom > audit.key`. ca_key is the SSH CA private key from `ssh-keygen -t ed25519 -f ssh_ca -N ''`.",
+  "audit_log": "audit.log",
+  "audit_key": "audit.key",
+  "ca_key": "ssh_ca",
+  "_hosts_comment": "One host you already reach over SSH. addr host:port; user the login account; host_key the line from `ssh-keyscan -t ed25519 <host>` (pins the server, prevents MITM); principal any label — it must be listed for `user` in the host's AuthorizedPrincipalsFile (see docs/QUICKSTART.md). command_policy is a small allowlist so the AI-action firewall is visible from the first command.",
+  "hosts": {
+    "myhost": {
+      "addr": "myhost.example.com:22",
+      "user": "deploy",
+      "host_key": "myhost.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...replace-with-ssh-keyscan-output...",
+      "principal": "infrabroker",
+      "command_policy": {
+        "mode": "allowlist",
+        "allow": [
+          "^uptime$",
+          "^df -h$",
+          "^systemctl status [a-zA-Z0-9._-]+$"
+        ]
+      }
+    }
+  }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,14 @@
   when approvers exist. Exits non-zero on any FAIL. The signer additionally logs
   a startup warning when `callers` has no `_default` or the sign rate limit is
   unset — the two most common fail-open omissions.
+- **Single-binary local-mode quickstart (#182)** — new
+  [`docs/QUICKSTART.md`](QUICKSTART.md) takes a newcomer from `git clone` to
+  their first policy-gated `ssh_execute` in under 10 minutes using one binary
+  (`mcp-broker`, stdio) and one `config.json` in local mode — no signer service,
+  no mTLS PKI. Ships a committed `config.minimal.example.json` (validated by the
+  confcheck anti-drift test), an MCP-client registration snippet, a `dry_run`
+  firewall demo, and a "when to move to remote mode" graduation section. Linked
+  from the README and mkdocs nav. Docs/examples only.
 
 ### Changed
 - **Per-agent action-budgets framing (#123)** — the README and

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,148 @@
+# Quickstart — first `ssh_execute` in under 10 minutes (local mode)
+
+The fastest path from `git clone` to your AI agent running its first policy-gated
+command on a host **you already reach over SSH** — one binary, one config file,
+no signer service and no mTLS PKI.
+
+This is **local (single-binary) mode**: the `mcp-broker` signs ephemeral SSH
+certificates in-process with a local CA. It is the on-ramp, **not** the
+production recommendation — a local PEM CA is lab/dev custody (the broker prints
+a warning to say so). When you want separated CA custody, human approvals, and
+RBAC, [graduate to remote mode](#when-to-move-to-remote-mode).
+
+Prerequisites: Go (to build), one Linux host you can already `ssh` into, and an
+MCP client (Claude Code / Claude Desktop / OpenCode).
+
+---
+
+## 1. Build the broker
+
+```bash
+git clone https://github.com/luisgf/infrabroker && cd infrabroker
+go build -o mcp-broker ./cmd/mcp-broker      # or: make build
+```
+
+## 2. Create the local CA and the audit key
+
+```bash
+mkdir -p ~/.infrabroker && cd ~/.infrabroker
+ssh-keygen -t ed25519 -f ssh_ca -N "" -C infrabroker-ca   # → ssh_ca (private) + ssh_ca.pub
+head -c 32 /dev/urandom > audit.key                       # 32-byte Ed25519 audit seed
+```
+
+Keep `ssh_ca` and `audit.key` private (`chmod 600`). `ssh_ca.pub` is the CA the
+hosts will trust.
+
+## 3. Enrol the target host (one paste per host)
+
+On the **target host's** `sshd`, trust your CA and authorise the certificate
+principal for the login account. As root on the host:
+
+```bash
+# a) install the CA public key you generated in step 2
+sudo install -m 0644 /path/to/ssh_ca.pub /etc/ssh/infrabroker_ca.pub
+
+# b) trust it, and map the cert principal to the login user
+sudo tee -a /etc/ssh/sshd_config >/dev/null <<'EOF'
+
+TrustedUserCAKeys /etc/ssh/infrabroker_ca.pub
+AuthorizedPrincipalsFile /etc/ssh/auth_principals/%u
+EOF
+
+# c) allow the "infrabroker" principal to log in as the user you'll use (here: deploy)
+sudo mkdir -p /etc/ssh/auth_principals
+echo infrabroker | sudo tee /etc/ssh/auth_principals/deploy
+
+sudo systemctl reload ssh    # or: sudo systemctl reload sshd
+```
+
+(The `principal` and `user` here must match your `config.json` below.
+`deploy/sshd_config.snippet` documents the host side in full.)
+
+## 4. Write the minimal config
+
+Copy [`config.minimal.example.json`](https://github.com/luisgf/infrabroker/blob/main/config.minimal.example.json)
+to `~/.infrabroker/config.json` and edit the one host block. Pin the host key so
+a man-in-the-middle cannot impersonate the server:
+
+```bash
+ssh-keyscan -t ed25519 myhost.example.com     # copy the output line into "host_key"
+```
+
+```jsonc
+{
+  "audit_log": "/Users/you/.infrabroker/audit.log",
+  "audit_key": "/Users/you/.infrabroker/audit.key",
+  "ca_key":    "/Users/you/.infrabroker/ssh_ca",
+  "hosts": {
+    "myhost": {
+      "addr": "myhost.example.com:22",
+      "user": "deploy",
+      "host_key": "myhost.example.com ssh-ed25519 AAAA…from-ssh-keyscan…",
+      "principal": "infrabroker",
+      "command_policy": {
+        "mode": "allowlist",
+        "allow": ["^uptime$", "^df -h$", "^systemctl status [a-zA-Z0-9._-]+$"]
+      }
+    }
+  }
+}
+```
+
+The `command_policy` allowlist is the **AI-action firewall**: only these
+commands can run, visible from the first request. Anything else is denied by the
+signer, not the shell.
+
+## 5. Register the broker with your MCP client
+
+```jsonc
+// Claude Code / Claude Desktop — ~/.claude.json
+"infrabroker": {
+  "type": "stdio",
+  "command": "/Users/you/infrabroker/mcp-broker",
+  "args": ["-config", "/Users/you/.infrabroker/config.json"]
+}
+```
+
+Restart the client. On startup the broker logs
+`mcp-broker (stdio) ready; 1 hosts configured` (and a one-line **PEM CA lab-use**
+warning — expected in local mode).
+
+## 6. Run your first command
+
+Ask the agent to use the tools:
+
+- **`ssh_list_servers`** → shows `myhost` and its capabilities.
+- **`ssh_execute(server="myhost", command="uptime")`** → runs it and returns
+  stdout / stderr / exit_code.
+- **`ssh_execute(server="myhost", command="rm -rf /", dry_run=true)`** →
+  returns a decision with `reason_code: "allowlist_no_match"` (denied) **without
+  connecting** — proof the firewall gates before anything runs.
+
+Every issuance and execution is recorded in the signed, hash-chained audit log:
+
+```bash
+broker-ctl audit tail   --log ~/.infrabroker/audit.log
+broker-ctl audit verify --log ~/.infrabroker/audit.log --key ~/.infrabroker/audit.key
+```
+
+---
+
+## When to move to remote mode
+
+Local mode keeps the CA **in the broker process** — fine for a lab or a personal
+setup, but the broker both decides and signs, and the PEM key sits on disk (the
+startup warning is deliberate). Move to **remote mode** when you want any of:
+
+- **Separated custody** — a standalone [`cmd/signer`](OPERATIONS.md) holds the CA
+  (Azure Key Vault or ssh-agent/hardware) and the policy; the broker never sees
+  the key. See the CA-custody choice in `deploy/README.md`.
+- **Human approvals & RBAC** — the control plane gates sensitive commands behind
+  four-eyes approval and restricts each broker CN to its groups.
+- **Recording, kill switch, multi-agent** — endpoint session recording and the
+  freeze/revocation controls described in [ARCHITECTURE.md](ARCHITECTURE.md) and
+  [THREAT_MODEL.md](THREAT_MODEL.md).
+
+The full setup — signer, PKI bootstrap, and the production checklist (which
+`broker-ctl doctor --security` automates) — is in [OPERATIONS.md](OPERATIONS.md)
+and `deploy/README.md`. Tool usage for the model is in [USAGE.md](USAGE.md).

--- a/internal/broker/config_example_test.go
+++ b/internal/broker/config_example_test.go
@@ -7,19 +7,26 @@ import (
 	"github.com/luisgf/infrabroker/internal/confcheck"
 )
 
-// TestBrokerExampleConfigMatchesStruct fails if config.example.json uses a key
-// that no longer exists on the broker Config struct.
+// TestBrokerExampleConfigMatchesStruct fails if a shipped example config uses a
+// key that no longer exists on the broker Config struct — the anti-drift guard
+// for both the full reference (config.example.json) and the single-binary
+// quickstart minimal config (config.minimal.example.json, docs/QUICKSTART.md).
 func TestBrokerExampleConfigMatchesStruct(t *testing.T) {
-	raw, err := os.ReadFile("../../config.example.json")
-	if err != nil {
-		t.Fatalf("read example: %v", err)
-	}
-	clean, err := confcheck.StripUnderscoreKeys(raw)
-	if err != nil {
-		t.Fatalf("strip comments: %v", err)
-	}
-	var cfg Config
-	if err := confcheck.DecodeStrict(clean, &cfg); err != nil {
-		t.Fatalf("config.example.json has a key not in Config (doc/code drift?): %v", err)
+	t.Parallel()
+	for _, path := range []string{"../../config.example.json", "../../config.minimal.example.json"} {
+		t.Run(path, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read example: %v", err)
+			}
+			clean, err := confcheck.StripUnderscoreKeys(raw)
+			if err != nil {
+				t.Fatalf("strip comments: %v", err)
+			}
+			var cfg Config
+			if err := confcheck.DecodeStrict(clean, &cfg); err != nil {
+				t.Fatalf("%s has a key not in Config (doc/code drift?): %v", path, err)
+			}
+		})
 	}
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Quickstart (local mode): QUICKSTART.md
   - Architecture: ARCHITECTURE.md
   - Threat model: THREAT_MODEL.md
   - Operations: OPERATIONS.md


### PR DESCRIPTION
## What

New `docs/QUICKSTART.md`: the fastest path from `git clone` to a policy-gated `ssh_execute`, using **one binary** (`mcp-broker`, stdio) and **one `config.json`** in local mode — in-process signing with a local CA, **no signer service and no mTLS PKI**.

Positioned as the on-ramp, not the production recommendation (a local PEM CA is lab/dev custody), with a graduation section to remote mode.

## Contents

- Build → local CA (`ssh-keygen`) → audit seed → host enrolment (`TrustedUserCAKeys` + `AuthorizedPrincipalsFile`, per `deploy/sshd_config.snippet`) → minimal `config.json` with a visible `command_policy` allowlist → MCP-client registration snippet → first `ssh_execute` + a `dry_run` firewall demo → where the signed audit log lands (`broker-ctl audit tail`/`verify`).
- **"When to move to remote mode"** — separated CA custody, approvals, RBAC, recording, kill switch.

## Verified end-to-end

Ran the real local-mode flow (not just prose): `go build ./cmd/mcp-broker` → `ssh-keygen` a CA → `head -c 32 /dev/urandom > audit.key` → the minimal config →

```
[WARN] ca.LoadCAFromPEM: CA key loaded from PEM in memory. Lab use only. …
mcp-broker (stdio) ready; 1 hosts configured
```

with the audit log opened — the PEM lab-use warning is exactly the local-mode posture the doc conveys. (A live `ssh_execute` needs the reader's own host + MCP client; the broker-side flow is verified.)

## Committed example + anti-drift

- `config.minimal.example.json` is committed and **validated forever** by the confcheck anti-drift test (`TestBrokerExampleConfigMatchesStruct`, extended to a table over both example configs).
- `make verify` green: race tests, govulncheck (0), docs `--strict` (no broken links). QUICKSTART reachable from the README (docs table + quickstart pointer) and the mkdocs nav.

No code changes beyond the example file and the anti-drift test wiring.

Closes #182