### PR TITLE
feat(config): preserve comments on broker-ctl edits + convert examples to JSONC (closes #183)

### DIFF
--- a/broker-ctl.example.json
+++ b/broker-ctl.example.json
@@ -1,7 +1,21 @@
 {
-  "_comment": "broker-ctl CLIENT parameters (optional). Where to reach the services and which mTLS identity to present, so the remote commands (reload, policy add/remove/grant/grants/revoke, approval, host list --remote) do not need --url/--cert/--key/--ca on every call. This is client-side config — the service policy lives in signer.json. Per-parameter precedence: explicit flag > BROKER_CTL_* env var > this file > built-in default. Search order: --client-config, $BROKER_CTL_CONFIG, ~/.config/broker-ctl/config.json, /etc/infrabroker/broker-ctl.json (the current working directory is NOT searched — use --client-config for a local file, to avoid a planted ./broker-ctl.json redirecting the mTLS endpoint/CA). Env vars: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and BROKER_CTL_CP_{URL,CERT,KEY,CA}.",
+  // broker-ctl CLIENT parameters (optional). Where to reach the services and
+  // which mTLS identity to present, so the remote commands (reload, policy
+  // add/remove/grant/grants/revoke, approval, host list --remote) do not need
+  // --url/--cert/--key/--ca on every call. This is client-side config — the
+  // service policy lives in signer.json. Per-parameter precedence: explicit flag
+  // > BROKER_CTL_* env var > this file > built-in default. Search order:
+  // --client-config, $BROKER_CTL_CONFIG, ~/.config/broker-ctl/config.json,
+  // /etc/infrabroker/broker-ctl.json (the current working directory is NOT
+  // searched — use --client-config for a local file, to avoid a planted
+  // ./broker-ctl.json redirecting the mTLS endpoint/CA). Env vars:
+  // BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and BROKER_CTL_CP_{URL,CERT,KEY,CA}.
 
-  "_signer_comment": "Signer-facing commands (reload, policy *, host list --remote). The cert CN must be in the signer's reload_callers for the policy/read APIs. If url is empty everywhere, it is derived from the listen field of --config. The admin CLI material lives in pki/admin/ (root-only): no service user must be able to read it and impersonate the admin.",
+  // Signer-facing commands (reload, policy *, host list --remote). The cert CN
+  // must be in the signer's reload_callers for the policy/read APIs. If url is
+  // empty everywhere, it is derived from the listen field of --config. The admin
+  // CLI material lives in pki/admin/ (root-only): no service user must be able to
+  // read it and impersonate the admin.
   "signer": {
     "url": "127.0.0.1:9443",
     "cert": "/etc/infrabroker/pki/admin/admin.crt",
@@ -9,7 +23,8 @@
     "ca": "/etc/infrabroker/pki/mtls_ca.crt"
   },
 
-  "_control_plane_comment": "Control-plane-facing commands (approval list/allow/deny). The cert CN must be in the control plane's approval.callers.",
+  // Control-plane-facing commands (approval list/allow/deny). The cert CN must be
+  // in the control plane's approval.callers.
   "control_plane": {
     "url": "127.0.0.1:7443",
     "cert": "/etc/infrabroker/pki/admin/admin.crt",

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -354,8 +354,7 @@ func cmdHostAdd(args []string) {
 		hp.CommandPolicy = cp
 	}
 
-	hosts[*name] = hp
-	if err := writeHosts(configPath, raw, hosts); err != nil {
+	if err := patchConfigEntry(configPath, "hosts", *name, hp, false); err != nil {
 		fatalf("writing config: %v", err)
 	}
 	fmt.Printf("host %q %s (addr=%s, user=%s, principal=%s)\n", *name, action, hp.Addr, hp.User, hp.Principal)
@@ -641,8 +640,7 @@ func cmdHostRemove(args []string) {
 		fatalf("host %q not found", name)
 	}
 
-	delete(hosts, name)
-	if err := writeHosts(configPath, raw, hosts); err != nil {
+	if err := patchConfigEntry(configPath, "hosts", name, nil, true); err != nil {
 		fatalf("writing config: %v", err)
 	}
 	fmt.Printf("host %q removed\n", name)
@@ -745,8 +743,7 @@ func cmdCAKeysAdd(args []string) {
 		}
 		action = "updated"
 	}
-	keys[*name] = entryJSON
-	if err := writeCAKeys(configPath, raw, keys); err != nil {
+	if err := patchConfigEntry(configPath, "ca_keys", *name, entryJSON, false); err != nil {
 		fatalf("writing config: %v", err)
 	}
 	fmt.Printf("ca-key %q %s (type=%s)\n", *name, action, *keyType)
@@ -817,8 +814,7 @@ func cmdCAKeysRemove(args []string) {
 		fatalf("ca-key %q not found", name)
 	}
 
-	delete(keys, name)
-	if err := writeCAKeys(configPath, raw, keys); err != nil {
+	if err := patchConfigEntry(configPath, "ca_keys", name, nil, true); err != nil {
 		fatalf("writing config: %v", err)
 	}
 	fmt.Printf("ca-key %q removed\n", name)
@@ -841,16 +837,6 @@ func extractCAKeys(raw map[string]json.RawMessage) (map[string]json.RawMessage, 
 		keys = map[string]json.RawMessage{}
 	}
 	return keys, nil
-}
-
-// writeCAKeys serialises ca_keys back into the raw map and writes the file.
-func writeCAKeys(path string, raw map[string]json.RawMessage, keys map[string]json.RawMessage) error {
-	keysJSON, err := json.MarshalIndent(keys, "  ", "  ")
-	if err != nil {
-		return err
-	}
-	raw["ca_keys"] = keysJSON
-	return writeRaw(path, raw)
 }
 
 // ── callers ───────────────────────────────────────────────────────────────────
@@ -927,8 +913,7 @@ func cmdCallersAdd(args []string) {
 		}
 		action = "updated"
 	}
-	callers[*name] = entry
-	if err := writeCallers(configPath, raw, callers); err != nil {
+	if err := patchConfigEntry(configPath, "callers", *name, entry, false); err != nil {
 		fatalf("writing config: %v", err)
 	}
 	fmt.Printf("caller %q %s (groups=%s)\n", *name, action, *groups)
@@ -993,8 +978,7 @@ func cmdCallersRemove(args []string) {
 		fatalf("caller %q not found", name)
 	}
 
-	delete(callers, name)
-	if err := writeCallers(configPath, raw, callers); err != nil {
+	if err := patchConfigEntry(configPath, "callers", name, nil, true); err != nil {
 		fatalf("writing config: %v", err)
 	}
 	fmt.Printf("caller %q removed\n", name)
@@ -1014,16 +998,6 @@ func extractCallers(raw map[string]json.RawMessage) (map[string]callerEntry, err
 		callers = map[string]callerEntry{}
 	}
 	return callers, nil
-}
-
-// writeCallers serialises callers back into the raw map and writes the file.
-func writeCallers(path string, raw map[string]json.RawMessage, callers map[string]callerEntry) error {
-	callersJSON, err := json.MarshalIndent(callers, "  ", "  ")
-	if err != nil {
-		return err
-	}
-	raw["callers"] = callersJSON
-	return writeRaw(path, raw)
 }
 
 // ── reload ────────────────────────────────────────────────────────────────────
@@ -1270,24 +1244,63 @@ func extractHosts(raw map[string]json.RawMessage) (map[string]hostEntry, error) 
 	return hosts, nil
 }
 
-// writeHosts serialises hosts back into the raw map and writes the file.
-func writeHosts(path string, raw map[string]json.RawMessage, hosts map[string]hostEntry) error {
-	hostsJSON, err := json.MarshalIndent(hosts, "  ", "  ")
+// patchConfigEntry rewrites the config at path so section[name] = value (or
+// removes it when remove is true), PRESERVING the file's // comments, key order
+// and formatting via a format-preserving JSON Patch (confcheck.Patch, #183),
+// written atomically. It is the comment-preserving replacement for the old
+// extract→mutate→re-marshal round trip. When the section object is absent it is
+// created with the single entry.
+func patchConfigEntry(path, section, name string, value any, remove bool) error {
+	orig, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	raw["hosts"] = hostsJSON
-	return writeRaw(path, raw)
+	var ops []map[string]any
+	if remove {
+		ops = []map[string]any{{"op": "remove", "path": "/" + section + "/" + jsonPtrEscape(name)}}
+	} else {
+		std, err := confcheck.Standardize(orig)
+		if err != nil {
+			return err
+		}
+		var top map[string]json.RawMessage
+		if err := json.Unmarshal(std, &top); err != nil {
+			return err
+		}
+		if _, ok := top[section]; ok {
+			ops = []map[string]any{{"op": "add", "path": "/" + section + "/" + jsonPtrEscape(name), "value": value}}
+		} else {
+			ops = []map[string]any{{"op": "add", "path": "/" + section, "value": map[string]any{name: value}}}
+		}
+	}
+	patch, err := json.Marshal(ops)
+	if err != nil {
+		return err
+	}
+	nb, err := confcheck.Patch(orig, patch)
+	if err != nil {
+		return err
+	}
+	return writeConfigAtomic(path, nb)
 }
 
-// writeRaw marshals raw as indented JSON and writes it atomically to path.
-func writeRaw(path string, raw map[string]json.RawMessage) error {
-	out, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
-		return err
+// jsonPtrEscape escapes a JSON Pointer reference token (RFC 6901): "~"→"~0",
+// "/"→"~1", so an arbitrary host/key/caller name is a valid pointer segment.
+func jsonPtrEscape(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+// writeConfigAtomic writes b to path via a temp file + rename, preserving the
+// existing file's permissions (0640 for a new file).
+func writeConfigAtomic(path string, b []byte) error {
+	mode := os.FileMode(0o640)
+	if fi, err := os.Stat(path); err == nil {
+		mode = fi.Mode().Perm()
 	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, append(out, '\n'), 0640); err != nil {
+	if err := os.WriteFile(tmp, b, mode); err != nil {
 		return err
 	}
 	return os.Rename(tmp, path)

--- a/cmd/broker-ctl/main_test.go
+++ b/cmd/broker-ctl/main_test.go
@@ -376,18 +376,10 @@ func TestCAKeysRoundTrip(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	raw, err := loadRaw(cfgPath)
-	if err != nil {
+	if err := patchConfigEntry(cfgPath, "ca_keys", "_default", mustMarshalCAKey(t, caKeyEntry{Type: "pem", Path: "/new/ca.key"}), false); err != nil {
 		t.Fatal(err)
 	}
-	keys, err := extractCAKeys(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	keys["_default"] = mustMarshalCAKey(t, caKeyEntry{Type: "pem", Path: "/new/ca.key"})
-	keys["prod"] = mustMarshalCAKey(t, caKeyEntry{Type: "akv", VaultURL: "https://prod.vault.azure.net", KeyName: "ssh-ca"})
-	if err := writeCAKeys(cfgPath, raw, keys); err != nil {
+	if err := patchConfigEntry(cfgPath, "ca_keys", "prod", mustMarshalCAKey(t, caKeyEntry{Type: "akv", VaultURL: "https://prod.vault.azure.net", KeyName: "ssh-ca"}), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -428,17 +420,7 @@ func TestCAKeysRemoveRoundTrip(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	raw, err := loadRaw(cfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	keys, err := extractCAKeys(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	delete(keys, "prod")
-	if err := writeCAKeys(cfgPath, raw, keys); err != nil {
+	if err := patchConfigEntry(cfgPath, "ca_keys", "prod", nil, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -472,29 +454,10 @@ func TestCAKeysAddRemovePreservaCamposAKV(t *testing.T) {
 	}
 
 	// Add an unrelated entry (as cmdCAKeysAdd does), then remove it again.
-	raw, err := loadRaw(cfgPath)
-	if err != nil {
+	if err := patchConfigEntry(cfgPath, "ca_keys", "lab", mustMarshalCAKey(t, caKeyEntry{Type: "pem", Path: "/lab/ca.key"}), false); err != nil {
 		t.Fatal(err)
 	}
-	keys, err := extractCAKeys(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	keys["lab"] = mustMarshalCAKey(t, caKeyEntry{Type: "pem", Path: "/lab/ca.key"})
-	if err := writeCAKeys(cfgPath, raw, keys); err != nil {
-		t.Fatal(err)
-	}
-
-	raw2, err := loadRaw(cfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	keys2, err := extractCAKeys(raw2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	delete(keys2, "lab")
-	if err := writeCAKeys(cfgPath, raw2, keys2); err != nil {
+	if err := patchConfigEntry(cfgPath, "ca_keys", "lab", nil, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -581,18 +544,10 @@ func TestCallersRoundTrip(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	raw, err := loadRaw(cfgPath)
-	if err != nil {
+	if err := patchConfigEntry(cfgPath, "callers", "broker-prod", callerEntry{AllowedGroups: []string{"prod", "staging"}}, false); err != nil {
 		t.Fatal(err)
 	}
-	callers, err := extractCallers(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	callers["broker-prod"] = callerEntry{AllowedGroups: []string{"prod", "staging"}}
-	callers["broker-dev"] = callerEntry{AllowedGroups: []string{"dev"}}
-	if err := writeCallers(cfgPath, raw, callers); err != nil {
+	if err := patchConfigEntry(cfgPath, "callers", "broker-dev", callerEntry{AllowedGroups: []string{"dev"}}, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -665,8 +620,7 @@ func TestCommandPolicyPreservedOnForce(t *testing.T) {
 		MaxTTLSeconds: 300, // updated TTL
 		CommandPolicy: existing.CommandPolicy,
 	}
-	hosts["web01"] = newEntry
-	if err := writeHosts(cfgPath, raw, hosts); err != nil {
+	if err := patchConfigEntry(cfgPath, "hosts", "web01", newEntry, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -721,8 +675,7 @@ func TestCommandPolicyErasedWhenPolicyFlagsSet(t *testing.T) {
 	}
 	newEntry := hosts["web01"]
 	newEntry.CommandPolicy = newCP
-	hosts["web01"] = newEntry
-	if err := writeHosts(cfgPath, raw, hosts); err != nil {
+	if err := patchConfigEntry(cfgPath, "hosts", "web01", newEntry, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -981,5 +934,51 @@ func TestParseGlobalFlagsRejectsConfigAfterSubcommand(t *testing.T) {
 func TestParseGlobalFlagsUnknownFlag(t *testing.T) {
 	if _, _, _, _, err := parseGlobalFlags([]string{"--nope", "host", "list"}); err == nil {
 		t.Fatal("expected an error for an unknown global flag")
+	}
+}
+
+// TestPatchConfigEntryPreservesComments is the #183 round-trip for broker-ctl's
+// raw config edits: a signer.json carrying // comments has a host added (then the
+// original removed), and the operator's comments survive on disk alongside the
+// change — the whole-map re-marshal used to flatten them.
+func TestPatchConfigEntryPreservesComments(t *testing.T) {
+	t.Parallel()
+	cfgPath := filepath.Join(t.TempDir(), "signer.json")
+	jsonc := `{
+  // operator note: managed hosts
+  "ca_key": "/etc/ca.key",
+  "hosts": {
+    "web01": { "addr": "10.0.0.1:22", "user": "ubuntu" } // pinned
+  }
+}`
+	if err := os.WriteFile(cfgPath, []byte(jsonc), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := patchConfigEntry(cfgPath, "hosts", "db01", hostEntry{Addr: "10.0.0.2:22", User: "postgres"}, false); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(cfgPath)
+	if s := string(b); !strings.Contains(s, "// operator note: managed hosts") || !strings.Contains(s, "// pinned") {
+		t.Errorf("operator // comments must survive a host add:\n%s", s)
+	}
+	raw, err := loadRaw(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hosts, err := extractHosts(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := hosts["db01"]; !ok || len(hosts) != 2 {
+		t.Errorf("the added host must be present alongside the existing one: %v", hosts)
+	}
+
+	// Removing the original host also preserves the top-level comment.
+	if err := patchConfigEntry(cfgPath, "hosts", "web01", nil, true); err != nil {
+		t.Fatal(err)
+	}
+	b2, _ := os.ReadFile(cfgPath)
+	if !strings.Contains(string(b2), "// operator note: managed hosts") {
+		t.Errorf("the top-level comment must survive a host removal:\n%s", b2)
 	}
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,22 +1,37 @@
 {
-  "_comment": "BROKER config. Two signing modes: (LOCAL) define ca_key and policy is inline in hosts (principal/source_address/allow_sudo/allow_pty/command_policy); (REMOTE) define the signer block and the CA key + policy live in the cmd/signer service — in that case hosts only need addr/user/host_key/jump and ca_key/principal/source_address are ignored — the broker logs a single startup warning naming any local-mode field (ca_key, command_policies, per-host policy) present in a remote-mode config, so a present-but-inactive policy is never mistaken for an enforced one.",
+  // BROKER config. Two signing modes: (LOCAL) define ca_key and policy is inline
+  // in hosts (principal/source_address/allow_sudo/allow_pty/command_policy);
+  // (REMOTE) define the signer block and the CA key + policy live in the
+  // cmd/signer service — in that case hosts only need addr/user/host_key/jump and
+  // ca_key/principal/source_address are ignored — the broker logs a single
+  // startup warning naming any local-mode field (ca_key, command_policies,
+  // per-host policy) present in a remote-mode config, so a present-but-inactive
+  // policy is never mistaken for an enforced one.
 
-  "_signer_remoto_comment": "REMOTE mode. url points to the SIGNER directly, or to the CONTROL PLANE (cmd/control-plane) if human approval / guardrails are used — same protocol. approval_wait_seconds: if url is a control plane, how long the broker waits for an approval to be resolved (202 response); 0 = do not wait.",
-  "_signer_remoto_example": {
-    "url": "https://control-plane.internal:7443",
-    "client_cert": "pki/broker.crt",
-    "client_key": "pki/broker.key",
-    "ca": "pki/signer_ca.crt",
-    "approval_wait_seconds": 120
-  },
+  // REMOTE mode. url points to the SIGNER directly, or to the CONTROL PLANE
+  // (cmd/control-plane) if human approval / guardrails are used — same protocol.
+  // approval_wait_seconds: if url is a control plane, how long the broker waits
+  // for an approval to be resolved (202 response); 0 = do not wait. Example:
+  //   "signer": {
+  //     "url": "https://control-plane.internal:7443",
+  //     "client_cert": "pki/broker.crt",
+  //     "client_key": "pki/broker.key",
+  //     "ca": "pki/signer_ca.crt",
+  //     "approval_wait_seconds": 120
+  //   }
 
   "ca_key": "pki/ssh_ca",
-  "_ca_keys_comment": "Multi-CA (local mode only): per-group CA key overrides. '_default' replaces the legacy ca_key. A host's 'groups' field selects which CA signs its certificates (first matching group wins). Ignored when the 'signer' block is set (remote mode). See signer.example.json for the full reference with AKV examples.",
-  "_ca_keys_example": {
-    "_default": { "type": "pem", "path": "pki/ssh_ca" },
-    "prod-web":  { "type": "akv", "vault_url": "https://my-vault.vault.azure.net", "key_name": "ssh-ca-prod-web" },
-    "databases": { "type": "pem", "path": "pki/db_ssh_ca" }
-  },
+
+  // Multi-CA (local mode only): per-group CA key overrides. '_default' replaces
+  // the legacy ca_key. A host's 'groups' field selects which CA signs its
+  // certificates (first matching group wins). Ignored when the 'signer' block is
+  // set (remote mode). See signer.example.json for the full reference with AKV
+  // examples. Example:
+  //   "ca_keys": {
+  //     "_default": { "type": "pem", "path": "pki/ssh_ca" },
+  //     "prod-web":  { "type": "akv", "vault_url": "https://my-vault.vault.azure.net", "key_name": "ssh-ca-prod-web" },
+  //     "databases": { "type": "pem", "path": "pki/db_ssh_ca" }
+  //   }
   "audit_log": "audit.log",
   "audit_key": "pki/audit.seed",
   "source_address": "203.0.113.10",
@@ -24,16 +39,40 @@
   "session_idle_seconds": 300,
   "session_max_seconds": 1800,
 
-  "_recording_comment": "Optional session recording. When set, shell and pty sessions are recorded to ASCIIcast v2 files in this directory. One file per session: <session_id>.cast. Files are playable with 'asciinema play'. Correlate with audit log via session_id. Empty or absent = recording disabled.",
+  // Optional session recording. When set, shell and pty sessions are recorded to
+  // ASCIIcast v2 files in this directory. One file per session: <session_id>.cast.
+  // Files are playable with 'asciinema play'. Correlate with audit log via
+  // session_id. Empty or absent = recording disabled.
   "session_recording_dir": "",
 
-  "_redact_comment": "Optional secret redaction (threat-model gap #8) on this broker's persistent/outbound sinks: the audit log free-text fields (command, err, warning, anomaly) and session recordings. Present — even empty {} — enables the built-in default patterns (password/token flags, mysql -p<pass>, VAR=secret assignments, URI user:pass@, Authorization headers, JWTs, AWS/GitHub/GitLab/Slack tokens, private-key blocks); a secret is replaced by [REDACTED:<rule>]. 'patterns' adds operator rules (RE2 regex; a (?P<secret>...) group masks only the secret, otherwise the whole match); 'disable_defaults' keeps only the operator rules. Redaction happens BEFORE the entry is signed, so 'broker-ctl audit verify' is unaffected — and the original is irrecoverable by design. Best-effort pattern matching, not DLP (see docs/SECURITY.md). NEVER touches the decision path: the signer and the certificate force-command always see the original command. Absent = disabled (previous behaviour).",
+  // Optional secret redaction (threat-model gap #8) on this broker's
+  // persistent/outbound sinks: the audit log free-text fields (command, err,
+  // warning, anomaly) and session recordings. Present — even empty {} — enables
+  // the built-in default patterns (password/token flags, mysql -p<pass>,
+  // VAR=secret assignments, URI user:pass@, Authorization headers, JWTs,
+  // AWS/GitHub/GitLab/Slack tokens, private-key blocks); a secret is replaced by
+  // [REDACTED:<rule>]. 'patterns' adds operator rules (RE2 regex; a
+  // (?P<secret>...) group masks only the secret, otherwise the whole match);
+  // 'disable_defaults' keeps only the operator rules. Redaction happens BEFORE the
+  // entry is signed, so 'broker-ctl audit verify' is unaffected — and the original
+  // is irrecoverable by design. Best-effort pattern matching, not DLP (see
+  // docs/SECURITY.md). NEVER touches the decision path: the signer and the
+  // certificate force-command always see the original command. Absent = disabled
+  // (previous behaviour).
   "redact": {},
 
-  "_file_transfer_comment": "Optional cap (bytes) on a single ssh_put_file / ssh_get_file transfer, per host that sets allow_file_transfer. A transfer larger than the cap is an error, not a truncation. 0 or absent = the built-in default (524288 = 512 KiB).",
+  // Optional cap (bytes) on a single ssh_put_file / ssh_get_file transfer, per
+  // host that sets allow_file_transfer. A transfer larger than the cap is an
+  // error, not a truncation. 0 or absent = the built-in default (524288 = 512
+  // KiB).
   "file_transfer_max_bytes": 524288,
 
-  "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format), started by every frontend (broker, mcp-broker, mcp-broker-http). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: broker_events_total{outcome}, broker_sessions_active, audit_append_failures_total.",
+  // Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics
+  // (Prometheus text format), started by every frontend (broker, mcp-broker,
+  // mcp-broker-http). NO authentication: bind to localhost or a private scrape
+  // interface, never a public address. Empty or absent = disabled. Key metrics:
+  // broker_events_total{outcome}, broker_sessions_active,
+  // audit_append_failures_total.
   "monitor_listen": "127.0.0.1:9180",
 
   "listen": ":8443",
@@ -41,19 +80,29 @@
   "server_key": "pki/broker.key",
   "client_ca": "pki/agents_ca.crt",
 
-  "_oauth_comment": "Used only by the remote MCP frontend cmd/mcp-broker-http. Validates the OIDC bearer token locally against the issuer's JWKS (auto-discovery). resource_url is the canonical URL of this MCP server (included in Protected Resource Metadata and WWW-Authenticate). groups_claim (optional) propagates the user's groups to the signer for per-user RBAC. With OAuth, listen serves HTTPS server-only (no mTLS); client_ca is ignored.",
-  "_resource_url_example": "https://infrabroker.example.com",
-  "_oauth_example": {
-    "issuer": "https://keycloak.example.com/realms/infra",
-    "audience": "https://infrabroker.example.com",
-    "required_scopes": ["mcp:tools"],
-    "user_claim": "preferred_username",
-    "groups_claim": "groups",
-    "max_token_age_seconds": 3600,
-    "clock_skew_seconds": 60
-  },
+  // Used only by the remote MCP frontend cmd/mcp-broker-http. Validates the OIDC
+  // bearer token locally against the issuer's JWKS (auto-discovery). resource_url
+  // is the canonical URL of this MCP server (included in Protected Resource
+  // Metadata and WWW-Authenticate). groups_claim (optional) propagates the user's
+  // groups to the signer for per-user RBAC. With OAuth, listen serves HTTPS
+  // server-only (no mTLS); client_ca is ignored. Example:
+  //   "resource_url": "https://infrabroker.example.com",
+  //   "oauth": {
+  //     "issuer": "https://keycloak.example.com/realms/infra",
+  //     "audience": "https://infrabroker.example.com",
+  //     "required_scopes": ["mcp:tools"],
+  //     "user_claim": "preferred_username",
+  //     "groups_claim": "groups",
+  //     "max_token_age_seconds": 3600,
+  //     "clock_skew_seconds": 60
+  //   }
 
-  "_command_policies_comment": "Local mode: named command-policy library + group mapping. A host's effective firewall is the COMPOSITION of its inline 'command_policy' plus every policy of every group it belongs to (additive: deny wins, allow is a union, require_approval is a union, shell_parse is OR). '_default' applies to every host. Define a policy once, attach it to groups, and let hosts pick it up via their 'groups' field. In remote mode these two sections live in signer.json.",
+  // Local mode: named command-policy library + group mapping. A host's effective
+  // firewall is the COMPOSITION of its inline 'command_policy' plus every policy of
+  // every group it belongs to (additive: deny wins, allow is a union,
+  // require_approval is a union, shell_parse is OR). '_default' applies to every
+  // host. Define a policy once, attach it to groups, and let hosts pick it up via
+  // their 'groups' field. In remote mode these two sections live in signer.json.
   "command_policies": {
     "ro-sys":    { "mode": "allowlist", "shell_parse": true, "allow": ["^uptime$", "^free( .*)?$", "^df( .*)?$", "^journalctl ", "^systemctl (status|show|is-active) "] },
     "no-danger": { "mode": "denylist", "deny": ["^rm ", "^reboot$", "^shutdown", "^mkfs", "^dd "] }
@@ -68,24 +117,35 @@
       "addr": "bastion.example.com:22",
       "user": "ops",
       "principal": "host:bastion",
-      "host_key": "ssh-ed25519 AAAA... (bastion host key)",
-      "_bastion_comment": "Local mode (v1.13.0): a host referenced as another host's 'jump' is auto-enabled as a bastion (as here, web01 jumps through it). For a standalone bastion set \"allow_as_bastion\": true explicitly. Leaf hosts are no longer bastionable by default."
+      "host_key": "ssh-ed25519 AAAA... (bastion host key)"
+      // Local mode (v1.13.0): a host referenced as another host's 'jump' is
+      // auto-enabled as a bastion (as here, web01 jumps through it). For a
+      // standalone bastion set "allow_as_bastion": true explicitly. Leaf hosts are
+      // no longer bastionable by default.
     },
     "web01": {
       "addr": "10.0.0.21:22",
       "user": "deploy",
       "principal": "host:web01",
       "host_key": "ssh-ed25519 AAAA... (web01 host key)",
-      "_jump_comment": "reachable only via bastion. source_address = egress IP of the BASTION (not the broker), because the TCP connection to web01 originates from the bastion.",
+      // reachable only via bastion. source_address = egress IP of the BASTION (not
+      // the broker), because the TCP connection to web01 originates from the
+      // bastion.
       "jump": "bastion",
       "source_address": "10.0.0.1",
-      "_groups_comment": "Local mode: groups controls which CA signs certificates for this host (multi-CA) and which callers can reach it (per-user RBAC).",
+      // Local mode: groups controls which CA signs certificates for this host
+      // (multi-CA) and which callers can reach it (per-user RBAC).
       "groups": ["prod-web"],
-      "_sudo_comment": "Local mode: enables NOPASSWD sudo to root and 'appuser'. Also enables PTY.",
+      // Local mode: enables NOPASSWD sudo to root and 'appuser'. Also enables PTY.
       "allow_sudo": true,
       "allowed_sudo_users": ["root", "appuser"],
       "allow_pty": true,
-      "_command_policy_comment": "AI-action firewall (local mode). mode allowlist/denylist/off; enforcement enforce(default)/audit. Use audit only for baseline collection: commands run but return/audit warnings such as would_deny or would_require_approval. mode=exec sessions are preflighted per ssh_session_exec; shell/pty sessions are rejected on command_policy hosts. In remote mode this lives in signer.json.",
+      // AI-action firewall (local mode). mode allowlist/denylist/off; enforcement
+      // enforce(default)/audit. Use audit only for baseline collection: commands
+      // run but return/audit warnings such as would_deny or would_require_approval.
+      // mode=exec sessions are preflighted per ssh_session_exec; shell/pty sessions
+      // are rejected on command_policy hosts. In remote mode this lives in
+      // signer.json.
       "command_policy": {
         "mode": "allowlist",
         "enforcement": "enforce",

--- a/config.minimal.example.json
+++ b/config.minimal.example.json
@@ -1,10 +1,23 @@
 {
-  "_comment": "MINIMAL local-mode config for the single-binary mcp-broker (stdio). In-process signing with a local CA — NO signer service and NO mTLS PKI. This is the on-ramp (see docs/QUICKSTART.md), not the production recommendation: a local PEM CA is lab/dev custody. Graduate to remote mode (config.example.json + signer.example.json) for separated CA custody, human approvals, and RBAC.",
-  "_files_comment": "Paths are relative to the broker's working directory; use absolute paths in a real install. audit_key is a >=32-byte Ed25519 seed: create it once with `head -c 32 /dev/urandom > audit.key`. ca_key is the SSH CA private key from `ssh-keygen -t ed25519 -f ssh_ca -N ''`.",
+  // MINIMAL local-mode config for the single-binary mcp-broker (stdio). In-process
+  // signing with a local CA — NO signer service and NO mTLS PKI. This is the
+  // on-ramp (see docs/QUICKSTART.md), not the production recommendation: a local
+  // PEM CA is lab/dev custody. Graduate to remote mode (config.example.json +
+  // signer.example.json) for separated CA custody, human approvals, and RBAC.
+
+  // Paths are relative to the broker's working directory; use absolute paths in a
+  // real install. audit_key is a >=32-byte Ed25519 seed: create it once with
+  // `head -c 32 /dev/urandom > audit.key`. ca_key is the SSH CA private key from
+  // `ssh-keygen -t ed25519 -f ssh_ca -N ''`.
   "audit_log": "audit.log",
   "audit_key": "audit.key",
   "ca_key": "ssh_ca",
-  "_hosts_comment": "One host you already reach over SSH. addr host:port; user the login account; host_key the line from `ssh-keyscan -t ed25519 <host>` (pins the server, prevents MITM); principal any label — it must be listed for `user` in the host's AuthorizedPrincipalsFile (see docs/QUICKSTART.md). command_policy is a small allowlist so the AI-action firewall is visible from the first command.",
+
+  // One host you already reach over SSH. addr host:port; user the login account;
+  // host_key the line from `ssh-keyscan -t ed25519 <host>` (pins the server,
+  // prevents MITM); principal any label — it must be listed for `user` in the
+  // host's AuthorizedPrincipalsFile (see docs/QUICKSTART.md). command_policy is a
+  // small allowlist so the AI-action firewall is visible from the first command.
   "hosts": {
     "myhost": {
       "addr": "myhost.example.com:22",

--- a/control-plane.example.json
+++ b/control-plane.example.json
@@ -1,17 +1,31 @@
 {
-  "_comment": "CONTROL PLANE config (cmd/control-plane). Sits between the broker and the signer: forwards signing requests propagating the broker identity (on_behalf_of) and orchestrates human approval for commands flagged as require_approval by the command policy. Does NOT hold the CA key (lives in the signer). Its mTLS client CN toward the signer must be in 'trusted_forwarders' in signer.json.",
+  // CONTROL PLANE config (cmd/control-plane). Sits between the broker and the
+  // signer: forwards signing requests propagating the broker identity
+  // (on_behalf_of) and orchestrates human approval for commands flagged as
+  // require_approval by the command policy. Does NOT hold the CA key (lives in
+  // the signer). Its mTLS client CN toward the signer must be in
+  // 'trusted_forwarders' in signer.json.
 
   "listen": ":7443",
 
-  "_server_tls_comment": "mTLS toward the BROKER: presents server_cert and requires clients (brokers and approvers) signed by client_ca. Since the same CA signs both roles, the broker and approver roles are separated by 'sign_callers' (below) and 'approval.callers'.",
+  // mTLS toward the BROKER: presents server_cert and requires clients (brokers
+  // and approvers) signed by client_ca. Since the same CA signs both roles, the
+  // broker and approver roles are separated by 'sign_callers' (below) and
+  // 'approval.callers'.
   "server_cert": "pki/control-plane.crt",
   "server_key": "pki/control-plane.key",
   "client_ca": "pki/mtls_ca.crt",
 
-  "_sign_callers_comment": "Broker CNs authorised to use the signing path (/v1/sign, /v1/hosts, /v1/sign/result). Non-empty = exact allowlist. Empty/absent = any authenticated broker EXCEPT a CN listed in 'approval.callers' (an approver is not a broker and is denied the sign path — role separation, secure by default). Set this explicitly to pin which brokers may originate signing requests.",
+  // Broker CNs authorised to use the signing path (/v1/sign, /v1/hosts,
+  // /v1/sign/result). Non-empty = exact allowlist. Empty/absent = any
+  // authenticated broker EXCEPT a CN listed in 'approval.callers' (an approver is
+  // not a broker and is denied the sign path — role separation, secure by
+  // default). Set this explicitly to pin which brokers may originate signing
+  // requests.
   "sign_callers": ["broker-1"],
 
-  "_signer_comment": "mTLS client toward the SIGNER. The cert (CN=control-plane-1) must be in trusted_forwarders in the signer.",
+  // mTLS client toward the SIGNER. The cert (CN=control-plane-1) must be in
+  // trusted_forwarders in the signer.
   "signer": {
     "url": "https://127.0.0.1:9443",
     "client_cert": "pki/control-plane.crt",
@@ -19,7 +33,21 @@
     "ca": "pki/signer_ca.crt"
   },
 
-  "_approval_comment": "Human approval. notifier is fail-closed at startup: only 'log' (default, writes the request to the log; approver uses 'broker-ctl approval list' or the built-in UI at /ui/approvals), 'webhook' (plain JSON POST to webhook_url, e.g. a Slack receiver) or 'teams' (Adaptive Card or MessageCard to a Microsoft Teams / Power Automate Workflow Incoming Webhook) are accepted. teams_format is also validated: 'workflow' (default, recommended for Power Automate), 'adaptivecard' (alias for workflow), or 'messagecard' (legacy M365 Connectors, being deprecated). approval_url_template: URL with '{id}' substituted by the approval ID; embedded as a 'View request' button in the Teams card. Point it at the built-in approval UI, e.g. 'https://cp.example:7443/ui/approvals/{id}' (the approver's browser needs an mTLS client cert whose CN is in approval.callers). timeout_seconds: TTL for pending requests from creation and for approved-but-uncollected requests from decision. callers: CNs authorised to approve/deny (POST /v1/approvals/{id} and the UI).",
+  // Human approval. notifier is fail-closed at startup: only 'log' (default,
+  // writes the request to the log; approver uses 'broker-ctl approval list' or
+  // the built-in UI at /ui/approvals), 'webhook' (plain JSON POST to webhook_url,
+  // e.g. a Slack receiver) or 'teams' (Adaptive Card or MessageCard to a
+  // Microsoft Teams / Power Automate Workflow Incoming Webhook) are accepted.
+  // teams_format is also validated: 'workflow' (default, recommended for Power
+  // Automate), 'adaptivecard' (alias for workflow), or 'messagecard' (legacy M365
+  // Connectors, being deprecated). approval_url_template: URL with '{id}'
+  // substituted by the approval ID; embedded as a 'View request' button in the
+  // Teams card. Point it at the built-in approval UI, e.g.
+  // 'https://cp.example:7443/ui/approvals/{id}' (the approver's browser needs an
+  // mTLS client cert whose CN is in approval.callers). timeout_seconds: TTL for
+  // pending requests from creation and for approved-but-uncollected requests from
+  // decision. callers: CNs authorised to approve/deny (POST /v1/approvals/{id}
+  // and the UI).
   "approval": {
     "notifier": "log",
     "webhook_url": "",
@@ -29,24 +57,63 @@
     "approval_url_template": "https://cp.example:7443/ui/approvals/{id}"
   },
 
-  "_behavior_comment": "Per-agent behaviour guardrails. The subject is the authenticated broker CN; it is qualified as '<broker CN>:<end_user>' only when the broker CN is listed in trusted_forwarders below (end_user is an unauthenticated request field — keying on it directly would let a client evade rate limits and anomaly detection by rotating it). mode is fail-closed at startup: only 'off' (default) | 'observe' (audits anomalies only) | 'enforce' (anomalies escalate to human approval; rate exceeded is denied with 429) are accepted. Anomalies: rate spike, host never used before by that agent, command outside its history (fingerprint = first token). rate_limit_per_min: maximum requests per subject per minute (0 = no limit). State is in-memory and bounded: the subject table is capped (max_subjects, default 4096) with least-recently-seen + idle-TTL eviction (subject_ttl_minutes, default 1440), and each subject's host/command history is capped (max_distinct_per_subject, default 1024); these optional fields default sanely and rarely need tuning. Restarting the control plane resets the baseline.",
+  // Per-agent behaviour guardrails. The subject is the authenticated broker CN;
+  // it is qualified as '<broker CN>:<end_user>' only when the broker CN is listed
+  // in trusted_forwarders below (end_user is an unauthenticated request field —
+  // keying on it directly would let a client evade rate limits and anomaly
+  // detection by rotating it). mode is fail-closed at startup: only 'off'
+  // (default) | 'observe' (audits anomalies only) | 'enforce' (anomalies escalate
+  // to human approval; rate exceeded is denied with 429) are accepted. Anomalies:
+  // rate spike, host never used before by that agent, command outside its history
+  // (fingerprint = first token). rate_limit_per_min: maximum requests per subject
+  // per minute (0 = no limit). State is in-memory and bounded: the subject table
+  // is capped (max_subjects, default 4096) with least-recently-seen + idle-TTL
+  // eviction (subject_ttl_minutes, default 1440), and each subject's host/command
+  // history is capped (max_distinct_per_subject, default 1024); these optional
+  // fields default sanely and rarely need tuning. Restarting the control plane
+  // resets the baseline.
   "behavior": {
     "mode": "observe",
     "rate_limit_per_min": 60
   },
 
-  "_trusted_forwarders_comment": "Broker client cert CNs whose end_user claim is trusted (brokers that authenticate end users, e.g. via OIDC). Mirrors trusted_forwarders in signer.json. Only for these CNs do the behaviour guardrails key on '<broker CN>:<end_user>'; for any other CN the end_user field is ignored and the broker CN alone is used. Empty/absent = end_user never qualifies the subject.",
+  // Broker client cert CNs whose end_user claim is trusted (brokers that
+  // authenticate end users, e.g. via OIDC). Mirrors trusted_forwarders in
+  // signer.json. Only for these CNs do the behaviour guardrails key on
+  // '<broker CN>:<end_user>'; for any other CN the end_user field is ignored and
+  // the broker CN alone is used. Empty/absent = end_user never qualifies the
+  // subject.
   "trusted_forwarders": [],
 
   "audit_log": "control_plane_audit.log",
   "audit_key": "pki/control_plane_audit.seed",
 
-  "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: controlplane_events_total{outcome}, controlplane_approvals_pending, audit_append_failures_total.",
+  // Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics
+  // (Prometheus text format). NO authentication: bind to localhost or a private
+  // scrape interface, never a public address. Empty or absent = disabled. Key
+  // metrics: controlplane_events_total{outcome}, controlplane_approvals_pending,
+  // audit_append_failures_total.
   "monitor_listen": "127.0.0.1:9170",
 
-  "_redact_comment": "Optional secret redaction (threat-model gap #8) on the control plane's persistent/outbound sinks: the audit log free-text fields AND the approval notification payload (log/webhook/Teams — the notification persists in a log or leaves the host). Present — even empty {} — enables the built-in default patterns; 'patterns' adds operator RE2 rules ((?P<secret>...) masks only the secret); 'disable_defaults' keeps only the operator rules. The approval registry keeps the ORIGINAL command: the mTLS approval UI (/ui/approvals) and GET /v1/approvals show the approver exactly what will run, and the approved request forwarded to the signer is untouched. Absent = disabled.",
+  // Optional secret redaction (threat-model gap #8) on the control plane's
+  // persistent/outbound sinks: the audit log free-text fields AND the approval
+  // notification payload (log/webhook/Teams — the notification persists in a log
+  // or leaves the host). Present — even empty {} — enables the built-in default
+  // patterns; 'patterns' adds operator RE2 rules ((?P<secret>...) masks only the
+  // secret); 'disable_defaults' keeps only the operator rules. The approval
+  // registry keeps the ORIGINAL command: the mTLS approval UI (/ui/approvals) and
+  // GET /v1/approvals show the approver exactly what will run, and the approved
+  // request forwarded to the signer is untouched. Absent = disabled.
   "redact": {},
 
-  "_state_db_comment": "Optional SQLite database persisting the approval registry (pending and approved-but-uncollected requests, with the original wire request — public material only) across restarts (pure-Go driver, no system dependency). Empty or absent = in-memory only (a restart clears pending approvals). If set and the file cannot be opened/migrated, the service refuses to start (fail-closed). WAL mode leaves state.db-wal/-shm sidecar files next to it — include all three in backups. The behaviour baseline stays in-memory by design (it re-learns quickly). Production: /var/lib/infrabroker/control-plane/state.db.",
+  // Optional SQLite database persisting the approval registry (pending and
+  // approved-but-uncollected requests, with the original wire request — public
+  // material only) across restarts (pure-Go driver, no system dependency). Empty
+  // or absent = in-memory only (a restart clears pending approvals). If set and
+  // the file cannot be opened/migrated, the service refuses to start
+  // (fail-closed). WAL mode leaves state.db-wal/-shm sidecar files next to it —
+  // include all three in backups. The behaviour baseline stays in-memory by
+  // design (it re-learns quickly). Production:
+  // /var/lib/infrabroker/control-plane/state.db.
   "state_db": ""
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -79,6 +79,16 @@
   `//` comments, key order, and formatting survive an allow-rule edit instead of
   being flattened by a parse→marshal round trip. (`broker-ctl`'s own host/CA/caller
   edits and the `.example.json` conversion remain the last follow-up.)
+- **JSONC config, completed (#183, part 3 — broker-ctl writes + examples)** —
+  `broker-ctl`'s config edits (`host`/`ca-keys`/`callers` add & remove) now rewrite
+  the file with the same format-preserving JSON Patch, so an operator's `//`
+  comments survive a host/CA/caller edit (they were previously flattened by the
+  whole-map re-marshal). And the five shipped `*.example.json` files are converted
+  from `_*`-key comments to real `//` comments — self-documenting JSONC that the
+  anti-drift tests validate through the new loader. This closes #183: every config
+  file accepts JSONC on load, every rewrite path preserves comments, and the
+  examples demonstrate the canonical style (legacy `_*` comment keys still load,
+  deprecated).
 
 ### Changed
 - **Per-agent action-budgets framing (#123)** — the README and

--- a/signer.example.json
+++ b/signer.example.json
@@ -1,66 +1,118 @@
 {
-  "_comment": "SIGNING SERVICE config (cmd/signer). Holds the CA key and the policy. Brokers request certs via mTLS; the CN of their client cert is the 'caller'.",
+  // SIGNING SERVICE config (cmd/signer). Holds the CA key and the policy. Brokers
+  // request certs via mTLS; the CN of their client cert is the 'caller'.
 
   "listen": ":9443",
   "server_cert": "pki/signer.crt",
   "server_key": "pki/signer.key",
   "client_ca": "pki/brokers_ca.crt",
 
-  "_ca_key_comment": "Custody: PEM for now; replaceable with a crypto.Signer from KMS/Secure Enclave/HSM without touching the rest (ca.LoadCAFromPEM → ssh.Signer).",
+  // Custody: PEM for now; replaceable with a crypto.Signer from KMS/Secure
+  // Enclave/HSM without touching the rest (ca.LoadCAFromPEM → ssh.Signer).
   "ca_key": "pki/ssh_ca",
 
-  "_ca_keys_comment": "Multi-CA: per-group CA key overrides. The reserved key '_default' replaces the legacy ca_key above when present. Hosts whose 'groups' field contains a key in ca_keys use that CA; the first matching group wins; other hosts fall back to the default CA. Supported types: 'pem' (local PEM file — emits a warning, lab/dev only), 'akv' (Azure Key Vault — the private key never leaves AKV), and 'agent' (the CA private key lives in a running ssh-agent — YubiKey PIV / SoftHSM / TPM via 'ssh-add -s'; 'public_key_path' is REQUIRED and pins which agent key is the CA, 'socket' defaults to $SSH_AUTH_SOCK). AKV supports RSA (2048/3072/4096) and EC (P-256/P-384/P-521); Ed25519 is NOT supported by AKV but IS supported by 'agent'.",
-  "_ca_keys_example": {
-    "_default": {
-      "type": "akv",
-      "vault_url": "https://my-vault.vault.azure.net",
-      "key_name": "ssh-ca-default"
-    },
-    "prod-web": {
-      "type": "akv",
-      "vault_url": "https://my-vault.vault.azure.net",
-      "key_name": "ssh-ca-prod-web"
-    },
-    "databases": {
-      "type": "pem",
-      "path": "pki/db_ssh_ca"
-    },
-    "secrets": {
-      "type": "agent",
-      "public_key_path": "pki/ssh_ca_agent.pub",
-      "socket": "/run/infrabroker/ssh-agent.sock"
-    }
-  },
+  // Multi-CA: per-group CA key overrides. The reserved key '_default' replaces the
+  // legacy ca_key above when present. Hosts whose 'groups' field contains a key in
+  // ca_keys use that CA; the first matching group wins; other hosts fall back to
+  // the default CA. Supported types: 'pem' (local PEM file — emits a warning,
+  // lab/dev only), 'akv' (Azure Key Vault — the private key never leaves AKV), and
+  // 'agent' (the CA private key lives in a running ssh-agent — YubiKey PIV /
+  // SoftHSM / TPM via 'ssh-add -s'; 'public_key_path' is REQUIRED and pins which
+  // agent key is the CA, 'socket' defaults to $SSH_AUTH_SOCK). AKV supports RSA
+  // (2048/3072/4096) and EC (P-256/P-384/P-521); Ed25519 is NOT supported by AKV
+  // but IS supported by 'agent'. Example:
+  //   "ca_keys": {
+  //     "_default":  { "type": "akv", "vault_url": "https://my-vault.vault.azure.net", "key_name": "ssh-ca-default" },
+  //     "prod-web":  { "type": "akv", "vault_url": "https://my-vault.vault.azure.net", "key_name": "ssh-ca-prod-web" },
+  //     "databases": { "type": "pem", "path": "pki/db_ssh_ca" },
+  //     "secrets":   { "type": "agent", "public_key_path": "pki/ssh_ca_agent.pub", "socket": "/run/infrabroker/ssh-agent.sock" }
+  //   }
 
   "audit_log": "signer_audit.log",
   "audit_key": "pki/signer_audit.seed",
   "max_ttl_seconds": 300,
 
-  "_auto_reload_comment": "Optional: if > 0, the signer polls this file's mtime every N seconds and hot-reloads on change (same validated, atomic path as SIGHUP / POST /v1/reload — a half-written file mid-save is rejected and the previous good state kept). 0 or absent = disabled. Convenient with GitOps or hand edits; pair with restrictive file permissions since any writer of this file then changes policy.",
+  // Optional: if > 0, the signer polls this file's mtime every N seconds and
+  // hot-reloads on change (same validated, atomic path as SIGHUP / POST /v1/reload
+  // — a half-written file mid-save is rejected and the previous good state kept).
+  // 0 or absent = disabled. Convenient with GitOps or hand edits; pair with
+  // restrictive file permissions since any writer of this file then changes policy.
   "auto_reload_seconds": 0,
 
-  "_monitor_comment": "Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics (Prometheus text format). NO authentication: bind to localhost or a private scrape interface, never a public address. Empty or absent = disabled. Key metrics: signer_sign_requests_total{outcome} (includes outcome='rate-limited', which is not audited by design), audit_append_failures_total.",
+  // Optional plain-HTTP monitoring listener with /healthz (liveness) and /metrics
+  // (Prometheus text format). NO authentication: bind to localhost or a private
+  // scrape interface, never a public address. Empty or absent = disabled. Key
+  // metrics: signer_sign_requests_total{outcome} (includes outcome='rate-limited',
+  // which is not audited by design), audit_append_failures_total.
   "monitor_listen": "127.0.0.1:9160",
 
-  "_redact_comment": "Optional secret redaction on the signer's audit log free-text fields (threat-model gap #8). The signer's audit records request metadata rather than the raw command, but error strings can embed user text — every persistent sink applies the same invariant. Present — even empty {} — enables the built-in default patterns; 'patterns' adds operator RE2 rules; 'disable_defaults' keeps only the operator rules. Applied before the entry is signed (verification unaffected). Absent = disabled.",
+  // Optional secret redaction on the signer's audit log free-text fields
+  // (threat-model gap #8). The signer's audit records request metadata rather than
+  // the raw command, but error strings can embed user text — every persistent sink
+  // applies the same invariant. Present — even empty {} — enables the built-in
+  // default patterns; 'patterns' adds operator RE2 rules; 'disable_defaults' keeps
+  // only the operator rules. Applied before the entry is signed (verification
+  // unaffected). Absent = disabled.
   "redact": {},
 
-  "_sign_rate_limit_comment": "Optional per-CN rate limit on POST /v1/sign (threat-model gap #4): token bucket keyed on the authenticated mTLS peer CN — burst up to the cap, continuous refill — checked before the request body is parsed. Excess requests get 429 with a Retry-After hint; rejections are deliberately NOT written to the audit log (the log must not become the flooding amplifier). Hot-reloadable. 0 or absent = disabled. Recommended in production; size it to your busiest legitimate broker (each ssh_execute is one sign call, each ssh_session_exec one preflight call).",
+  // Optional per-CN rate limit on POST /v1/sign (threat-model gap #4): token bucket
+  // keyed on the authenticated mTLS peer CN — burst up to the cap, continuous
+  // refill — checked before the request body is parsed. Excess requests get 429
+  // with a Retry-After hint; rejections are deliberately NOT written to the audit
+  // log (the log must not become the flooding amplifier). Hot-reloadable. 0 or
+  // absent = disabled. Recommended in production; size it to your busiest
+  // legitimate broker (each ssh_execute is one sign call, each ssh_session_exec one
+  // preflight call).
   "sign_rate_limit_per_min": 120,
 
-  "_max_grant_ttl_comment": "Optional upper bound (seconds) on a runtime grant's TTL. Applies to BOTH widen-only grants (POST /v1/policy/hosts/{host}/grants, 'broker-ctl policy grant' — a longer request is rejected 400) AND approve-and-learn approval waivers ('broker-ctl approval allow <id> --learn --ttl' — a longer request is CLAMPED to this cap, never rejected, since the certificate was already issued). 0 or absent = no cap. Grants are operator-only (reload_callers); waivers are minted only from a trusted_forwarder after an approval and scoped to the approved broker/end-user subject. Without state_db below, grants/waivers are in-memory (lost on restart, kept across reloads).",
+  // Optional upper bound (seconds) on a runtime grant's TTL. Applies to BOTH
+  // widen-only grants (POST /v1/policy/hosts/{host}/grants, 'broker-ctl policy
+  // grant' — a longer request is rejected 400) AND approve-and-learn approval
+  // waivers ('broker-ctl approval allow <id> --learn --ttl' — a longer request is
+  // CLAMPED to this cap, never rejected, since the certificate was already issued).
+  // 0 or absent = no cap. Grants are operator-only (reload_callers); waivers are
+  // minted only from a trusted_forwarder after an approval and scoped to the
+  // approved broker/end-user subject. Without state_db below, grants/waivers are
+  // in-memory (lost on restart, kept across reloads).
   "max_grant_ttl_seconds": 0,
 
-  "_state_db_comment": "Optional SQLite database persisting runtime grants, approve-and-learn waivers, and the kill-switch freeze set (#117) across restarts (pure-Go driver, no system dependency). Empty or absent = in-memory only: a restart drops grants/waivers (fail-safe, since grants only widen) but ALSO drops freezes, which fails OPEN — a frozen subject silently regains access — so set state_db in production. If set and the file cannot be opened/migrated, the signer refuses to start (fail-closed). WAL mode leaves state.db-wal/-shm sidecar files next to it — include all three in backups. Production: /var/lib/infrabroker/signer/state.db.",
+  // Optional SQLite database persisting runtime grants, approve-and-learn waivers,
+  // and the kill-switch freeze set (#117) across restarts (pure-Go driver, no
+  // system dependency). Empty or absent = in-memory only: a restart drops
+  // grants/waivers (fail-safe, since grants only widen) but ALSO drops freezes,
+  // which fails OPEN — a frozen subject silently regains access — so set state_db
+  // in production. If set and the file cannot be opened/migrated, the signer
+  // refuses to start (fail-closed). WAL mode leaves state.db-wal/-shm sidecar files
+  // next to it — include all three in backups. Production:
+  // /var/lib/infrabroker/signer/state.db.
   "state_db": "",
 
-  "_reload_comment": "Client cert CNs authorised to invoke POST /v1/reload (hot-reload the host policy, max_ttl_seconds, and the CA key) AND the policy-change APIs over mTLS: the validated mutation API POST/DELETE /v1/policy/hosts/{host}/allow (durable add/remove of a command-policy allow rule, e.g. 'broker-ctl policy add') and the runtime grants API POST /v1/policy/hosts/{host}/grants · GET /v1/policy/grants · DELETE /v1/policy/grants/{id} (temporary, expiring, widen-only grants, e.g. 'broker-ctl policy grant'). Same 'may change policy' trust tier. Empty or absent = those HTTP endpoints disabled (403); SIGHUP still works because it is local to the host. listen, TLS, and audit_log require a restart.",
+  // Client cert CNs authorised to invoke POST /v1/reload (hot-reload the host
+  // policy, max_ttl_seconds, and the CA key) AND the policy-change APIs over mTLS:
+  // the validated mutation API POST/DELETE /v1/policy/hosts/{host}/allow (durable
+  // add/remove of a command-policy allow rule, e.g. 'broker-ctl policy add') and
+  // the runtime grants API POST /v1/policy/hosts/{host}/grants · GET
+  // /v1/policy/grants · DELETE /v1/policy/grants/{id} (temporary, expiring,
+  // widen-only grants, e.g. 'broker-ctl policy grant'). Same 'may change policy'
+  // trust tier. Empty or absent = those HTTP endpoints disabled (403); SIGHUP still
+  // works because it is local to the host. listen, TLS, and audit_log require a
+  // restart.
   "reload_callers": ["broker-admin"],
 
-  "_trusted_forwarders_comment": "CNs authorised to act on behalf of another broker (on_behalf_of field / X-On-Behalf-Of header). This is the control plane CN (cmd/control-plane). Only these CNs may (a) impersonate a broker for RBAC and (b) set approved=true to issue commands that require approval. A regular broker must NOT be listed here. Empty/absent = nobody can impersonate (direct broker→signer still works).",
+  // CNs authorised to act on behalf of another broker (on_behalf_of field /
+  // X-On-Behalf-Of header). This is the control plane CN (cmd/control-plane). Only
+  // these CNs may (a) impersonate a broker for RBAC and (b) set approved=true to
+  // issue commands that require approval. A regular broker must NOT be listed here.
+  // Empty/absent = nobody can impersonate (direct broker→signer still works).
   "trusted_forwarders": ["control-plane-1"],
 
-  "_callers_comment": "Group-based RBAC. Maps broker mTLS cert CN → allowed groups. An absent CN has no group restriction (backward compatible): sees and signs all hosts — UNLESS the reserved '_default' entry exists, in which case absent CNs inherit it ('_default': {'allowed_groups': []} = default-deny, recommended for production). A present CN can only see (/v1/hosts) and sign (/v1/sign) hosts whose 'groups' field intersects with its allowed_groups. Empty allowed_groups = total denial.",
+  // Group-based RBAC. Maps broker mTLS cert CN → allowed groups. An absent CN has
+  // no group restriction (backward compatible): sees and signs all hosts — UNLESS
+  // the reserved '_default' entry exists, in which case absent CNs inherit it
+  // ('_default': {'allowed_groups': []} = default-deny, recommended for
+  // production). A present CN can only see (/v1/hosts) and sign (/v1/sign) hosts
+  // whose 'groups' field intersects with its allowed_groups. Empty allowed_groups =
+  // total denial.
   "callers": {
     "broker-1":    { "allowed_groups": ["prod-web", "databases"] },
     "broker-web":  { "allowed_groups": ["prod-web"] },
@@ -68,19 +120,35 @@
     "_default":    { "allowed_groups": [] }
   },
 
-  "_command_policies_comment": "Named command-policy library (AI-action firewall). Define a policy once and attach it to groups via 'group_command_policies'. A host's effective firewall is the COMPOSITION of its inline 'command_policy' plus every policy of every group it belongs to. Composition is additive: deny wins, allow is a UNION, require_approval is a union, and shell_parse is OR. enforcement defaults to enforce; audit lets commands run and emits would_deny/would_require_approval warnings. In composition, enforce wins over audit.",
+  // Named command-policy library (AI-action firewall). Define a policy once and
+  // attach it to groups via 'group_command_policies'. A host's effective firewall
+  // is the COMPOSITION of its inline 'command_policy' plus every policy of every
+  // group it belongs to. Composition is additive: deny wins, allow is a UNION,
+  // require_approval is a union, and shell_parse is OR. enforcement defaults to
+  // enforce; audit lets commands run and emits would_deny/would_require_approval
+  // warnings. In composition, enforce wins over audit.
   "command_policies": {
     "ro-sys":    { "mode": "allowlist", "shell_parse": true, "allow": ["^uptime$", "^free( .*)?$", "^df( .*)?$", "^journalctl ", "^systemctl (status|show|is-active) "] },
     "no-danger": { "mode": "denylist", "deny": ["^rm ", "^reboot$", "^shutdown", "^mkfs", "^dd "] }
   },
 
-  "_group_command_policies_comment": "Maps a group name to the policy names from 'command_policies' that apply to its hosts. The reserved group '_default' applies to EVERY host (mirrors ca_keys '_default'). A host gets the union of the policies of all its groups plus '_default'. Groups not listed here contribute no firewall (they still drive RBAC and CA selection).",
+  // Maps a group name to the policy names from 'command_policies' that apply to its
+  // hosts. The reserved group '_default' applies to EVERY host (mirrors ca_keys
+  // '_default'). A host gets the union of the policies of all its groups plus
+  // '_default'. Groups not listed here contribute no firewall (they still drive
+  // RBAC and CA selection).
   "group_command_policies": {
     "_default": ["no-danger"],
     "prod-web": ["ro-sys"]
   },
 
-  "_hosts_comment": "Per-host issuance policy. The 'groups' field declares the RBAC groups this host belongs to; a restricted caller only sees it if they share at least one group. If 'groups' is absent, the host belongs to no group (restricted callers will not see it). Empty allowed_callers = any authenticated broker; allow_as_bastion enables the host as a ProxyJump target. WARNING: if a host uses 'jump', the bastion must be in the same groups or the broker will not be able to resolve the chain.",
+  // Per-host issuance policy. The 'groups' field declares the RBAC groups this host
+  // belongs to; a restricted caller only sees it if they share at least one group.
+  // If 'groups' is absent, the host belongs to no group (restricted callers will
+  // not see it). Empty allowed_callers = any authenticated broker; allow_as_bastion
+  // enables the host as a ProxyJump target. WARNING: if a host uses 'jump', the
+  // bastion must be in the same groups or the broker will not be able to resolve
+  // the chain.
   "hosts": {
     "bastion": {
       "principal": "host:bastion",
@@ -94,10 +162,12 @@
       "source_address": "10.0.0.1",
       "max_ttl_seconds": 120,
       "groups": ["prod-web"],
-      "_sudo_comment": "Enables sudo to root only (empty allowed_sudo_users implies root only).",
+      // Enables sudo to root only (empty allowed_sudo_users implies root only).
       "allow_sudo": true,
       "allow_pty": true,
-      "_file_transfer_comment": "Enables ssh_put_file / ssh_get_file on this host (default false — secure by default). Transfers run as the SSH user (no sudo) and the generated command (cat > path / bounded read) is still subject to command_policy.",
+      // Enables ssh_put_file / ssh_get_file on this host (default false — secure by
+      // default). Transfers run as the SSH user (no sudo) and the generated command
+      // (cat > path / bounded read) is still subject to command_policy.
       "allow_file_transfer": true
     },
     "web02": {
@@ -105,11 +175,17 @@
       "source_address": "10.0.0.2",
       "max_ttl_seconds": 120,
       "groups": ["prod-web"],
-      "_sudo_comment": "Enables sudo to root or the 'deploy' user.",
+      // Enables sudo to root or the 'deploy' user.
       "allow_sudo": true,
       "allowed_sudo_users": ["root", "deploy"],
       "allow_pty": true,
-      "_command_policy_comment": "AI-action firewall. mode allowlist = command must match a regex in 'allow'; denylist = must not match any in 'deny'; off/absent = no restriction. enforcement enforce(default) blocks/gates; use audit only for baseline collection because it allows and emits warnings. 'require_approval' flags commands for out-of-band human approval in enforce mode. shell_parse parses POSIX sh before evaluation. mode=exec sessions are checked per ssh_session_exec; shell/pty sessions are rejected.",
+      // AI-action firewall. mode allowlist = command must match a regex in 'allow';
+      // denylist = must not match any in 'deny'; off/absent = no restriction.
+      // enforcement enforce(default) blocks/gates; use audit only for baseline
+      // collection because it allows and emits warnings. 'require_approval' flags
+      // commands for out-of-band human approval in enforce mode. shell_parse parses
+      // POSIX sh before evaluation. mode=exec sessions are checked per
+      // ssh_session_exec; shell/pty sessions are rejected.
       "command_policy": {
         "mode": "allowlist",
         "enforcement": "enforce",
@@ -126,30 +202,51 @@
     }
   },
 
-  "_kubernetes_comment": "OPTIONAL Kubernetes target (credential-broker). Each cluster is DEFAULT-DENY: at least one allow/require_approval rule is required, and anything unmatched is refused. The broker never sees a cluster credential — the signer mints a short-lived bound ServiceAccount token per action and the cluster's native RBAC (layer B) enforces it. Setup: create a minter ServiceAccount whose ENTIRE RBAC is `create` on serviceaccounts/token for the SAs in sa_bindings, and put its token in token_file; create the agent SAs (broker-*) with the least-privilege Roles the agent needs. Cluster names must be DISJOINT from host names above (grants and audit are indexed by that shared name). Absent = SSH-only signer.",
+  // OPTIONAL Kubernetes target (credential-broker). Each cluster is DEFAULT-DENY:
+  // at least one allow/require_approval rule is required, and anything unmatched is
+  // refused. The broker never sees a cluster credential — the signer mints a
+  // short-lived bound ServiceAccount token per action and the cluster's native RBAC
+  // (layer B) enforces it. Setup: create a minter ServiceAccount whose ENTIRE RBAC
+  // is `create` on serviceaccounts/token for the SAs in sa_bindings, and put its
+  // token in token_file; create the agent SAs (broker-*) with the least-privilege
+  // Roles the agent needs. Cluster names must be DISJOINT from host names above
+  // (grants and audit are indexed by that shared name). Absent = SSH-only signer.
   "kubernetes": {
     "clusters": {
       "prod-k8s": {
         "api_server": "https://10.0.0.5:6443",
         "ca_cert": "pki/prod-k8s-ca.crt",
-        "_token_file_comment": "The minter credential: a ServiceAccount token whose only RBAC is create on serviceaccounts/token for the SAs below. Rotate it out-of-band; the signer re-reads it per mint.",
+        // The minter credential: a ServiceAccount token whose only RBAC is create
+        // on serviceaccounts/token for the SAs below. Rotate it out-of-band; the
+        // signer re-reads it per mint.
         "token_file": "pki/prod-k8s-minter.token",
-        "_token_ttl_comment": "Bound-token lifetime in seconds. Range [600, 900] (TokenRequest refuses less than 600); default 600.",
+        // Bound-token lifetime in seconds. Range [600, 900] (TokenRequest refuses
+        // less than 600); default 600.
         "token_ttl_seconds": 600,
         "groups": ["platform"],
-        "_sa_bindings_comment": "Map end-user groups → the ServiceAccount whose bound token is minted for them (layer-B RBAC). Evaluated in order; the first group-intersecting binding wins; a binding with empty groups is the default and matches any caller (including identity-less stdio/mTLS).",
+        // Map end-user groups → the ServiceAccount whose bound token is minted for
+        // them (layer-B RBAC). Evaluated in order; the first group-intersecting
+        // binding wins; a binding with empty groups is the default and matches any
+        // caller (including identity-less stdio/mTLS).
         "sa_bindings": [
           { "groups": ["platform"], "namespace": "agents", "service_account": "broker-platform" },
           { "namespace": "agents", "service_account": "broker-readonly" }
         ],
-        "_rules_comment": "Structured ActionPolicy, compiled to the same firewall machinery as command_policy (deny wins; grants/approve-and-learn/recommend all apply). Each rule matches on verbs/resources/namespaces/names (omitted or '*' = any). effect: allow | deny | require_approval (require_approval implies allow, gated behind human approval). NOTE: leaving 'secrets' out of every allow rule keeps it default-denied — recommended.",
+        // Structured ActionPolicy, compiled to the same firewall machinery as
+        // command_policy (deny wins; grants/approve-and-learn/recommend all apply).
+        // Each rule matches on verbs/resources/namespaces/names (omitted or '*' =
+        // any). effect: allow | deny | require_approval (require_approval implies
+        // allow, gated behind human approval). NOTE: leaving 'secrets' out of every
+        // allow rule keeps it default-denied — recommended.
         "rules": [
           { "verbs": ["get", "list", "logs"], "resources": ["pods", "deployments", "services", "configmaps", "events"], "effect": "allow" },
           { "verbs": ["apply"], "resources": ["deployments"], "namespaces": ["staging"], "effect": "allow" },
           { "verbs": ["delete", "apply"], "resources": ["deployments", "pods"], "namespaces": ["prod"], "effect": "require_approval" },
           { "verbs": ["*"], "resources": ["secrets"], "effect": "deny" }
         ],
-        "_extra_resources_comment": "OPTIONAL: extend the curated core resource table with CRDs (no API discovery — explicit and reviewable). Each needs resource (plural), group, version, kind, namespaced.",
+        // OPTIONAL: extend the curated core resource table with CRDs (no API
+        // discovery — explicit and reviewable). Each needs resource (plural), group,
+        // version, kind, namespaced.
         "extra_resources": [
           { "resource": "certificates", "group": "cert-manager.io", "version": "v1", "kind": "Certificate", "namespaced": true }
         ]


### PR DESCRIPTION
**Closes #183** — the final part (3 of 3). Part 1 (load, #194) and part 2 (signer writes, #195) are merged.

## What

1. **`broker-ctl` config edits preserve comments.** `host` / `ca-keys` / `callers` add & remove rewrote the whole section map and re-marshaled it, flattening `//` comments and formatting. They now apply a **format-preserving JSON Patch** (`confcheck.Patch`) per edited entry via a generic `patchConfigEntry(section, name, value|remove)` — creates the section when absent, preserves everything else, atomic write preserving the file mode. The four whole-map writers (`writeHosts`/`writeCAKeys`/`writeCallers`/`writeRaw`) are removed.

2. **All five `*.example.json` files converted** from `_*`-key comments to real `//` comments — self-documenting JSONC. Content preserved; the confcheck anti-drift tests validate every example through the standardizing loader. Legacy `_*` comment keys still load (deprecated).

## Tests

- New round-trip: a `signer.json` with `//` comments has a host added then the original removed — the operator's comments survive on disk alongside the change.
- The existing `ca-keys`/`callers`/`hosts` edit round-trip tests adapted to the per-entry patch API (asserted **values unchanged**).
- All four example anti-drift tests pass with the `//`-commented examples.
- Periphery checked: nothing parses the examples with a strict tool (`jq` in `run_oauth_lab.sh` is on OIDC tokens/API responses, not configs); `make dist`/`install.sh` only **copy** them, and the services load JSONC.
- `make verify` green: race tests, govulncheck 0, docs `--strict`, no `docs/reference` drift.

## #183 end state

Every config file accepts JSONC on load (part 1), every rewrite path preserves comments (parts 2–3), and the shipped examples demonstrate the canonical `//` style.

Closes #183