### PR TITLE
feat(config): accept JSONC (comments, trailing commas) on load

### DIFF
--- a/cmd/broker-ctl/clientconfig.go
+++ b/cmd/broker-ctl/clientconfig.go
@@ -36,11 +36,12 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/luisgf/infrabroker/internal/confcheck"
 )
 
 // clientTarget holds the connection parameters for one remote service.
@@ -102,7 +103,7 @@ func loadClientConfigFrom(cands []ccCandidate) (clientConfig, string, error) {
 			return clientConfig{}, "", fmt.Errorf("client config %s: %w", c.path, err)
 		}
 		var cfg clientConfig
-		if err := json.Unmarshal(b, &cfg); err != nil {
+		if err := confcheck.Unmarshal(b, &cfg); err != nil {
 			return clientConfig{}, "", fmt.Errorf("client config %s: %w", c.path, err)
 		}
 		return cfg, c.path, nil

--- a/cmd/broker-ctl/doctor.go
+++ b/cmd/broker-ctl/doctor.go
@@ -14,6 +14,8 @@ import (
 	"net"
 	"os"
 	"strings"
+
+	"github.com/luisgf/infrabroker/internal/confcheck"
 )
 
 const (
@@ -110,7 +112,7 @@ func loadDoctorJSON(path string, v any) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, v)
+	return confcheck.Unmarshal(b, v)
 }
 
 func checkSignerConfig(path string) []doctorFinding {

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/version"
 )
 
@@ -1247,7 +1248,7 @@ func loadRaw(path string) (map[string]json.RawMessage, error) {
 		return nil, err
 	}
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
+	if err := confcheck.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 	return raw, nil
@@ -1301,7 +1302,7 @@ func readSignerURL(configPath string) (string, error) {
 	var cfg struct {
 		Listen string `json:"listen"`
 	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	if err := confcheck.Unmarshal(data, &cfg); err != nil {
 		return "", err
 	}
 	if cfg.Listen == "" {

--- a/cmd/broker-ctl/policy.go
+++ b/cmd/broker-ctl/policy.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/policyrec"
 	"github.com/luisgf/infrabroker/internal/signer"
 )
@@ -328,7 +329,7 @@ func cmdPolicyRecommend(args []string) {
 	if err != nil {
 		fatalf("read config: %v", err)
 	}
-	if err := json.Unmarshal(b, &cfg); err != nil {
+	if err := confcheck.Unmarshal(b, &cfg); err != nil {
 		fatalf("parse config: %v", err)
 	}
 	compiled, err := signer.CompileHostPolicies(cfg.Hosts, cfg.CommandPolicies, cfg.GroupCommandPolicies)
@@ -427,7 +428,7 @@ func cmdPolicyExplain(args []string) {
 	if err != nil {
 		fatalf("read config: %v", err)
 	}
-	if err := json.Unmarshal(b, &cfg); err != nil {
+	if err := confcheck.Unmarshal(b, &cfg); err != nil {
 		fatalf("parse config: %v", err)
 	}
 	hp, ok := cfg.Hosts[*host]

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -39,7 +39,7 @@ type runResponse struct {
 }
 
 func main() {
-	cfgPath := flag.String("config", "config.json", "path to JSON configuration file")
+	cfgPath := flag.String("config", "config.json", "path to the JSON/JSONC configuration file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	verbose := flag.Bool("verbose", false, "with --version, print detailed build info")
 	flag.Parse()

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -165,7 +165,7 @@ func (s *server) signCaller(w http.ResponseWriter, r *http.Request) (string, boo
 }
 
 func main() {
-	cfgPath := flag.String("config", "control-plane.json", "path to JSON configuration file")
+	cfgPath := flag.String("config", "control-plane.json", "path to the JSON/JSONC configuration file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	verbose := flag.Bool("verbose", false, "with --version, print detailed build info")
 	flag.Parse()

--- a/cmd/mcp-broker-http/main.go
+++ b/cmd/mcp-broker-http/main.go
@@ -45,7 +45,7 @@ const prmPath = "/.well-known/oauth-protected-resource"
 const maxMCPBody = 1 << 20 // 1 MiB
 
 func main() {
-	cfgPath := flag.String("config", "config.json", "path to JSON configuration file")
+	cfgPath := flag.String("config", "config.json", "path to the JSON/JSONC configuration file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	verbose := flag.Bool("verbose", false, "with --version, print detailed build info")
 	flag.Parse()

--- a/cmd/mcp-broker/main.go
+++ b/cmd/mcp-broker/main.go
@@ -34,7 +34,7 @@ func stdioCaller(context.Context) broker.Caller {
 }
 
 func main() {
-	cfgPath := flag.String("config", "config.json", "path to JSON configuration file")
+	cfgPath := flag.String("config", "config.json", "path to the JSON/JSONC configuration file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	verbose := flag.Bool("verbose", false, "with --version, print detailed build info")
 	flag.Parse()

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -142,7 +142,7 @@ type K8sConfig struct {
 }
 
 func main() {
-	cfgPath := flag.String("config", "signer.json", "path to JSON configuration file")
+	cfgPath := flag.String("config", "signer.json", "path to the JSON/JSONC configuration file")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	verbose := flag.Bool("verbose", false, "with --version, print detailed build info")
 	flag.Parse()

--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/luisgf/infrabroker/internal/audit"
 	"github.com/luisgf/infrabroker/internal/auth"
+	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/signer"
 )
 
@@ -131,7 +132,7 @@ func loadRawConfig(path string) (map[string]json.RawMessage, error) {
 		return nil, err
 	}
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := confcheck.Unmarshal(b, &raw); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 	return raw, nil

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,15 @@
   confcheck anti-drift test), an MCP-client registration snippet, a `dry_run`
   firewall demo, and a "when to move to remote mode" graduation section. Linked
   from the README and mkdocs nav. Docs/examples only.
+- **JSONC config files (#183, part 1 — load)** — every config file
+  (`config.json`, `signer.json`, `control-plane.json`, `broker-ctl.json`) now
+  accepts `//` and `/* */` comments and trailing commas (JWCC) when loaded — on
+  startup and on every reload path — so a config can be annotated with real
+  comments instead of `_*` comment keys. Plain JSON keeps loading byte-for-byte
+  unchanged and a typo'd key still fails closed; the legacy `_*` comment keys keep
+  working but are now deprecated in favour of real comments. (Comment-preserving
+  config *rewrites* — the signer policy-mutation API and `broker-ctl` edits — and
+  the conversion of the shipped `.example.json` files land in a follow-up.)
 
 ### Changed
 - **Per-agent action-budgets framing (#123)** — the README and

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -866,6 +866,12 @@ it must be revoked before expiry.
     broker logs one aggregated startup warning naming them, so a present-but-
     inactive policy is never mistaken for an enforced one (the same error class
     as the `_default` firewall gap, #82).
+11. **Configs accept JSONC** (#183): every config file (`config.json`,
+    `signer.json`, `control-plane.json`, `broker-ctl.json`) may carry `//` and
+    `/* */` comments and trailing commas — now the canonical way to annotate a
+    config. Plain JSON keeps loading unchanged, and the legacy `_*` comment keys
+    keep working (deprecated in favour of real comments). Malformed JSONC fails
+    closed like any other parse error, on startup and on every reload path.
 
 ### Per-agent identity: OAuth2 client_credentials
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/slack-go/slack v0.27.0
+	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	golang.org/x/crypto v0.53.0
 	modernc.org/sqlite v1.53.0
 	mvdan.cc/sh/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/slack-go/slack v0.27.0 h1:VWOpUzOK6UAPCCQlFxl79jhv8a/b+GOSJMnWziDJ8B8
 github.com/slack-go/slack v0.27.0/go.mod h1:UEe+jmo9WLlwHB04qsOrTDvqM7Aa4rQL3O5wF3n0hx4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/internal/broker/config_example_test.go
+++ b/internal/broker/config_example_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/luisgf/infrabroker/internal/confcheck"
@@ -28,5 +29,27 @@ func TestBrokerExampleConfigMatchesStruct(t *testing.T) {
 				t.Fatalf("%s has a key not in Config (doc/code drift?): %v", path, err)
 			}
 		})
+	}
+}
+
+// TestLoadConfigAcceptsJSONC proves the broker's real load path (LoadConfig →
+// confcheck.Strict) accepts // and /* */ comments and a trailing comma (#183).
+func TestLoadConfigAcceptsJSONC(t *testing.T) {
+	t.Parallel()
+	p := filepath.Join(t.TempDir(), "config.json")
+	jsonc := "{\n" +
+		"  // canonical comment style\n" +
+		"  \"listen\": \":9000\",       // trailing line comment\n" +
+		"  \"max_ttl_seconds\": 60,   /* block */\n" +
+		"}\n"
+	if err := os.WriteFile(p, []byte(jsonc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(p)
+	if err != nil {
+		t.Fatalf("a JSONC config.json must load: %v", err)
+	}
+	if cfg.Listen != ":9000" || cfg.MaxTTLSeconds != 60 {
+		t.Errorf("JSONC values must decode: listen=%q ttl=%d", cfg.Listen, cfg.MaxTTLSeconds)
 	}
 }

--- a/internal/confcheck/confcheck.go
+++ b/internal/confcheck/confcheck.go
@@ -11,7 +11,36 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/tailscale/hujson"
 )
+
+// Standardize converts JSONC/JWCC (// and /* */ comments, plus trailing commas)
+// into plain JSON by replacing comments with whitespace and dropping trailing
+// commas; plain JSON passes through unchanged (idempotent). Every config loader
+// applies it, so config files may carry real // comments. It does NOT touch
+// object keys, so the legacy "_*" comment-key convention — and the reserved
+// "_default" data key — keep working exactly as before.
+func Standardize(raw []byte) ([]byte, error) {
+	b, err := hujson.Standardize(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing JSONC: %w", err)
+	}
+	return b, nil
+}
+
+// Unmarshal standardizes JSONC then json.Unmarshals raw into v WITHOUT the
+// strict unknown-key check. It is for the raw config readers — partial structs
+// and map[string]json.RawMessage decoders that must tolerate the rest of a real
+// config — so a config carrying // comments or trailing commas loads for them
+// too. Use Strict for the authoritative typed load with typo detection.
+func Unmarshal(raw []byte, v any) error {
+	std, err := Standardize(raw)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(std, v)
+}
 
 // StripUnderscoreKeys removes the inline documentation keys recursively (see
 // isCommentKey for what counts as a comment). It deliberately keeps "_"-prefixed
@@ -20,6 +49,10 @@ import (
 // broker CN) — so they are loaded AND reach the strict validation pass; removing
 // them would lose data and hide a typo nested inside such an entry.
 func StripUnderscoreKeys(raw []byte) ([]byte, error) {
+	raw, err := Standardize(raw)
+	if err != nil {
+		return nil, err
+	}
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return nil, fmt.Errorf("parsing JSON: %w", err)
@@ -88,6 +121,13 @@ func DecodeStrict(b []byte, v any) error {
 // would otherwise leave a setting more open than intended. Used by the runtime
 // config loaders (startup, reload, and the validated policy-mutation path).
 func Strict(raw []byte, v any) error {
+	// JSONC → plain JSON first, so both passes accept // comments and trailing
+	// commas. Malformed JSONC fails closed here (same posture as a malformed
+	// config today).
+	raw, err := Standardize(raw)
+	if err != nil {
+		return err
+	}
 	// Pass 1 — load the real configuration leniently. This preserves every map
 	// key, including any that legitimately begins with "_" (e.g. a broker CN named
 	// "_ci" in callers, or a "_default" group), and ignores the "_*" comment keys

--- a/internal/confcheck/confcheck_test.go
+++ b/internal/confcheck/confcheck_test.go
@@ -79,3 +79,41 @@ func TestStrict(t *testing.T) {
 		t.Errorf("an inline scalar _note must be treated as a comment: %v", err)
 	}
 }
+
+func TestStrictAcceptsJSONC(t *testing.T) {
+	t.Parallel()
+
+	// // and /* */ comments plus a trailing comma load like plain JSON, and a
+	// legacy _comment key keeps working alongside a real // comment.
+	jsonc := []byte(`{
+		// the canonical comment style now
+		"_comment": "legacy comment key still accepted",
+		"name": "cp",            // trailing line comment
+		"sign_callers": ["a"],   /* block comment */
+		"ca_keys": {"_default": "k"},
+	}`)
+	var s sample
+	if err := Strict(jsonc, &s); err != nil {
+		t.Fatalf("JSONC (comments + trailing comma) must load: %v", err)
+	}
+	if s.Name != "cp" || len(s.Callers) != 1 || s.Keys["_default"] != "k" {
+		t.Errorf("JSONC values must decode correctly: %+v", s)
+	}
+
+	// A typo is still caught even with comments present (fail-closed unchanged).
+	if err := Strict([]byte(`{ // note
+		"sign_caller": ["a"] }`), &sample{}); err == nil {
+		t.Error("a typo'd field must still be rejected through the JSONC path")
+	}
+
+	// Plain JSON is unchanged (idempotent standardize).
+	std, err := Standardize([]byte(`{"name":"x"}`))
+	if err != nil || string(std) != `{"name":"x"}` {
+		t.Errorf("plain JSON must pass through unchanged: %q %v", std, err)
+	}
+
+	// Malformed input fails closed with a parse error.
+	if _, err := Standardize([]byte(`{"name": }`)); err == nil {
+		t.Error("malformed JSONC must fail closed")
+	}
+}


### PR DESCRIPTION
**Part of #183** (this is part 1 — the load path; comment-preserving rewrites + example conversion follow in part 2, which will close the issue).

## What

Every config file — `config.json`, `signer.json`, `control-plane.json`, `broker-ctl.json` — now accepts **JSONC/JWCC**: `//` and `/* */` comments and trailing commas, so operators can annotate a config with real comments instead of the `_*`-key convention.

## How

- New `confcheck.Standardize` (wraps [`github.com/tailscale/hujson`](https://github.com/tailscale/hujson)) turns JSONC → plain JSON; `confcheck.Unmarshal` = Standardize + `json.Unmarshal` for the non-strict raw readers.
- `confcheck.Strict` standardizes before **both** its passes (lenient load + strict typo detection); `StripUnderscoreKeys` standardizes too, so the anti-drift example tests accept `//` comments.
- Wired through every loader: the 3 struct loaders already funnel through `Strict`; the one bypass (broker-ctl client config) and the raw-map readers used by the write/display paths (signer `loadRawConfig`, broker-ctl `loadRaw`/`readSignerURL`/`policy`/`doctor`) now use `confcheck.Unmarshal`.
- `-config` help texts → "JSON/JSONC"; `docs/OPERATIONS.md` documents the new canonical comment style + deprecation of `_*` keys.

## Guarantees

- Plain JSON loads **byte-for-byte unchanged**; a typo'd key **still fails closed** through `confcheck.Strict`; legacy `_*` comment keys keep working (deprecated).
- Malformed JSONC fails closed with a parse error — same posture as today — on startup **and** on every reload path (all loaders share the choke point).

## Tests / verify

- `confcheck` unit test: `//` + `/* */` + trailing comma loads; typo still rejected; plain JSON unchanged; malformed fails closed.
- `internal/broker` integration test: the real `LoadConfig` path accepts a JSONC `config.json`.
- `make verify` green: race tests, **govulncheck 0** (hujson is clean), docs `--strict`.

## Not in this PR (part 2)

- Format-preserving **rewrites** (signer policy-mutation API and `broker-ctl` host/ca-keys/callers edits) so an operator's `//` comments survive a config edit.
- Converting the shipped `.example.json` files from `_*` keys to real `//` comments.

Part of #183