### PR TITLE
chore(lab): e2e sudo + PTY elevation lab

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -163,6 +163,14 @@
   with a reasoned exception. Also unified `mcpserver`'s tool-error construction
   on the `toolError` helper. Pure refactor: tests unchanged, docgen output and
   the MCP tool surface byte-identical.
+- **e2e elevation lab (#140)** — new `lab/run_sudo_lab.sh` exercises the sudo +
+  PTY path end to end (previously only unit-tested): `ssh_execute(sudo=true)` and
+  a `mode=pty` session opened with `sudo=true`. It stands up a local sshd and,
+  instead of real NOPASSWD sudoers (which need root), installs a `sudo` shim on
+  the session `PATH` via sshd `SetEnv`, so the broker's actual elevation line
+  (`sudo -n -- /bin/sh -c …`) runs on the host and is asserted through the shim
+  log plus the `sudo:root` label in the signed audit trail. `lab/mcpclient` gained
+  a `LAB_SUDO=1` scenario.
 
 ## [v1.38.0] - 2026-07-04
 

--- a/lab/mcpclient/main.go
+++ b/lab/mcpclient/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -51,6 +52,12 @@ func main() {
 		return ""
 	}
 
+	// LAB_SUDO=1 runs only the elevation scenario (run_sudo_lab.sh) and exits.
+	if os.Getenv("LAB_SUDO") == "1" {
+		runSudoScenario(call, text, target)
+		return
+	}
+
 	fmt.Println("\n## 1. ssh_execute one-shot (via bastion):")
 	r := call("ssh_execute", map[string]any{"server": target, "command": "hostname; echo OK_ONESHOT"})
 	fmt.Printf("isError=%v\n%s\n", r.IsError, text(r))
@@ -82,4 +89,37 @@ func main() {
 		r = call("ssh_execute", map[string]any{"server": denied, "command": "id"})
 		fmt.Printf("isError=%v\n%s\n", r.IsError, text(r))
 	}
+}
+
+// runSudoScenario exercises the elevation path end to end: a one-shot
+// ssh_execute(sudo=true) and a pty session opened with sudo=true. Each asserts
+// the command ran (the marker is echoed) and is non-error; run_sudo_lab.sh
+// additionally checks that the host's `sudo` was actually invoked (shim log) and
+// that the audit trail records the elevation label.
+func runSudoScenario(
+	call func(string, map[string]any) *mcp.CallToolResult,
+	text func(*mcp.CallToolResult) string,
+	target string,
+) {
+	fmt.Println("## sudo one-shot: ssh_execute(sudo=true)")
+	r := call("ssh_execute", map[string]any{"server": target, "command": "id -un; echo ONESHOT_SUDO_OK", "sudo": true})
+	fmt.Printf("isError=%v\n%s\n", r.IsError, text(r))
+	if r.IsError || !strings.Contains(text(r), "ONESHOT_SUDO_OK") {
+		log.Fatalf("sudo one-shot must run the command; got isError=%v %q", r.IsError, text(r))
+	}
+
+	fmt.Println("\n## pty session with elevation: ssh_session_open(mode=pty, sudo=true)")
+	r = call("ssh_session_open", map[string]any{"server": target, "mode": "pty", "sudo": true})
+	if r.IsError {
+		log.Fatalf("pty+sudo session open must succeed: %s", text(r))
+	}
+	sid := r.StructuredContent.(map[string]any)["session_id"].(string)
+	fmt.Printf("open -> %s\n", text(r))
+	out := text(call("ssh_session_exec", map[string]any{"session_id": sid, "command": "echo PTY_SUDO_OK"}))
+	fmt.Printf("pty exec -> %s\n", out)
+	call("ssh_session_close", map[string]any{"session_id": sid})
+	if !strings.Contains(out, "PTY_SUDO_OK") {
+		log.Fatalf("pty+sudo exec must run the command; got %q", out)
+	}
+	fmt.Println("\nSUDO_SCENARIO_OK")
 }

--- a/lab/run_sudo_lab.sh
+++ b/lab/run_sudo_lab.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Lab e2e de la ruta de ELEVACIÓN (sudo + PTY) del broker MCP.
+# Cubre el hueco: sudo/PTY están en tests unitarios pero no en un lab e2e.
+#
+# Levanta UN sshd local (destino, :2227) que confía en la CA; el host permite
+# allow_sudo + allow_pty. En vez de configurar NOPASSWD sudoers reales (que
+# requieren root), instala un SHIM de `sudo` en el PATH de la sesión vía
+# `SetEnv PATH` del sshd: el shim imita `sudo -n [-u user] -- CMD` ejecutando CMD
+# y registrando cada invocación. Así el lab ejercita la ruta REAL del broker
+# —cert con elevación → sesión → la línea `sudo -n -- /bin/sh -c ...` ejecutada
+# en el host— sin necesitar privilegio de root en la máquina que corre el lab.
+#
+# Verifica:
+#   1. ssh_execute(sudo=true) one-shot corre a través de la línea sudo.
+#   2. sesión pty con sudo=true: el shell se lanza bajo sudo.
+#   3. el `sudo` del host se invocó de verdad (shim log) y la auditoría firmada
+#      registra la etiqueta de elevación (sudo:root).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LAB="$ROOT/lab/work-sudo"
+USER_NAME="$(id -un)"
+T_PORT=2227
+
+rm -rf "$LAB"; mkdir -p "$LAB/t" "$LAB/shim"
+
+echo "== 1. CA + host key + principal + shim de sudo =="
+ssh-keygen -t ed25519 -N '' -C ca -f "$LAB/ssh_ca" >/dev/null
+ssh-keygen -t ed25519 -N '' -f "$LAB/t/host" >/dev/null
+printf 'host:target\n' > "$LAB/t/principals"
+chmod 600 "$LAB/t/host" "$LAB/t/principals"
+
+# Shim NOPASSWD: registra la invocación (ruta baked al generar) y ejecuta el
+# comando restante, imitando `sudo -n [-u user] -- CMD` sin privilegio real.
+: > "$LAB/sudo-shim.log"
+cat > "$LAB/shim/sudo" <<SHIM
+#!/bin/sh
+echo "sudo-shim invoked: \$*" >> "$LAB/sudo-shim.log"
+while [ \$# -gt 0 ]; do case "\$1" in -n) shift;; -u) shift 2;; --) shift; break;; *) break;; esac; done
+exec "\$@"
+SHIM
+chmod +x "$LAB/shim/sudo"
+
+echo "== 2. arrancar sshd destino (SetEnv PATH → el shim gana a /usr/bin/sudo) =="
+cat > "$LAB/t/sshd_config" <<EOF
+Port $T_PORT
+ListenAddress 127.0.0.1
+HostKey $LAB/t/host
+TrustedUserCAKeys $LAB/ssh_ca.pub
+AuthorizedPrincipalsFile $LAB/t/principals
+PidFile $LAB/t/sshd.pid
+LogLevel VERBOSE
+PasswordAuthentication no
+UsePAM no
+StrictModes no
+SetEnv PATH=$LAB/shim:/usr/bin:/bin
+EOF
+"$(command -v sshd || echo /usr/sbin/sshd)" -f "$LAB/t/sshd_config" -E "$LAB/t/sshd.log"
+sleep 1
+T_PID="$(cat "$LAB/t/sshd.pid")"
+trap 'kill "$T_PID" 2>/dev/null || true; rm -rf "$LAB"' EXIT
+
+echo "== 3. config del broker (target con allow_sudo + allow_pty) =="
+head -c 32 /dev/urandom > "$LAB/audit.seed"
+cat > "$LAB/config.json" <<EOF
+{
+  "ca_key": "$LAB/ssh_ca",
+  "audit_log": "$LAB/audit.log",
+  "audit_key": "$LAB/audit.seed",
+  "source_address": "127.0.0.1",
+  "max_ttl_seconds": 120,
+  "hosts": {
+    "target": {
+      "addr": "127.0.0.1:$T_PORT", "user": "$USER_NAME",
+      "principal": "host:target", "host_key": "$(cat "$LAB/t/host.pub")",
+      "source_address": "127.0.0.1",
+      "allow_sudo": true, "allow_pty": true
+    }
+  }
+}
+EOF
+
+echo "== 4. compilar y ejecutar el escenario de elevación (LAB_SUDO=1) =="
+( cd "$ROOT" && go build -o "$LAB/mcp-broker" ./cmd/mcp-broker )
+( cd "$ROOT" && LAB_SUDO=1 go run ./lab/mcpclient "$LAB/mcp-broker" "$LAB/config.json" target )
+
+echo
+echo "== 5. el sudo del host se invocó de verdad (shim log) =="
+if [ ! -s "$LAB/sudo-shim.log" ]; then
+  echo "FAIL: el shim de sudo no se invocó — la línea de elevación no llegó al host" >&2
+  exit 1
+fi
+sed 's/^/   /' "$LAB/sudo-shim.log"
+
+echo
+echo "== 6. auditoría firmada: etiqueta de elevación (sudo:root) =="
+if ! grep -q 'sudo:root' "$LAB/audit.log"; then
+  echo "FAIL: la auditoría no registró la elevación (sudo:root)" >&2
+  cat "$LAB/audit.log" >&2
+  exit 1
+fi
+grep -o '"elevation":"sudo:root"' "$LAB/audit.log" | head -3 | sed 's/^/   /'
+
+echo "Lab sudo/PTY OK."


### PR DESCRIPTION
## What

New `lab/run_sudo_lab.sh` — an end-to-end lab for the **elevation path**, which was covered by unit tests but had no e2e lab (#140). It exercises:

1. `ssh_execute(sudo=true)` — one-shot with elevation;
2. `ssh_session_open(mode=pty, sudo=true)` — a PTY session launched under sudo.

`lab/mcpclient` gained a `LAB_SUDO=1` scenario that drives both and asserts each ran (a marker is echoed) and is non-error.

## Fake sudo, real broker path

Real NOPASSWD sudoers need root to configure, so the lab installs a **`sudo` shim** on the session `PATH` via sshd `SetEnv PATH=…`. The shim mimics `sudo -n [-u user] -- CMD`, logging each invocation and exec'ing the rest. The broker's **actual** elevation line — `sudo -n -- /bin/sh -c …`, built by the signer and sent to the host — therefore runs for real; only the privileged `sudo` binary is stubbed. The lab then asserts:

- the host's `sudo` was actually invoked (shim log shows `-n -- /bin/sh -c …`);
- the signed audit trail records the `sudo:root` elevation label.

This exercises the broker→signer→host elevation wiring that unit tests can't, without needing root on the machine running the lab.

## Verified

Ran locally end to end — output:

```
## sudo one-shot: ssh_execute(sudo=true)  → luislgf / ONESHOT_SUDO_OK  [exit=0]
## pty session with elevation             → PTY_SUDO_OK               [exit=0]
SUDO_SCENARIO_OK
   sudo-shim invoked: -n -- /bin/sh -c id -un; echo ONESHOT_SUDO_OK
   sudo-shim invoked: -n -- /bin/sh
   "elevation":"sudo:root"  ×3
Lab sudo/PTY OK.
```

Self-contained (local sshd as the current user, high port), touches no system config. `make verify` green (builds/vets `lab/mcpclient`); the lab script itself is a manual e2e harness (labs are not part of CI), verified by running it.

Closes #140