### PR TITLE
feat(signer)!: refuse a volatile freeze without state_db unless opted in (#184)

### DIFF
--- a/cmd/broker-ctl/doctor.go
+++ b/cmd/broker-ctl/doctor.go
@@ -210,7 +210,7 @@ func rateLimitFinding(perMin int) doctorFinding {
 
 func stateDBFinding(path, svc string) doctorFinding {
 	if strings.TrimSpace(path) == "" {
-		return doctorFinding{docWARN, svc + " state_db set", "not set — runtime grants/waivers/freezes are in-memory and lost on restart (a freeze silently unfreezes). Set `state_db` to a persistent path."}
+		return doctorFinding{docWARN, svc + " state_db set", "not set — runtime grants/waivers/freezes are in-memory and lost on restart (a freeze needs it to survive, and is refused without it unless opted in as volatile). Set `state_db` to a persistent path."}
 	}
 	return doctorFinding{docPASS, svc + " state_db set", ""}
 }

--- a/cmd/broker-ctl/freeze.go
+++ b/cmd/broker-ctl/freeze.go
@@ -52,9 +52,10 @@ func cmdFreeze(args []string) {
 	fs := flag.NewFlagSet("freeze", flag.ExitOnError)
 	caller, endUser, sessionID, serial := subjectFlags(fs)
 	reason := fs.String("reason", "", "optional reason recorded in the audit log")
+	volatile := fs.Bool("volatile", false, "accept a memory-only freeze when the signer has no state_db (it is lost on restart)")
 	urlFlag, cert, key, ca := signerFlags(fs)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] freeze (--caller cn | --end-user u | --session-id id | --serial n) [--reason r]")
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] freeze (--caller cn | --end-user u | --session-id id | --serial n) [--reason r] [--volatile]")
 		fs.PrintDefaults()
 	}
 	must(fs.Parse(args))
@@ -62,13 +63,14 @@ func cmdFreeze(args []string) {
 	resolveSignerTarget(fs)
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
-	freezePost(client, base, kind, value, *reason)
+	freezePost(client, base, kind, value, *reason, *volatile)
 }
 
 // freezePost calls POST /v1/freeze and prints the outcome. Shared by
-// `broker-ctl freeze` and `broker-ctl session kill`.
-func freezePost(client *http.Client, base, kind, value, reason string) {
-	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value, "reason": reason})
+// `broker-ctl freeze` and `broker-ctl session kill`. allowVolatile opts into a
+// memory-only freeze on a signer with no state_db (otherwise refused, HTTP 409).
+func freezePost(client *http.Client, base, kind, value, reason string, allowVolatile bool) {
+	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value, "reason": reason, "allow_volatile": allowVolatile})
 	req, err := http.NewRequest(http.MethodPost, base+"/v1/freeze", bytes.NewReader(body))
 	if err != nil {
 		fatalf("request: %v", err)
@@ -104,9 +106,10 @@ func cmdSession(args []string) {
 	}
 	fs := flag.NewFlagSet("session kill", flag.ExitOnError)
 	reason := fs.String("reason", "", "optional reason recorded in the audit log")
+	volatile := fs.Bool("volatile", false, "accept a memory-only freeze when the signer has no state_db (it is lost on restart)")
 	urlFlag, cert, key, ca := signerFlags(fs)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] session kill <session-id> [--reason r]")
+		fmt.Fprintln(os.Stderr, "Usage: broker-ctl [--config f] session kill <session-id> [--reason r] [--volatile]")
 		fs.PrintDefaults()
 	}
 	must(fs.Parse(args[1:]))
@@ -117,7 +120,7 @@ func cmdSession(args []string) {
 	id := fs.Arg(0)
 	resolveSignerTarget(fs)
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
-	freezePost(client, base, signer.FreezeSessionID, id, *reason)
+	freezePost(client, base, signer.FreezeSessionID, id, *reason, *volatile)
 }
 
 // cmdUnfreeze calls the signer's POST /v1/unfreeze (mTLS, reload_callers) to

--- a/cmd/signer/freeze_http_test.go
+++ b/cmd/signer/freeze_http_test.go
@@ -12,25 +12,42 @@ import (
 
 	"github.com/luisgf/infrabroker/internal/audit"
 	"github.com/luisgf/infrabroker/internal/signer"
+	"github.com/luisgf/infrabroker/internal/statedb"
 )
 
-// freezeTestServer builds a minimal server with a freeze store, an in-memory
-// grant store, and reload_callers={admin}. The sign path's freeze check runs
-// before host/pubkey resolution, so no CA or host policy is needed to exercise
-// a frozen denial.
-func freezeTestServer(t *testing.T) *server {
+// freezeAuditLog opens a throwaway signed audit log for a freeze test server.
+func freezeAuditLog(t *testing.T) *audit.Log {
 	t.Helper()
 	seed := make([]byte, ed25519.SeedSize)
-	auditLog, err := audit.Open(filepath.Join(t.TempDir(), "audit.log"), ed25519.NewKeyFromSeed(seed))
+	l, err := audit.Open(filepath.Join(t.TempDir(), "audit.log"), ed25519.NewKeyFromSeed(seed))
 	if err != nil {
 		t.Fatalf("audit open: %v", err)
 	}
-	t.Cleanup(func() { auditLog.Close() })
+	t.Cleanup(func() { l.Close() })
+	return l
+}
+
+// freezeTestServer builds a minimal server with a state-db-backed freeze store,
+// an in-memory grant store, and reload_callers={admin}. The sign path's freeze
+// check runs before host/pubkey resolution, so no CA or host policy is needed to
+// exercise a frozen denial. The store is db-backed (not memory-only) so the
+// volatile-freeze gate is satisfied — that gate is covered by TestFreezeVolatileGate.
+func freezeTestServer(t *testing.T) *server {
+	t.Helper()
+	db, err := statedb.Open(filepath.Join(t.TempDir(), "state.db"), signer.StateMigrations())
+	if err != nil {
+		t.Fatalf("state db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	freezes, err := signer.NewFreezeStoreDB(db)
+	if err != nil {
+		t.Fatalf("freeze store: %v", err)
+	}
 	return &server{
-		audit:    auditLog,
+		audit:    freezeAuditLog(t),
 		reloadCN: map[string]struct{}{"admin": {}},
 		grants:   signer.NewGrantStore(),
-		freezes:  signer.NewFreezeStore(),
+		freezes:  freezes,
 	}
 }
 
@@ -41,6 +58,40 @@ func freezeMux(s *server) *http.ServeMux {
 	mux.HandleFunc("GET /v1/revocations", s.handleRevocations)
 	mux.HandleFunc("/v1/sign", s.handleSign)
 	return mux
+}
+
+// TestFreezeVolatileGate covers the state_db-less path: a memory-only freeze
+// store fails open (freezes vanish on restart), so POST /v1/freeze must refuse a
+// freeze unless the caller opts in with allow_volatile.
+func TestFreezeVolatileGate(t *testing.T) {
+	t.Parallel()
+	srv := &server{
+		audit:    freezeAuditLog(t),
+		reloadCN: map[string]struct{}{"admin": {}},
+		grants:   signer.NewGrantStore(),
+		freezes:  signer.NewFreezeStore(), // memory-only → Volatile()==true
+	}
+	mux := freezeMux(srv)
+
+	// Without allow_volatile: refused (409), nothing frozen.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin", map[string]any{"kind": "caller", "value": "brk2"}))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("volatile freeze without opt-in: status = %d, want 409 (body %s)", rec.Code, rec.Body.String())
+	}
+	if n := len(srv.freezes.List()); n != 0 {
+		t.Fatalf("a refused volatile freeze must not freeze anything, have %d", n)
+	}
+
+	// With allow_volatile: accepted (200), subject frozen.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin", map[string]any{"kind": "caller", "value": "brk2", "allow_volatile": true}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("volatile freeze with opt-in: status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	if n := len(srv.freezes.List()); n != 1 {
+		t.Fatalf("an opted-in volatile freeze must freeze the subject, have %d", n)
+	}
 }
 
 func TestFreezeEndpointRequiresReloadCN(t *testing.T) {

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -182,6 +182,8 @@ func main() {
 		}
 		log.Printf("state db: %s (%d live grants, %d freezes restored)",
 			cfg.StateDB, len(grantStore.List(time.Now())), len(freezeStore.List()))
+	} else {
+		log.Printf("warning: state_db is not set — runtime grants, approve-and-learn waivers and freezes are volatile (lost on restart); a freeze via /v1/freeze needs allow_volatile (see: broker-ctl doctor --security)")
 	}
 
 	local, err := buildState(context.Background(), cfg, grantStore)
@@ -869,28 +871,34 @@ type freezeRequest struct {
 	Kind   string `json:"kind"`
 	Value  string `json:"value"`
 	Reason string `json:"reason,omitempty"`
+	// AllowVolatile lets a freeze be accepted even when the signer has no state_db
+	// and the freeze would be lost on restart (fail-open). Off by default, so a
+	// volatile freeze is refused unless the operator opts in (broker-ctl freeze
+	// --volatile). Ignored on /v1/unfreeze.
+	AllowVolatile bool `json:"allow_volatile,omitempty"`
 }
 
 // decodeFreezeSubject reads and validates a freeze subject from the request
 // body. The value and reason are rejected if they carry control/whitespace so a
 // forged token cannot splice into the audit stream (auditFreeze writes them as
-// key=value tokens). Returns ok=false with the response already written.
-func (s *server) decodeFreezeSubject(w http.ResponseWriter, r *http.Request) (signer.FreezeSubject, string, bool) {
+// key=value tokens). Also returns whether the caller opted into a volatile
+// freeze. Returns ok=false with the response already written.
+func (s *server) decodeFreezeSubject(w http.ResponseWriter, r *http.Request) (subj signer.FreezeSubject, reason string, allowVolatile, ok bool) {
 	r.Body = http.MaxBytesReader(w, r.Body, 16*1024)
 	var req freezeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
-		return signer.FreezeSubject{}, "", false
+		return signer.FreezeSubject{}, "", false, false
 	}
 	if !signer.ValidFreezeKind(req.Kind) {
 		http.Error(w, "invalid kind (caller|end_user|session_id|serial)", http.StatusBadRequest)
-		return signer.FreezeSubject{}, "", false
+		return signer.FreezeSubject{}, "", false, false
 	}
 	if req.Value == "" || signer.HasUnsafeTokenChar(req.Value) || signer.HasUnsafeTokenChar(req.Reason) {
 		http.Error(w, "invalid value or reason: empty, control or whitespace characters not allowed", http.StatusBadRequest)
-		return signer.FreezeSubject{}, "", false
+		return signer.FreezeSubject{}, "", false, false
 	}
-	return signer.FreezeSubject{Kind: req.Kind, Value: req.Value}, req.Reason, true
+	return signer.FreezeSubject{Kind: req.Kind, Value: req.Value}, req.Reason, req.AllowVolatile, true
 }
 
 // handleFreeze serves POST /v1/freeze: freeze a subject so it gets no new
@@ -902,8 +910,15 @@ func (s *server) handleFreeze(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	subj, reason, ok := s.decodeFreezeSubject(w, r)
+	subj, reason, allowVolatile, ok := s.decodeFreezeSubject(w, r)
 	if !ok {
+		return
+	}
+	// Without a state_db the freeze lives only in memory and vanishes on restart —
+	// a subject the operator blocked silently regains access (fail-open). Refuse
+	// unless the caller explicitly accepts that (allow_volatile / --volatile).
+	if s.freezes.Volatile() && !allowVolatile {
+		http.Error(w, "freeze would be volatile: the signer has no state_db, so this freeze is lost on restart. Configure state_db, or resend with allow_volatile to accept a memory-only freeze.", http.StatusConflict)
 		return
 	}
 	// Serialise freeze mutations with the other config mutations so the freeze
@@ -931,7 +946,7 @@ func (s *server) handleUnfreeze(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	subj, _, ok := s.decodeFreezeSubject(w, r)
+	subj, _, _, ok := s.decodeFreezeSubject(w, r)
 	if !ok {
 		return
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -455,6 +455,9 @@ kill its live sessions (#117). A **freeze subject** is a `{ "kind": ..., "value"
   approve-and-learn waivers. `value` and `reason` must not contain
   control/whitespace characters (audit-stream safety) → `400` otherwise.
   Response: `{ "status": "ok", "newly_frozen": true, "grants_revoked": 1 }`.
+  When the signer has no `state_db` the freeze would be lost on restart
+  (fail-open), so it is **refused with `409 Conflict`** unless the body sets
+  `"allow_volatile": true` (v2.0.0) to accept a memory-only freeze.
 - **`POST /v1/unfreeze`** (mTLS, `reload_callers`). Body: `{ "kind": "caller",
   "value": "broker-1" }`. Response: `{ "status": "ok", "was_frozen": true }`.
 - **`GET /v1/revocations`** (mTLS, any authenticated caller — operational data a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,15 @@
   `"_default": {"allowed_groups": []}` is now redundant with the default and can
   be dropped. `broker-ctl doctor --security` WARNs when no `callers` table is
   set, or when a `_default` grants groups.
+- **A volatile freeze is now refused (#184)** — when the signer has no `state_db`
+  the kill-switch freeze set lives only in memory and is lost on restart (a frozen
+  subject would silently regain access — fail-open). `POST /v1/freeze` now returns
+  `409 Conflict` in that case unless the request opts in with
+  `"allow_volatile": true` (`broker-ctl freeze --volatile`, also on `session kill`).
+  **Migration:** set `state_db` in production (recommended regardless, for grant/
+  waiver/approval persistence); pass `--volatile` only for a deliberately
+  ephemeral, lab-style freeze. The signer also logs a startup warning when
+  `state_db` is unset.
 
 ### Added
 - **Kill switch / revocation (#117)** — the signer gained `POST /v1/freeze`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -520,7 +520,9 @@ broker-ctl unfreeze --caller broker-1
 > **Requires `state_db`.** Freezes are persisted **fail-closed**: with `state_db`
 > set they survive a signer restart, and the signer **refuses to start** if it
 > cannot load the freeze set (a lost freeze would fail *open*). **Without**
-> `state_db`, a restart clears all freezes — set `state_db` in production.
+> `state_db` a freeze is volatile (lost on restart), so since v2.0.0
+> `broker-ctl freeze` is **refused** unless you pass `--volatile` to accept a
+> memory-only freeze — set `state_db` in production.
 
 > **Avoid self-lockout.** Do not freeze the `caller` CN your own tooling or the
 > control plane uses, or you cut off the path you administer through. Freezes are

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -258,8 +258,11 @@ subject (`broker CN`, `end_user`, `session_id`, or certificate `serial`,
 
 The freeze set is fail-closed persistent (`state_db`): unlike a grant, a freeze
 that failed to load would fail *open*, so the signer refuses to start on a load
-error rather than silently un-freezing a blocked subject. Freezing requires
-`state_db` to survive a signer restart.
+error rather than silently un-freezing a blocked subject. A freeze only survives
+a restart with `state_db`, so since v2.0.0 `POST /v1/freeze` **refuses** a freeze
+when `state_db` is unset unless the caller explicitly accepts a memory-only
+freeze (`allow_volatile` / `broker-ctl freeze --volatile`) — the fail-open of a
+silently-volatile freeze is opt-in, not the default.
 
 - **Residual:** an already-issued **one-shot** cert stays valid for its
   remaining window (`<= max_ttl`, minutes) — a freeze denies the *next* sign and
@@ -284,11 +287,14 @@ Sessions, approvals, grants, and behavior baselines live in process memory.
 Running multiple broker or control-plane replicas would split this state.
 Horizontal scaling requires externalizing it (e.g. Redis with TTL).
 - **Mitigation (restart survival, not multi-instance):** the opt-in `state_db`
-  (SQLite, write-through) persists the signer's runtime grants/waivers and the
-  control plane's approval registry across restarts. The in-memory state
-  remains the only state consulted on the decision path; live SSH sessions and
-  behaviour baselines are intentionally not persisted (a TCP connection cannot
-  be resurrected; the baseline re-learns).
+  (SQLite, write-through) persists the signer's runtime grants/waivers, the
+  kill-switch freeze set, and the control plane's approval registry across
+  restarts. Grants/waivers fail safe if dropped (they only widen), but a dropped
+  freeze fails open — so without `state_db` a freeze is refused unless explicitly
+  opted into as volatile (gap #3). The in-memory state remains the only state
+  consulted on the decision path; live SSH sessions and behaviour baselines are
+  intentionally not persisted (a TCP connection cannot be resurrected; the
+  baseline re-learns).
 - **Residual risk (crash window):** an approval is marked consumed with a
   best-effort write *after* the certificate is issued. A crash (or a state-db
   write failure, counted by `statedb_errors_total`) in that window re-exposes

--- a/internal/signer/freeze.go
+++ b/internal/signer/freeze.go
@@ -116,6 +116,12 @@ func NewFreezeStoreDB(db *sql.DB) (*FreezeStore, error) {
 	return s, nil
 }
 
+// Volatile reports whether this store is memory-only (no state db). A freeze in
+// a volatile store does NOT survive a signer restart, so it fails OPEN — the
+// freeze handler requires an explicit opt-in (allow_volatile) before accepting
+// one, and production deployments should set state_db instead.
+func (s *FreezeStore) Volatile() bool { return s.db == nil }
+
 // Add freezes subj. Write-through, insert-first: if it cannot be persisted the
 // call fails and the in-memory set does not diverge from disk (an in-memory-only
 // freeze would vanish on restart — fail-open). Re-freezing a subject refreshes

--- a/signer.example.json
+++ b/signer.example.json
@@ -79,11 +79,12 @@
   // Optional SQLite database persisting runtime grants, approve-and-learn waivers,
   // and the kill-switch freeze set (#117) across restarts (pure-Go driver, no
   // system dependency). Empty or absent = in-memory only: a restart drops
-  // grants/waivers (fail-safe, since grants only widen) but ALSO drops freezes,
-  // which fails OPEN — a frozen subject silently regains access — so set state_db
-  // in production. If set and the file cannot be opened/migrated, the signer
-  // refuses to start (fail-closed). WAL mode leaves state.db-wal/-shm sidecar files
-  // next to it — include all three in backups. Production:
+  // grants/waivers (fail-safe, since grants only widen). A freeze would be lost
+  // too (fail-OPEN), so since v2.0.0 POST /v1/freeze REFUSES a freeze when
+  // state_db is unset unless the caller opts in (broker-ctl freeze --volatile) —
+  // set state_db in production. If set and the file cannot be opened/migrated, the
+  // signer refuses to start (fail-closed). WAL mode leaves state.db-wal/-shm
+  // sidecar files next to it — include all three in backups. Production:
   // /var/lib/infrabroker/signer/state.db.
   "state_db": "",
 


### PR DESCRIPTION
**Part of #184** (secure-by-default, v2.0.0). Second of three fail-open → fail-closed flips.

## What changes
When the signer has no `state_db`, the kill-switch freeze set (#117) lives only in memory and is **lost on restart** — a subject the operator blocked silently regains access (fail-open). `POST /v1/freeze` now returns **`409 Conflict`** in that case unless the request opts in with `"allow_volatile": true`.

- `FreezeStore.Volatile()` exposes the memory-only state (`db == nil`, immutable after construction).
- `handleFreeze` gates on it (before taking the write lock / mutating), reading `allow_volatile` from the decoded body.
- `broker-ctl freeze --volatile` (and `broker-ctl session kill --volatile`) set the flag.
- The signer logs a **startup warning** when `state_db` is unset.

`POST /v1/unfreeze` is unaffected (releasing is always safe). A `state_db`-backed signer is unchanged.

## Breaking-change migration
- Set `state_db` in production — recommended regardless, for grant/waiver/approval persistence. Then freezes just work.
- Pass `--volatile` only for a deliberately ephemeral, lab-style freeze.

## Tests
- `freezeTestServer` is now `state_db`-backed (temp SQLite), so the existing freeze tests exercise semantics unchanged.
- New `TestFreezeVolatileGate`: a memory-only store refuses the freeze with `409` (nothing frozen), then accepts it with `allow_volatile:true` (subject frozen).
- Full `go test -race ./...` green; `make docs-check` green.

## Docs
THREAT_MODEL gaps #3/#5, OPERATIONS, API (`/v1/freeze` body + `409`), `broker-ctl doctor --security` finding, and the `signer.example.json` `state_db` comment updated; CHANGELOG breaking-changes bullet.