### PR TITLE
feat(signer): preserve comments on policy-mutation config rewrite

### DIFF
--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/luisgf/infrabroker/internal/audit"
 	"github.com/luisgf/infrabroker/internal/auth"
@@ -95,11 +96,11 @@ func (s *server) mutateAllow(host, pattern string, add bool) (int, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 
-	raw, err := loadRawConfig(s.cfgPath)
+	orig, err := os.ReadFile(s.cfgPath)
 	if err != nil {
 		return 0, err
 	}
-	newBytes, err := editAllow(raw, host, pattern, add)
+	newBytes, err := editAllow(orig, host, pattern, add)
 	if err != nil {
 		return 0, err
 	}
@@ -124,67 +125,92 @@ func (s *server) mutateAllow(host, pattern string, add bool) (int, error) {
 	return len(cfg.Hosts), nil
 }
 
-// loadRawConfig reads signer.json into a top-level raw map, preserving comments
-// and unknown keys verbatim.
-func loadRawConfig(path string) (map[string]json.RawMessage, error) {
-	b, err := os.ReadFile(path)
+// jsonPtrEscape escapes a JSON Pointer reference token (RFC 6901): "~"→"~0",
+// "/"→"~1", so a host name is a valid pointer segment.
+func jsonPtrEscape(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+// editAllow edits one host's command_policy allowlist in the raw JSONC config
+// and returns the new bytes, PRESERVING every other byte — comments, key order,
+// formatting — via a format-preserving JSON Patch (confcheck.Patch). It reads
+// the current shape from a standardized copy, then applies the minimal patch:
+// create command_policy / allow when absent, append or remove the pattern, and
+// (on add) flip an off/empty mode to allowlist — matching the previous
+// parse→marshal behaviour byte-for-byte in value, but without losing comments.
+func editAllow(orig []byte, host, pattern string, add bool) ([]byte, error) {
+	std, err := confcheck.Standardize(orig)
 	if err != nil {
 		return nil, err
 	}
-	var raw map[string]json.RawMessage
-	if err := confcheck.Unmarshal(b, &raw); err != nil {
+	var top struct {
+		Hosts map[string]json.RawMessage `json:"hosts"`
+	}
+	if err := json.Unmarshal(std, &top); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
-	return raw, nil
-}
-
-// editAllow edits one host's command_policy allowlist within the raw config and
-// returns the new indented bytes. Top-level keys and all OTHER hosts (with their
-// comments) are preserved verbatim; only the edited host is re-marshaled.
-func editAllow(raw map[string]json.RawMessage, host, pattern string, add bool) ([]byte, error) {
-	hosts := map[string]json.RawMessage{}
-	if h, ok := raw["hosts"]; ok {
-		if err := json.Unmarshal(h, &hosts); err != nil {
-			return nil, fmt.Errorf("parsing hosts: %w", err)
-		}
-	}
-	hraw, ok := hosts[host]
+	hraw, ok := top.Hosts[host]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", errHostNotFound, host)
 	}
-	var hp signer.HostPolicy
-	if err := json.Unmarshal(hraw, &hp); err != nil {
+	var hostObj map[string]json.RawMessage
+	if err := json.Unmarshal(hraw, &hostObj); err != nil {
 		return nil, fmt.Errorf("parsing host %q: %w", host, err)
 	}
-	cp := hp.CommandPolicy
+	cpRaw, hasCP := hostObj["command_policy"]
+	var cp signer.CommandPolicy
+	allowExists := false
+	if hasCP {
+		if err := json.Unmarshal(cpRaw, &cp); err != nil {
+			return nil, fmt.Errorf("parsing host %q command_policy: %w", host, err)
+		}
+		var cpObj map[string]json.RawMessage
+		_ = json.Unmarshal(cpRaw, &cpObj)
+		_, allowExists = cpObj["allow"]
+	}
+
+	type patchOp struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value,omitempty"`
+	}
+	base := "/hosts/" + jsonPtrEscape(host) + "/command_policy"
+	var ops []patchOp
 	if add {
 		if slices.Contains(cp.Allow, pattern) {
 			return nil, fmt.Errorf("%w: pattern already in the allowlist", errNoChange)
 		}
-		if cp.Mode == "" || cp.Mode == signer.CmdPolicyOff {
-			cp.Mode = signer.CmdPolicyAllowlist
+		setMode := cp.Mode == "" || cp.Mode == signer.CmdPolicyOff
+		switch {
+		case !hasCP:
+			ops = append(ops, patchOp{"add", base, map[string]any{
+				"mode": signer.CmdPolicyAllowlist, "allow": []string{pattern},
+			}})
+		case !allowExists:
+			ops = append(ops, patchOp{"add", base + "/allow", []string{pattern}})
+			if setMode {
+				ops = append(ops, patchOp{"add", base + "/mode", signer.CmdPolicyAllowlist})
+			}
+		default:
+			ops = append(ops, patchOp{"add", base + "/allow/-", pattern})
+			if setMode {
+				ops = append(ops, patchOp{"add", base + "/mode", signer.CmdPolicyAllowlist})
+			}
 		}
-		cp.Allow = append(cp.Allow, pattern)
 	} else {
 		i := slices.Index(cp.Allow, pattern)
 		if i < 0 {
 			return nil, fmt.Errorf("%w: pattern not in the allowlist", errNoChange)
 		}
-		cp.Allow = slices.Delete(cp.Allow, i, i+1)
+		ops = append(ops, patchOp{Op: "remove", Path: fmt.Sprintf("%s/allow/%d", base, i)})
 	}
-	hp.CommandPolicy = cp
-
-	nh, err := json.Marshal(hp)
+	patch, err := json.Marshal(ops)
 	if err != nil {
 		return nil, err
 	}
-	hosts[host] = nh
-	nhosts, err := json.Marshal(hosts)
-	if err != nil {
-		return nil, err
-	}
-	raw["hosts"] = nhosts
-	return json.MarshalIndent(raw, "", "  ")
+	return confcheck.Patch(orig, patch)
 }
 
 // atomicWrite writes b to path via a temp file + rename, preserving the existing

--- a/cmd/signer/policy_test.go
+++ b/cmd/signer/policy_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/signer"
 )
 
@@ -18,17 +20,12 @@ const policyFixture = `{
   }
 }`
 
-func rawOf(t *testing.T, s string) map[string]json.RawMessage {
-	t.Helper()
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(s), &m); err != nil {
-		t.Fatalf("fixture: %v", err)
-	}
-	return m
-}
-
 func allowOf(t *testing.T, b []byte, host string) signer.CommandPolicy {
 	t.Helper()
+	b, err := confcheck.Standardize(b) // the edited config may carry // comments
+	if err != nil {
+		t.Fatalf("standardize: %v", err)
+	}
 	var top, hosts map[string]json.RawMessage
 	if err := json.Unmarshal(b, &top); err != nil {
 		t.Fatalf("reparse top: %v", err)
@@ -45,7 +42,7 @@ func allowOf(t *testing.T, b []byte, host string) signer.CommandPolicy {
 
 func TestEditAllowAddAndPreserve(t *testing.T) {
 	t.Parallel()
-	b, err := editAllow(rawOf(t, policyFixture), "web01", "^free( .*)?$", true)
+	b, err := editAllow([]byte(policyFixture), "web01", "^free( .*)?$", true)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -68,7 +65,7 @@ func TestEditAllowAddAndPreserve(t *testing.T) {
 
 func TestEditAllowOnHostWithoutPolicySetsAllowlist(t *testing.T) {
 	t.Parallel()
-	b, err := editAllow(rawOf(t, policyFixture), "db01", "^uptime$", true)
+	b, err := editAllow([]byte(policyFixture), "db01", "^uptime$", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +76,7 @@ func TestEditAllowOnHostWithoutPolicySetsAllowlist(t *testing.T) {
 
 func TestEditAllowRemove(t *testing.T) {
 	t.Parallel()
-	b, err := editAllow(rawOf(t, policyFixture), "web01", "^uptime$", false)
+	b, err := editAllow([]byte(policyFixture), "web01", "^uptime$", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,13 +87,41 @@ func TestEditAllowRemove(t *testing.T) {
 
 func TestEditAllowErrors(t *testing.T) {
 	t.Parallel()
-	if _, err := editAllow(rawOf(t, policyFixture), "ghost", "^x$", true); !errors.Is(err, errHostNotFound) {
+	if _, err := editAllow([]byte(policyFixture), "ghost", "^x$", true); !errors.Is(err, errHostNotFound) {
 		t.Errorf("unknown host -> errHostNotFound, got %v", err)
 	}
-	if _, err := editAllow(rawOf(t, policyFixture), "web01", "^uptime$", true); !errors.Is(err, errNoChange) {
+	if _, err := editAllow([]byte(policyFixture), "web01", "^uptime$", true); !errors.Is(err, errNoChange) {
 		t.Errorf("duplicate add -> errNoChange, got %v", err)
 	}
-	if _, err := editAllow(rawOf(t, policyFixture), "web01", "^nope$", false); !errors.Is(err, errNoChange) {
+	if _, err := editAllow([]byte(policyFixture), "web01", "^nope$", false); !errors.Is(err, errNoChange) {
 		t.Errorf("removing absent pattern -> errNoChange, got %v", err)
+	}
+}
+
+// TestEditAllowPreservesLineComments is the #183 round-trip: a signer.json that
+// carries // comments has an allow rule added through the policy-mutation edit,
+// and the comments survive on disk alongside the new rule.
+func TestEditAllowPreservesLineComments(t *testing.T) {
+	t.Parallel()
+	jsonc := `{
+  // operator note: production web tier
+  "reload_callers": ["admin"],
+  "hosts": {
+    "web01": {
+      "principal": "host:web01", // pinned principal
+      "command_policy": { "mode": "allowlist", "allow": ["^uptime$"] }
+    }
+  }
+}`
+	b, err := editAllow([]byte(jsonc), "web01", "^df -h$", true)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "// operator note: production web tier") || !strings.Contains(s, "// pinned principal") {
+		t.Errorf("operator // comments must survive the edit:\n%s", s)
+	}
+	if cp := allowOf(t, b, "web01"); len(cp.Allow) != 2 || cp.Allow[1] != "^df -h$" {
+		t.Errorf("the new rule must be present: %+v", cp)
 	}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,13 @@
   working but are now deprecated in favour of real comments. (Comment-preserving
   config *rewrites* — the signer policy-mutation API and `broker-ctl` edits — and
   the conversion of the shipped `.example.json` files land in a follow-up.)
+- **Comment-preserving signer policy mutations (#183, part 2 — signer writes)** —
+  the signer's validated policy-mutation API (`broker-ctl policy add/remove`,
+  which persists `signer.json` atomically) now rewrites the file with a
+  format-preserving JSON Patch (`confcheck.Patch`, via hujson), so an operator's
+  `//` comments, key order, and formatting survive an allow-rule edit instead of
+  being flattened by a parse→marshal round trip. (`broker-ctl`'s own host/CA/caller
+  edits and the `.example.json` conversion remain the last follow-up.)
 
 ### Changed
 - **Per-agent action-budgets framing (#123)** — the README and

--- a/internal/confcheck/confcheck.go
+++ b/internal/confcheck/confcheck.go
@@ -22,11 +22,43 @@ import (
 // object keys, so the legacy "_*" comment-key convention — and the reserved
 // "_default" data key — keep working exactly as before.
 func Standardize(raw []byte) ([]byte, error) {
-	b, err := hujson.Standardize(raw)
+	// hujson.Standardize edits its input in place (comment bytes → whitespace), so
+	// copy first — callers must be able to keep the original bytes (e.g. to then
+	// apply a format-preserving Patch to them).
+	b, err := hujson.Standardize(append([]byte(nil), raw...))
 	if err != nil {
 		return nil, fmt.Errorf("parsing JSONC: %w", err)
 	}
 	return b, nil
+}
+
+// Patch applies an RFC 6902 JSON Patch to raw JSONC bytes, PRESERVING the file's
+// comments, formatting, and key order (via hujson), and returns the new bytes.
+// It is the format-preserving counterpart to a parse→marshal round trip: the
+// config-rewrite paths (signer policy mutation, broker-ctl edits) use it so an
+// operator's // comments survive an edit. A patch that does not apply (e.g. a
+// path whose parent is absent) is an error and nothing is written.
+func Patch(raw, patch []byte) ([]byte, error) {
+	v, err := hujson.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing JSONC: %w", err)
+	}
+	if err := v.Patch(patch); err != nil {
+		return nil, fmt.Errorf("applying config patch: %w", err)
+	}
+	v.Format() // re-indent only the patched-in values; existing lines are untouched
+	return v.Pack(), nil
+}
+
+// HasComments reports whether raw carries JSONC features (// or /* */ comments,
+// or trailing commas) that a parse→marshal round trip would lose. Rewrite paths
+// use it to decide between a format-preserving edit and the plain path.
+func HasComments(raw []byte) bool {
+	v, err := hujson.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return !v.IsStandard()
 }
 
 // Unmarshal standardizes JSONC then json.Unmarshals raw into v WITHOUT the

--- a/internal/confcheck/confcheck_test.go
+++ b/internal/confcheck/confcheck_test.go
@@ -1,6 +1,9 @@
 package confcheck
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 type sample struct {
 	Name    string              `json:"name"`
@@ -115,5 +118,52 @@ func TestStrictAcceptsJSONC(t *testing.T) {
 	// Malformed input fails closed with a parse error.
 	if _, err := Standardize([]byte(`{"name": }`)); err == nil {
 		t.Error("malformed JSONC must fail closed")
+	}
+}
+
+func TestPatchPreservesComments(t *testing.T) {
+	t.Parallel()
+	orig := []byte(`{
+  // keep this top comment
+  "hosts": {
+    "web": {
+      "principal": "host:web", // inline note kept
+      "command_policy": { "mode": "allowlist", "allow": ["^uptime$"] }
+    }
+  }
+}`)
+	// Append a pattern to a nested array — the editAllow scenario.
+	patch := []byte(`[{"op":"add","path":"/hosts/web/command_policy/allow/-","value":"^df -h$"}]`)
+	out, err := Patch(orig, patch)
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "// keep this top comment") || !strings.Contains(s, "// inline note kept") {
+		t.Errorf("operator comments must survive the patch:\n%s", s)
+	}
+	if !strings.Contains(s, "^df -h$") {
+		t.Errorf("the patched-in value must be present:\n%s", s)
+	}
+	// The result must still load through the strict loader.
+	var cfg struct {
+		Hosts map[string]struct {
+			Principal     string `json:"principal"`
+			CommandPolicy struct {
+				Mode  string   `json:"mode"`
+				Allow []string `json:"allow"`
+			} `json:"command_policy"`
+		} `json:"hosts"`
+	}
+	if err := Strict(out, &cfg); err != nil {
+		t.Fatalf("patched config must still load: %v", err)
+	}
+	if got := cfg.Hosts["web"].CommandPolicy.Allow; len(got) != 2 || got[1] != "^df -h$" {
+		t.Errorf("allow must have the appended pattern: %v", got)
+	}
+
+	// HasComments distinguishes JSONC from plain JSON.
+	if !HasComments(orig) || HasComments([]byte(`{"a":1}`)) {
+		t.Error("HasComments must be true for // comments and false for plain JSON")
 	}
 }


### PR DESCRIPTION
**Part of #183** (part 2 — signer writes; `broker-ctl` edits + `.example.json` conversion follow to close it).

## What

The signer's validated policy-mutation API (`broker-ctl policy add/remove`, which persists `signer.json` atomically) rewrote the file via parse→`MarshalIndent`, flattening `//` comments, key order, and formatting. It now rewrites with a **format-preserving JSON Patch**, so an operator's comments survive an allow-rule edit.

## How

- New `confcheck.Patch(raw, patch)` — applies an RFC 6902 JSON Patch to JSONC bytes via [hujson](https://github.com/tailscale/hujson), preserving comments/formatting/key order; and `confcheck.HasComments`.
- `editAllow` reworked: reads the current shape from a **standardized copy** (host exists? command_policy/allow present? current mode), builds the minimal patch (create `command_policy`/`allow` when absent, append or remove the pattern, flip an off/empty `mode` to `allowlist`), and applies it to the **original** bytes. The resulting **values are byte-for-byte** what the old path produced.
- **Root-cause fix:** `confcheck.Standardize` now copies its input — `hujson.Standardize` edits the slice in place, so inspecting a config was stripping the very comments a subsequent `Patch` had to preserve.

## Tests

- `cmd/signer`: existing `editAllow` tests adapted to the new `[]byte` signature (values unchanged) **plus** a new round-trip — a `signer.json` carrying `//` comments gets an allow rule added and the comments survive alongside the new rule.
- `internal/confcheck`: `Patch` preserves `//` comments through a nested-array append and the result still loads; `HasComments` distinguishes JSONC from plain JSON.
- `make verify` green: race tests, govulncheck (0), docs `--strict`.

## Remaining for #183 (follow-up)

- `broker-ctl`'s host / ca-keys / callers edits (currently whole-map rewrites) → format-preserving.
- Convert the shipped `.example.json` files from `_*` keys to real `//` comments.

Part of #183