### PR TITLE
feat(audit)!: fail-closed audit append by default (audit_fail_mode) (#184)

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -125,6 +125,10 @@ func classifyError(err error) (int, string) {
 		return http.StatusNotFound, err.Error()
 	case errors.Is(err, broker.ErrUpstream):
 		return http.StatusBadGateway, "upstream failure"
+	case errors.Is(err, broker.ErrAuditUnavailable):
+		// Fail-closed audit: the action's result is withheld because it could not
+		// be durably recorded. 500 (a broker-side availability failure), not 403.
+		return http.StatusInternalServerError, "audit unavailable"
 	default:
 		return http.StatusForbidden, err.Error()
 	}

--- a/cmd/broker/main_test.go
+++ b/cmd/broker/main_test.go
@@ -19,6 +19,7 @@ func TestClassifyError(t *testing.T) {
 		{"bad request → 400", fmt.Errorf("%w: command is required", broker.ErrBadRequest), http.StatusBadRequest, "command is required"},
 		{"unknown host → 404", fmt.Errorf("%w: %q", broker.ErrUnknownHost, "web01"), http.StatusNotFound, "web01"},
 		{"upstream → 502 generic", fmt.Errorf("%w: connection: boom", broker.ErrUpstream), http.StatusBadGateway, "upstream failure"},
+		{"audit unavailable → 500", fmt.Errorf("%w", broker.ErrAuditUnavailable), http.StatusInternalServerError, "audit unavailable"},
 		{"denial → 403 default", fmt.Errorf("caller %q not authorised", "x"), http.StatusForbidden, "not authorised"},
 	}
 	for _, tc := range tests {

--- a/cmd/signer/audit_failclosed_test.go
+++ b/cmd/signer/audit_failclosed_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/monitor"
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// brokenAuditLog returns an opened audit log whose backing directory has been
+// removed, so the next Append fails (ensureOpen cannot reopen the path). Models
+// an unwritable audit sink (full disk, revoked permissions) for the fail-closed
+// tests without an in-package test seam.
+func brokenAuditLog(t *testing.T) *audit.Log {
+	t.Helper()
+	dir := t.TempDir()
+	seed := make([]byte, ed25519.SeedSize)
+	al, err := audit.Open(filepath.Join(dir, "audit.log"), ed25519.NewKeyFromSeed(seed))
+	if err != nil {
+		t.Fatalf("audit open: %v", err)
+	}
+	al.Close()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove audit dir: %v", err)
+	}
+	return al
+}
+
+// TestSignerAppendAuditFailMode covers the helper both services funnel through:
+// closed denies (returns errAuditUnavailable), open logs and proceeds.
+func TestSignerAppendAuditFailMode(t *testing.T) {
+	t.Parallel()
+	closed := &server{audit: brokenAuditLog(t), auditFailClosed: true}
+	if err := closed.appendAudit(audit.Entry{Outcome: "x"}); !errors.Is(err, errAuditUnavailable) {
+		t.Fatalf("closed mode must return errAuditUnavailable, got %v", err)
+	}
+	open := &server{audit: brokenAuditLog(t), auditFailClosed: false}
+	if err := open.appendAudit(audit.Entry{Outcome: "x"}); err != nil {
+		t.Fatalf("open mode must proceed, got %v", err)
+	}
+}
+
+// TestAuditFailClosedModeParsing asserts the config parser: default + explicit
+// closed fail closed, open fails open, anything else is a config error.
+func TestAuditFailClosedModeParsing(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		mode       string
+		wantClosed bool
+		wantErr    bool
+	}{
+		{"", true, false},
+		{"closed", true, false},
+		{"open", false, false},
+		{"nonsense", false, true},
+	} {
+		got, err := audit.FailClosed(tc.mode)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("mode %q: err = %v, wantErr %v", tc.mode, err, tc.wantErr)
+		}
+		if err == nil && got != tc.wantClosed {
+			t.Errorf("mode %q: closed = %v, want %v", tc.mode, got, tc.wantClosed)
+		}
+	}
+}
+
+// TestSignFrozenAuditFailClosed drives the /v1/sign audit gate through the frozen
+// denial (which does not need a CA or host policy): with a broken log the closed
+// signer returns 500 "audit unavailable" and increments audit_blocked_total,
+// while the open signer still returns the normal 403 (unaudited).
+func TestSignFrozenAuditFailClosed(t *testing.T) {
+	// Not parallel: it reads the process-global audit_blocked_total counter.
+	frozenSign := func(failClosed bool) *httptest.ResponseRecorder {
+		srv := &server{
+			audit:           brokenAuditLog(t),
+			auditFailClosed: failClosed,
+			reloadCN:        map[string]struct{}{"admin": {}},
+			grants:          signer.NewGrantStore(),
+			freezes:         signer.NewFreezeStore(),
+		}
+		// Freeze brk1 directly in the store (bypassing the freeze handler and its
+		// own volatile gate); the sign path then hits the frozen denial.
+		if _, err := srv.freezes.Add(signer.FreezeSubject{Kind: "caller", Value: "brk1"}, "", "admin", time.Now()); err != nil {
+			t.Fatalf("freeze add: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		freezeMux(srv).ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/sign", "brk1", signer.WireRequest{
+			Host: "web01", Role: signer.RoleTarget, Purpose: signer.PurposeOneshot, Command: "uptime",
+		}))
+		return rec
+	}
+
+	before := monitor.GetCounter("audit_blocked_total", "").Value()
+	if rec := frozenSign(true); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("closed mode: frozen sign with a broken log → status %d, want 500 (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := monitor.GetCounter("audit_blocked_total", "").Value(); got <= before {
+		t.Fatalf("audit_blocked_total must increment on a blocked action: before=%d after=%d", before, got)
+	}
+
+	// Open mode: the append still fails, but the operation proceeds to the normal
+	// frozen denial (403) rather than 500.
+	if rec := frozenSign(false); rec.Code != http.StatusForbidden {
+		t.Fatalf("open mode: frozen sign with a broken log → status %d, want 403 (body %s)", rec.Code, rec.Body.String())
+	}
+}

--- a/cmd/signer/grants.go
+++ b/cmd/signer/grants.go
@@ -172,8 +172,8 @@ func (s *server) maybeLearnWaiver(caller string, req signer.WireRequest, issued 
 	}
 	if issued.Decision == nil || !issued.Decision.RequireApproval {
 		// Learn was requested but the command is not approval-gated: nothing to
-		// waive. Audit the no-op so the mismatch is visible to operators.
-		s.appendAudit(audit.Entry{
+		// waive. Audit the no-op so the mismatch is visible to operators (best-effort).
+		_ = s.appendAudit(audit.Entry{
 			Caller: caller, Host: req.Host, Command: "approval-waiver",
 			Outcome: "approval-waiver-skipped", ApprovalID: req.LearnApprovalID,
 			ApprovedBy: req.LearnApprover, Err: "command is not require_approval; nothing to waive",
@@ -203,17 +203,30 @@ func (s *server) maybeLearnWaiver(caller string, req signer.WireRequest, issued 
 	if err != nil {
 		e.Command, e.Outcome, e.Err = "approval-waiver", "approval-waiver-failed", err.Error()
 	}
-	s.appendAudit(e)
+	// Best-effort: the waiver is a supplementary record; the issuance gate
+	// (auditEmission) is what fails the sign when the log is unwritable.
+	_ = s.appendAudit(e)
 }
 
-// appendAudit writes an audit entry, logging a warning on failure.
-func (s *server) appendAudit(e audit.Entry) {
+// appendAudit writes an audit entry. In the default fail-closed mode
+// (audit_fail_mode=closed) an Append failure returns errAuditUnavailable so the
+// caller can deny the audited action — no signed record, no action; in "open"
+// mode it logs and returns nil (the pre-2.0 behaviour). Best-effort callers
+// (reads, cleanup, and supplementary records already backstopped by the issuance
+// gate) ignore the returned error.
+func (s *server) appendAudit(e audit.Entry) error {
 	if aerr := s.audit.Append(e); aerr != nil {
+		if s.auditFailClosed {
+			log.Printf("audit unavailable, denying action: %v", aerr)
+			return errAuditUnavailable
+		}
 		log.Printf("warning: error writing signer audit log: %v", aerr)
 	}
+	return nil
 }
 
-// auditGrant records a grant operation in the signed audit log.
+// auditGrant records a grant operation in the signed audit log (best-effort: the
+// grant has already been applied by the time this runs).
 func (s *server) auditGrant(caller, host, id string, allow []string, outcome string, err error) {
 	e := audit.Entry{Caller: caller, Host: host, Command: "grant " + id, Outcome: outcome}
 	if len(allow) > 0 {
@@ -222,7 +235,5 @@ func (s *server) auditGrant(caller, host, id string, allow []string, outcome str
 	if err != nil {
 		e.Err = err.Error()
 	}
-	if aerr := s.audit.Append(e); aerr != nil {
-		log.Printf("warning: error writing signer audit log: %v", aerr)
-	}
+	_ = s.appendAudit(e)
 }

--- a/cmd/signer/k8s.go
+++ b/cmd/signer/k8s.go
@@ -17,14 +17,20 @@ import (
 func (s *server) handleSignK8s(w http.ResponseWriter, r *http.Request, caller string, req signer.WireRequest, isForwarder, effectiveApproved bool, local localSigner, callers signer.CallerTable) {
 	clusters := local.Clusters()
 	if _, ok := clusters[req.Host]; !ok {
-		s.auditK8s(caller, req, 0, "denied", nil, fmt.Errorf("no policy for cluster %q", req.Host))
+		if aerr := s.auditK8s(caller, req, 0, "denied", nil, fmt.Errorf("no policy for cluster %q", req.Host)); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		http.Error(w, "unknown cluster", http.StatusForbidden)
 		return
 	}
 	// Per-caller group RBAC over the cluster table (mirrors HostSetForCaller).
 	if set, restricted := signer.ClusterSetForCaller(caller, clusters, callers); restricted {
 		if _, ok := set[req.Host]; !ok {
-			s.auditK8s(caller, req, 0, "denied", nil, fmt.Errorf("cluster %q outside group for %q", req.Host, caller))
+			if aerr := s.auditK8s(caller, req, 0, "denied", nil, fmt.Errorf("cluster %q outside group for %q", req.Host, caller)); aerr != nil {
+				writeAuditUnavailable(w)
+				return
+			}
 			http.Error(w, "cluster not authorised", http.StatusForbidden)
 			return
 		}
@@ -53,7 +59,10 @@ func (s *server) handleSignK8s(w http.ResponseWriter, r *http.Request, caller st
 	}
 	issued, err := local.SignIntent(r.Context(), in)
 	if err != nil {
-		s.auditK8s(caller, req, 0, "denied", nil, err)
+		if aerr := s.auditK8s(caller, req, 0, "denied", nil, err); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
@@ -71,16 +80,26 @@ func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer
 		if issued.Decision != nil && !issued.Decision.Allowed {
 			outcome = "dry_run_denied"
 		}
-		s.auditK8s(caller, req, 0, outcome, issued.Decision, nil)
+		if aerr := s.auditK8s(caller, req, 0, outcome, issued.Decision, nil); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
 		return
 	}
 	if issued.K8sToken == "" {
-		s.auditK8s(caller, req, 0, "approval-required", issued.Decision, nil)
+		if aerr := s.auditK8s(caller, req, 0, "approval-required", issued.Decision, nil); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
 		return
 	}
-	s.auditK8s(caller, req, issued.Serial, "issued", issued.Decision, nil)
+	// Issuance gate: no durable "issued" record, no bound token in the response.
+	if aerr := s.auditK8s(caller, req, issued.Serial, "issued", issued.Decision, nil); aerr != nil {
+		writeAuditUnavailable(w)
+		return
+	}
 	writeJSON(w, http.StatusOK, signer.WireResponse{
 		K8sToken:       issued.K8sToken,
 		K8sTokenExpiry: issued.K8sTokenExpiry,
@@ -97,7 +116,10 @@ func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer
 // yet been checked against the canonical). A k8s_apply manifest is never
 // logged verbatim (it can carry a Secret) — its sha256 rides in body_sha256,
 // added by the broker's execution entry, not here.
-func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, outcome string, dec *signer.DecisionInfo, err error) {
+// auditK8s is the single audit funnel for the /v1/sign Kubernetes branch. Like
+// auditEmission it returns an error in fail-closed mode so the caller denies the
+// request (no bound token leaves the signer) when the log cannot be written.
+func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, outcome string, dec *signer.DecisionInfo, err error) error {
 	signRequestsTotal.With(outcome).Inc()
 	host := req.Host
 	if cp, ok := s.currentClusters()[req.Host]; ok {
@@ -133,7 +155,7 @@ func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, 
 	if err != nil {
 		e.Err = err.Error()
 	}
-	s.appendAudit(e)
+	return s.appendAudit(e)
 }
 
 // currentClusters returns the compiled cluster table under RLock.

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -57,6 +58,12 @@ type Config struct {
 	// Issuance audit log (independent of the broker).
 	AuditLog string `json:"audit_log"`
 	AuditKey string `json:"audit_key"`
+
+	// AuditFailMode governs what happens when the audit log cannot be written.
+	// "closed" (default): the action being audited is denied — no signed audit
+	// record, no certificate. "open": log the error, count the metric, and
+	// proceed (the pre-2.0 behaviour). Empty = "closed".
+	AuditFailMode string `json:"audit_fail_mode,omitempty"`
 
 	// MaxTTLSeconds: global cap when the host policy does not set one.
 	MaxTTLSeconds int `json:"max_ttl_seconds"`
@@ -214,24 +221,30 @@ func main() {
 		}
 	}
 
+	auditFailClosed, err := audit.FailClosed(cfg.AuditFailMode)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
 	tlsCfg, err := auth.ServerTLSConfig(cfg.ServerCert, cfg.ServerKey, cfg.ClientCA)
 	if err != nil {
 		log.Fatalf("tls: %v", err)
 	}
 
 	srv := &server{
-		local:       local,
-		audit:       auditLog,
-		hosts:       cfg.Hosts,
-		callers:     cfg.Callers,
-		reloadCN:    reloadSet(cfg.ReloadCallers),
-		forwarders:  reloadSet(cfg.TrustedForwarders),
-		signRateMin: cfg.SignRateLimitPerMin,
-		cfgPath:     *cfgPath,
-		grants:      grantStore,
-		freezes:     freezeStore,
-		maxGrantTTL: time.Duration(cfg.MaxGrantTTLSeconds) * time.Second,
-		rateLimiter: signer.NewRateLimiter(),
+		local:           local,
+		audit:           auditLog,
+		hosts:           cfg.Hosts,
+		callers:         cfg.Callers,
+		reloadCN:        reloadSet(cfg.ReloadCallers),
+		forwarders:      reloadSet(cfg.TrustedForwarders),
+		signRateMin:     cfg.SignRateLimitPerMin,
+		cfgPath:         *cfgPath,
+		grants:          grantStore,
+		freezes:         freezeStore,
+		maxGrantTTL:     time.Duration(cfg.MaxGrantTTLSeconds) * time.Second,
+		rateLimiter:     signer.NewRateLimiter(),
+		auditFailClosed: auditFailClosed,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/sign", srv.handleSign)
@@ -449,6 +462,11 @@ type server struct {
 	audit   *audit.Log
 	cfgPath string
 
+	// auditFailClosed denies the audited action when the audit log cannot be
+	// written (audit_fail_mode=closed, the default). False = fail-open (log and
+	// proceed).
+	auditFailClosed bool
+
 	// grants is the shared runtime grant store (widen-only command-policy grants).
 	// Created once and reused across reloads so live grants are not lost on a
 	// config reload; its own mutex makes it concurrency-safe. maxGrantTTL caps a
@@ -611,13 +629,14 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// req.EndUser are both charset-checked above, so they are safe to audit.
 	if subj, frozen := s.freezes.Frozen(caller, req.EndUser); frozen {
 		signRequestsTotal.With("frozen-denied").Inc()
-		if aerr := s.audit.Append(audit.Entry{
+		if aerr := s.appendAudit(audit.Entry{
 			Caller:  caller,
 			Host:    req.Host,
 			Outcome: "frozen_denied",
 			Err:     fmt.Sprintf("frozen: %s=%s", subj.Kind, subj.Value),
 		}); aerr != nil {
-			log.Printf("warning: error writing signer audit log: %v", aerr)
+			writeAuditUnavailable(w)
+			return
 		}
 		http.Error(w, "subject is frozen", http.StatusForbidden)
 		return
@@ -639,7 +658,10 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// the requested host must belong to one of its groups.
 	if hostSet, restricted := signer.HostSetForCaller(caller, hosts, callers); restricted {
 		if _, ok := hostSet[req.Host]; !ok {
-			s.auditEmission(caller, req, hosts, 0, "denied", nil, fmt.Errorf("host %q outside group for %q", req.Host, caller))
+			if aerr := s.auditEmission(caller, req, hosts, 0, "denied", nil, fmt.Errorf("host %q outside group for %q", req.Host, caller)); aerr != nil {
+				writeAuditUnavailable(w)
+				return
+			}
 			http.Error(w, "host not authorised", http.StatusForbidden)
 			return
 		}
@@ -666,7 +688,10 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	}
 	issued, err := local.SignIntent(r.Context(), in)
 	if err != nil {
-		s.auditEmission(caller, req, hosts, 0, "denied", nil, err)
+		if aerr := s.auditEmission(caller, req, hosts, 0, "denied", nil, err); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
@@ -674,9 +699,9 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// for this opted-in caller (the same human requested and approved in-chat).
 	// Only when the command actually required approval.
 	if selfApproves && !isForwarder && req.Approved && issued.Decision != nil && issued.Decision.RequireApproval {
-		if aerr := s.audit.Append(audit.Entry{Caller: caller, Host: req.Host, Outcome: "self_approved"}); aerr != nil {
-			log.Printf("warning: error writing signer audit log: %v", aerr)
-		}
+		// Best-effort: a supplementary marker; the "issued" gate below is what
+		// fails the sign if the log is unwritable.
+		_ = s.appendAudit(audit.Entry{Caller: caller, Host: req.Host, Outcome: "self_approved"})
 	}
 	// Approve-and-learn: mint a TTL'd approval waiver after an approved sign that
 	// requested it. The waiver is scoped to the effective caller/end-user/elevation.
@@ -697,7 +722,10 @@ func (s *server) respondSignResult(w http.ResponseWriter, caller string, req sig
 		if issued.Decision != nil && !issued.Decision.Allowed {
 			outcome = "dry_run_denied"
 		}
-		s.auditEmission(caller, req, hosts, 0, outcome, issued.Decision, nil)
+		if aerr := s.auditEmission(caller, req, hosts, 0, outcome, issued.Decision, nil); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
 		return
 	}
@@ -706,12 +734,21 @@ func (s *server) respondSignResult(w http.ResponseWriter, caller string, req sig
 	// not been approved yet. Return the decision (empty cert) so the control
 	// plane can orchestrate approval.
 	if issued.Certificate == nil {
-		s.auditEmission(caller, req, hosts, 0, "approval-required", issued.Decision, nil)
+		if aerr := s.auditEmission(caller, req, hosts, 0, "approval-required", issued.Decision, nil); aerr != nil {
+			writeAuditUnavailable(w)
+			return
+		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
 		return
 	}
 
-	s.auditEmission(caller, req, hosts, issued.Serial, "issued", issued.Decision, nil)
+	// Issuance gate: if the "issued" record cannot be persisted in fail-closed
+	// mode, deny — the certificate is never written to the response, so no action
+	// can proceed downstream.
+	if aerr := s.auditEmission(caller, req, hosts, issued.Serial, "issued", issued.Decision, nil); aerr != nil {
+		writeAuditUnavailable(w)
+		return
+	}
 	writeJSON(w, http.StatusOK, signer.WireResponse{
 		Certificate:     string(ssh.MarshalAuthorizedKey(issued.Certificate)),
 		Serial:          issued.Serial,
@@ -749,13 +786,13 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 	// discover hosts to attempt. A match means caller equals a value that was
 	// charset-validated when it was frozen, so subj is safe to audit.
 	if subj, frozen := s.freezes.Frozen(caller, ""); frozen {
-		if aerr := s.audit.Append(audit.Entry{
+		// Best-effort: GET /v1/hosts is a read; a broken log must not turn host
+		// discovery into a 500 (only the sign path fails closed).
+		_ = s.appendAudit(audit.Entry{
 			Caller:  caller,
 			Outcome: "frozen_denied",
 			Err:     fmt.Sprintf("frozen: %s=%s", subj.Kind, subj.Value),
-		}); aerr != nil {
-			log.Printf("warning: error writing signer audit log: %v", aerr)
-		}
+		})
 		http.Error(w, "subject is frozen", http.StatusForbidden)
 		return
 	}
@@ -841,10 +878,8 @@ func (s *server) auditReload(caller string, hosts int, outcome string, err error
 	if err != nil {
 		e.Err = err.Error()
 	}
-	// M1: log the error instead of silently discarding it.
-	if aerr := s.audit.Append(e); aerr != nil {
-		log.Printf("warning: error writing signer audit log: %v", aerr)
-	}
+	// Best-effort: the reload has already applied by the time this records it.
+	_ = s.appendAudit(e)
 }
 
 // requireReloadCN authenticates a mutation request and checks the CN is in
@@ -987,9 +1022,8 @@ func (s *server) auditFreeze(caller, outcome string, subj signer.FreezeSubject, 
 	if err != nil {
 		e.Err = err.Error()
 	}
-	if aerr := s.audit.Append(e); aerr != nil {
-		log.Printf("warning: error writing signer audit log: %v", aerr)
-	}
+	// Best-effort: the freeze/unfreeze has already applied by the time this runs.
+	_ = s.appendAudit(e)
 }
 
 // signRequestsTotal counts /v1/sign requests by outcome. Fed by auditEmission
@@ -998,7 +1032,23 @@ func (s *server) auditFreeze(caller, outcome string, subj signer.FreezeSubject, 
 var signRequestsTotal = monitor.GetCounterVec("signer_sign_requests_total",
 	"POST /v1/sign requests by outcome.", "outcome")
 
-func (s *server) auditEmission(caller string, req signer.WireRequest, hosts signer.PolicyTable, serial uint64, outcome string, dec *signer.DecisionInfo, err error) {
+// errAuditUnavailable is returned by the audit helpers when audit_fail_mode is
+// "closed" (the default) and the tamper-evident log cannot be written. On the
+// sign path it turns into a 500 and no certificate is issued.
+var errAuditUnavailable = errors.New("audit unavailable")
+
+// writeAuditUnavailable records the blocked action and writes the 500 an audited
+// sign path returns when fail-closed mode cannot persist the outcome.
+func writeAuditUnavailable(w http.ResponseWriter) {
+	audit.RecordBlocked()
+	http.Error(w, "audit unavailable", http.StatusInternalServerError)
+}
+
+// auditEmission is the single audit funnel for /v1/sign (SSH). It returns an
+// error in fail-closed mode when the log cannot be written, so the caller denies
+// the request (no cert leaves the signer) — the load-bearing gate for
+// "no signed audit record, no action" across one-shot and session issuance.
+func (s *server) auditEmission(caller string, req signer.WireRequest, hosts signer.PolicyTable, serial uint64, outcome string, dec *signer.DecisionInfo, err error) error {
 	signRequestsTotal.With(outcome).Inc()
 	cmd := "role=" + req.Role + " purpose=" + req.Purpose
 	if req.SessionMode != "" {
@@ -1045,10 +1095,7 @@ func (s *server) auditEmission(caller string, req signer.WireRequest, hosts sign
 	if err != nil {
 		e.Err = err.Error()
 	}
-	// M1: log the error instead of silently discarding it.
-	if aerr := s.audit.Append(e); aerr != nil {
-		log.Printf("warning: error writing signer audit log: %v", aerr)
-	}
+	return s.appendAudit(e)
 }
 
 // writeJSON serialises v as JSON with the given HTTP status code.

--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"regexp"
@@ -245,9 +244,8 @@ func (s *server) auditPolicy(caller, host, pattern string, add bool, outcome str
 	if err != nil {
 		e.Err = err.Error()
 	}
-	if aerr := s.audit.Append(e); aerr != nil {
-		log.Printf("warning: error writing signer audit log: %v", aerr)
-	}
+	// Best-effort: the policy mutation has already applied by the time this runs.
+	_ = s.appendAudit(e)
 }
 
 // handlePolicyHostsRead serves the full host-policy table (GET /v1/policy/hosts).
@@ -288,7 +286,6 @@ func (s *server) auditPolicyRead(caller string, hosts int, outcome string, err e
 	if err != nil {
 		e.Err = err.Error()
 	}
-	if aerr := s.audit.Append(e); aerr != nil {
-		log.Printf("warning: error writing signer audit log: %v", aerr)
-	}
+	// Best-effort: a read audit; GET /v1/policy/hosts must not 500 on a broken log.
+	_ = s.appendAudit(e)
 }

--- a/config.example.json
+++ b/config.example.json
@@ -34,6 +34,14 @@
   //   }
   "audit_log": "audit.log",
   "audit_key": "pki/audit.seed",
+
+  // What happens when the audit log cannot be written. "closed" (default): the
+  // action (ssh_execute, session open/exec, file transfer, k8s) is denied with
+  // "audit unavailable" and its result withheld — no durable record, no result.
+  // "open": log the error and return the result anyway (the pre-2.0 behaviour).
+  // Omit for the secure default. Watch audit_append_failures_total / audit_blocked_total.
+  "audit_fail_mode": "closed",
+
   "source_address": "203.0.113.10",
   "max_ttl_seconds": 300,
   "session_idle_seconds": 300,

--- a/docs/API.md
+++ b/docs/API.md
@@ -544,6 +544,7 @@ forwards to the signer on behalf of the calling broker (`on_behalf_of` = broker 
 | `401 Unauthorized` | Missing or invalid mTLS client certificate. |
 | `403 Forbidden` | Denied by policy/RBAC at the signer; or the CN is not authorised for the sign path (`sign_callers`, or an approver CN). |
 | `429 Too Many Requests` | Behavioral rate limit exceeded for the subject (`behavior.mode=enforce`). |
+| `500 Internal Server Error` | `audit unavailable` — the signer could not write the issuance record and runs fail-closed (`audit_fail_mode: "closed"`, the default), so no certificate was issued. |
 | `502 Bad Gateway` | Signer reachable but its response carried no certificate in a non-approval state (unexpected signer condition). |
 
 **Behavioral guardrails:** when `behavior.mode` is `observe` or `enforce`, the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,19 @@
   waiver/approval persistence); pass `--volatile` only for a deliberately
   ephemeral, lab-style freeze. The signer also logs a startup warning when
   `state_db` is unset.
+- **Audit append is now fail-closed (#184, closes #133)** — when the audit log
+  cannot be written, the audited action is denied instead of proceeding
+  unrecorded. New `audit_fail_mode: "closed" | "open"` on both the signer and
+  broker configs, default **`closed`**. On the signer a failed issuance audit
+  means the certificate/bound token is never returned (`500 "audit unavailable"`),
+  which transitively gates one-shot exec, sessions, and file transfers; on the
+  broker a failed action-completion record withholds the result (`500`). A new
+  `audit_blocked_total` metric counts denied actions (alongside the existing
+  `audit_append_failures_total`). **Migration:** keep the audit filesystem healthy
+  — a full/unwritable audit disk now stops actions until resolved (see the
+  "audit unavailable" runbook in Operations); set `audit_fail_mode: "open"` to
+  restore the pre-2.0 log-and-proceed behaviour. Signer 429 rate-limit rejections
+  remain deliberately un-audited and are unaffected.
 
 ### Added
 - **Kill switch / revocation (#117)** — the signer gained `POST /v1/freeze`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -727,6 +727,35 @@ record *before* a well-formed one (mid-file corruption, which does not block
 startup because the signer reads the last line), it refuses and points you to
 `audit verify` to investigate.
 
+#### Actions failing with "audit unavailable" (fail-closed audit)
+
+Since v2.0.0 the signer and broker are **fail-closed on audit writes** by default
+(`audit_fail_mode: "closed"`): if the audit log cannot be written, the signer
+issues no certificate and the broker withholds the result, both returning
+`500 "audit unavailable"`. This is the honest availability trade — a full or
+unwritable audit disk stops actions until it is resolved. When operations start
+failing with that error:
+
+```bash
+# 1. Confirm it is the audit sink: the metric jumps and the process log carries
+#    "audit unavailable, denying action" / "…withholding result".
+curl -s http://127.0.0.1:9160/metrics | grep -E 'audit_(append_failures|blocked)_total'
+
+# 2. The usual cause is a full or read-only filesystem under the audit path.
+df -h /var/lib/infrabroker/signer   # and .../broker
+journalctl -u infrabroker-signer -n 50
+
+# 3. Free space / fix permissions / rotate off old segments, then actions resume
+#    automatically (no restart needed — the next Append self-heals).
+```
+
+Break-glass: if you must keep operating while fixing the disk, set
+`audit_fail_mode: "open"` and **restart** the service (this setting is read at
+startup, not hot-reloaded) — actions then proceed with only a logged warning and
+the trail has a gap for that window. Revert to `closed` and restart once healthy.
+Usually unnecessary: once the disk is fixed the next `Append` self-heals and
+actions resume with no config change.
+
 See [USAGE.md § 7](USAGE.md#7-reviewing-audit-logs) for the full audit-review
 guide (jq recipes, field reference, chain-integrity details).
 
@@ -949,7 +978,8 @@ key in `signer.json` / `control-plane.json`.
 | `controlplane_approvals_pending` | control plane | Approval requests currently awaiting a human decision (gauge, read at scrape time). |
 | `broker_events_total{outcome}` | broker frontends | Audit events by outcome (`executed`, `denied`, `session_open`, `session_exec`, `session_close`, `error`, …). |
 | `broker_sessions_active` | broker frontends | Persistent SSH sessions currently open (gauge). |
-| `audit_append_failures_total` | all | Audit-log `Append` errors. **Alert on any increase**: the operation continues by design (threat-model gap #9), so this counter is the only machine-readable signal that the audit trail has a gap. |
+| `audit_append_failures_total` | all | Audit-log `Append` errors. **Alert on any increase**: the machine-readable signal that the audit sink is failing. With `audit_fail_mode: "closed"` (the default) the audited action is then denied (see `audit_blocked_total`); with `"open"` it proceeds and the trail has a gap. |
+| `audit_blocked_total` | signer, broker | Actions denied because the audit log could not be written and the service is fail-closed (`audit_fail_mode: "closed"`). **Alert on any increase**: operations are being refused with `500 "audit unavailable"` — check the audit filesystem (threat-model gap #9). |
 
 Example scrape check:
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -361,17 +361,31 @@ would otherwise persist in plaintext in every one of those sinks.
   managers) and keep treating audit logs / recordings as sensitive at rest
   (`0600`, restricted directories).
 
-### 9. Audit failure is fail-open
-If writing an audit entry fails (disk full, I/O error), the failure is logged
-but the operation **still proceeds** — issuance and execution are not blocked.
-This favors availability over a hard guarantee that every action is recorded. A
-compliance deployment that requires "no audit, no action" would need a
-fail-closed toggle (not yet implemented).
-- **Mitigation today:** every service exposes the
-  `audit_append_failures_total` counter on its `monitor_listen` endpoint
-  (`/metrics`) — alert on any increase; it is the machine-readable signal that
-  the trail has a gap. The process log also carries `error writing audit log`
-  warnings. Keep the audit volume healthy.
+### 9. Audit failure is fail-closed by default
+If writing an audit entry fails (disk full, I/O error), the audited action is
+**denied** — "no signed audit record, no action". Since v2.0.0 this is the
+default (`audit_fail_mode: "closed"`) on both the signer and the broker:
+- **Signer (the load-bearing gate):** a failed issuance audit means the
+  certificate/bound token is **never written to the response**, so no downstream
+  action can proceed. Because credentials are per-operation ephemeral certs with
+  a force-command, gating issuance transitively covers one-shot exec, sessions,
+  and file transfers. The sign request returns `500 "audit unavailable"`.
+- **Broker (defence in depth):** an action-completion record that cannot be
+  written (`ssh_execute`, session open / `ssh_session_exec`, file transfer, k8s
+  action) causes the **result to be withheld** (`500 "audit unavailable"`). The
+  remote side effect of a post-execution audit failure already happened — the
+  documented residual — but the output is never returned without a durable trace.
+- **Documented opt-out (availability over the guarantee):** set
+  `audit_fail_mode: "open"` to restore the pre-2.0 behaviour (log the error and
+  proceed). The availability trade of the closed default is honest: a full or
+  unwritable audit disk **stops actions until it is resolved** — the runbook note
+  in [Operations](OPERATIONS.md) says what to check when actions fail with
+  "audit unavailable".
+- **Alerting:** `audit_append_failures_total` counts every write failure and
+  `audit_blocked_total` counts actions denied because of one; both are exposed on
+  `monitor_listen` (`/metrics`). The signer 429 rate-limit rejections remain
+  deliberately un-audited (the log must not amplify a flood), so they are never
+  affected by this mode.
 
 ### 10. Kubernetes: token grants the SA's RBAC, not a single call
 The Kubernetes target (v1.34.0) is a **credential-broker**: for an authorised

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -19,6 +19,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `signer` | `*SignerClientConfig` | Signer, when present, externalises signing to a remote service (HTTP+mTLS). The broker no longer holds the CA key or the policy. |
 | `audit_log` | `string` | Audit. |
 | `audit_key` | `string` | Ed25519 seed (>=32 bytes) |
+| `audit_fail_mode` | `string` | AuditFailMode governs what happens when the audit log cannot be written. "closed" (default): the audited action (ssh_execute, session open/exec, file transfer, k8s action) is denied with "audit unavailable" — the result is withheld. "open": log the error, count the metric, and return the result anyway (the pre-2.0 behaviour). Empty = "closed". |
 | `source_address` | `string` | SourceAddress: broker egress IP/CIDR, used in local mode. |
 | `max_ttl_seconds` | `int` | MaxTTLSeconds caps the maximum requestable TTL. |
 | `hosts_refresh_seconds` | `int` | HostsRefreshSeconds: host-list reload interval from the signer. Remote mode only. Default: 300 (5 minutes). |
@@ -113,6 +114,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `ca_keys` | `map[string]ca.CAKeyConfig` |  |
 | `audit_log` | `string` | Issuance audit log (independent of the broker). |
 | `audit_key` | `string` |  |
+| `audit_fail_mode` | `string` | AuditFailMode governs what happens when the audit log cannot be written. "closed" (default): the action being audited is denied — no signed audit record, no certificate. "open": log the error, count the metric, and proceed (the pre-2.0 behaviour). Empty = "closed". |
 | `max_ttl_seconds` | `int` | MaxTTLSeconds: global cap when the host policy does not set one. |
 | `auto_reload_seconds` | `int` | AutoReloadSeconds: if > 0, the signer polls signer.json's mtime every N seconds and hot-reloads on change — same validated, atomic path as SIGHUP / POST /v1/reload, so a transiently-invalid in-progress save is rejected and the previous good state is kept. 0 or absent = disabled (default). |
 | `sign_rate_limit_per_min` | `int` | SignRateLimitPerMin caps POST /v1/sign requests per authenticated client CN per minute (token bucket: burst up to the cap, continuous refill). Keyed on the mTLS peer CN — not on_behalf_of — and enforced before body parsing; excess requests get 429 with a Retry-After hint. Hot-reloadable. 0 or absent = disabled (backward compatible). |

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -269,10 +269,36 @@ func (l *Log) SetRedactor(r Redactor) {
 }
 
 // appendFailures counts Append errors across every log this process holds, so
-// operators can alert on audit-trail gaps (the call sites only log a warning —
-// the operation deliberately continues).
+// operators can alert on audit-trail gaps. In audit_fail_mode=open a failed
+// Append is only logged and the operation continues; in the default closed mode
+// the action is denied instead and also counted by blockedActions.
 var appendFailures = monitor.GetCounter("audit_append_failures_total",
-	"Audit log Append errors (the operation continues; the trail has a gap).")
+	"Audit log Append errors (mode=open: the operation continues; mode=closed: the action is denied).")
+
+// blockedActions counts actions denied because the audit log could not be
+// written and the service is in fail-closed mode (audit_fail_mode=closed, the
+// default). The alerting hook operators watch alongside audit_append_failures_total.
+var blockedActions = monitor.GetCounter("audit_blocked_total",
+	"Actions denied because the audit log could not be written (audit_fail_mode=closed).")
+
+// RecordBlocked increments audit_blocked_total. Broker and signer call it when
+// fail-closed mode turns an Append failure into a denied action.
+func RecordBlocked() { blockedActions.Inc() }
+
+// FailClosed parses an audit_fail_mode config value. "" and "closed" fail closed
+// (deny the audited action when the log cannot be written — the secure default);
+// "open" fails open (log the error and proceed, the pre-2.0 behaviour); any
+// other value is a configuration error.
+func FailClosed(mode string) (bool, error) {
+	switch mode {
+	case "", "closed":
+		return true, nil
+	case "open":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid audit_fail_mode %q (want \"closed\" or \"open\")", mode)
+	}
+}
 
 // Append signs and writes an entry. It computes prev_hash/seq and signs over
 // the canonical content (with the Sig field empty).

--- a/internal/broker/audit_failclosed_test.go
+++ b/internal/broker/audit_failclosed_test.go
@@ -1,0 +1,44 @@
+package broker
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/audit"
+)
+
+// brokenAuditLog returns an opened audit log whose backing directory has been
+// removed, so the next Append fails — models an unwritable sink for the
+// fail-closed tests.
+func brokenAuditLog(t *testing.T) *audit.Log {
+	t.Helper()
+	dir := t.TempDir()
+	seed := make([]byte, ed25519.SeedSize)
+	al, err := audit.Open(filepath.Join(dir, "audit.log"), ed25519.NewKeyFromSeed(seed))
+	if err != nil {
+		t.Fatalf("audit open: %v", err)
+	}
+	al.Close()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove audit dir: %v", err)
+	}
+	return al
+}
+
+// TestEngineAuditFailMode covers auditE, the funnel every action-completion site
+// checks: closed mode denies (ErrAuditUnavailable so the caller withholds the
+// result), open mode logs and proceeds.
+func TestEngineAuditFailMode(t *testing.T) {
+	t.Parallel()
+	closed := &Engine{cfg: &Config{}, auditLog: brokenAuditLog(t), auditFailClosed: true}
+	if err := closed.auditE(audit.Entry{Host: "web01", Outcome: "executed"}); !errors.Is(err, ErrAuditUnavailable) {
+		t.Fatalf("closed mode must return ErrAuditUnavailable, got %v", err)
+	}
+	open := &Engine{cfg: &Config{}, auditLog: brokenAuditLog(t), auditFailClosed: false}
+	if err := open.auditE(audit.Entry{Host: "web01", Outcome: "executed"}); err != nil {
+		t.Fatalf("open mode must proceed, got %v", err)
+	}
+}

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -43,6 +43,11 @@ var (
 	// ErrUpstream: an infrastructure failure (SSH dial/exec, or the signing
 	// service unreachable/5xx) — not the caller's authorization problem.
 	ErrUpstream = errors.New("upstream failure")
+	// ErrAuditUnavailable: the audit log could not be written and the broker runs
+	// in the default fail-closed mode (audit_fail_mode=closed), so the action's
+	// result is withheld rather than returned without a durable record. Maps to a
+	// 500 at the frontend.
+	ErrAuditUnavailable = errors.New("audit unavailable")
 )
 
 // Config is loaded from a JSON file.
@@ -69,6 +74,13 @@ type Config struct {
 	// Audit.
 	AuditLog string `json:"audit_log"`
 	AuditKey string `json:"audit_key"` // Ed25519 seed (>=32 bytes)
+
+	// AuditFailMode governs what happens when the audit log cannot be written.
+	// "closed" (default): the audited action (ssh_execute, session open/exec, file
+	// transfer, k8s action) is denied with "audit unavailable" — the result is
+	// withheld. "open": log the error, count the metric, and return the result
+	// anyway (the pre-2.0 behaviour). Empty = "closed".
+	AuditFailMode string `json:"audit_fail_mode,omitempty"`
 
 	// SourceAddress: broker egress IP/CIDR, used in local mode.
 	SourceAddress string `json:"source_address"`
@@ -316,9 +328,12 @@ type Engine struct {
 	sgn      signer.Signer
 	fetcher  hostFetcher // nil in local mode
 	auditLog *audit.Log
-	redactor *redact.Redactor // nil = redaction disabled
-	maxTTL   time.Duration
-	sessions *sessionManager
+	// auditFailClosed denies the audited action (withholds its result) when the
+	// audit log cannot be written (audit_fail_mode=closed, the default).
+	auditFailClosed bool
+	redactor        *redact.Redactor // nil = redaction disabled
+	maxTTL          time.Duration
+	sessions        *sessionManager
 
 	// clusterFetcher fetches the k8s cluster list; nil when no k8s target is
 	// configured (local mode, or a signer with no clusters).
@@ -488,6 +503,12 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		return nil, err
 	}
 
+	auditFailClosed, err := audit.FailClosed(cfg.AuditFailMode)
+	if err != nil {
+		al.Close()
+		return nil, err
+	}
+
 	idle := time.Duration(cfg.SessionIdleSeconds) * time.Second
 	if idle <= 0 {
 		idle = 5 * time.Minute
@@ -497,7 +518,7 @@ func NewEngine(cfg *Config) (*Engine, error) {
 		maxLife = 30 * time.Minute
 	}
 
-	e := &Engine{cfg: cfg, sgn: sgn, fetcher: fetcher, auditLog: al, redactor: redactor, maxTTL: maxTTL, ownIdentity: ownIdentity}
+	e := &Engine{cfg: cfg, sgn: sgn, fetcher: fetcher, auditLog: al, auditFailClosed: auditFailClosed, redactor: redactor, maxTTL: maxTTL, ownIdentity: ownIdentity}
 	e.sessions = newSessionManager(idle, maxLife, func(s *liveSession) {
 		e.auditE(audit.Entry{Caller: s.caller, Host: s.host, Serial: s.serial,
 			SessionID: s.id, Outcome: "session_close", Err: "reaped (idle/lifetime)"})
@@ -984,7 +1005,11 @@ func (e *Engine) Execute(ctx context.Context, c Caller, host, command string, tt
 		e.auditE(audit.Entry{Caller: c.ID, Host: host, Command: command, Serial: serial, Outcome: "error", Err: err.Error()})
 		return nil, fmt.Errorf("%w: execution: %v", ErrUpstream, err)
 	}
-	e.auditE(audit.Entry{
+	// Fail-closed gate: the command already ran, but withhold its output if the
+	// "executed" record cannot be persisted — the agent gets ErrAuditUnavailable
+	// instead of untraceable output (the remote side effect is the documented
+	// residual of any post-execution audit).
+	if err := e.auditE(audit.Entry{
 		Caller:     c.ID,
 		Host:       host,
 		Command:    command,
@@ -995,7 +1020,9 @@ func (e *Engine) Execute(ctx context.Context, c Caller, host, command string, tt
 		PTY:        opts.PTY,
 		PolicyRule: decisionRule(dec),
 		Warning:    strings.Join(warnings, "; "),
-	})
+	}); err != nil {
+		return nil, err
+	}
 	return &Result{Stdout: res.Stdout, Stderr: res.Stderr, ExitCode: res.ExitCode, Serial: serial, Warnings: warnings}, nil
 }
 
@@ -1297,17 +1324,38 @@ func (e *Engine) Close() error {
 var eventsTotal = monitor.GetCounterVec("broker_events_total",
 	"Broker audit events by outcome.", "outcome")
 
-func (e *Engine) auditE(ent audit.Entry) {
+// auditE writes an audit entry. In the default fail-closed mode an Append
+// failure returns ErrAuditUnavailable so an action-completion caller withholds
+// the result — no durable record, no result handed back; in "open" mode it logs,
+// counts the metric (via Append), and returns nil (the pre-2.0 behaviour).
+// Best-effort callers (pre-execution denials, mid-session and cleanup records)
+// ignore the returned error.
+func (e *Engine) auditE(ent audit.Entry) error {
 	eventsTotal.With(ent.Outcome).Inc()
 	if hi, ok := e.hostInfo(ent.Host); ok {
 		if ent.User == "" {
 			ent.User = hi.User
 		}
 	}
-	// M1: log the error instead of silently discarding it.
+	return e.appendAudit(ent)
+}
+
+// appendAudit writes ent and applies the fail-closed policy: in the default mode
+// an Append failure records audit_blocked_total and returns ErrAuditUnavailable
+// so an action-completion caller withholds the result; in "open" mode it logs
+// and returns nil. auditE adds host-user enrichment + the outcome metric first;
+// auditK8s counts its own metric and enriches from the cluster table, so it
+// calls this directly.
+func (e *Engine) appendAudit(ent audit.Entry) error {
 	if err := e.auditLog.Append(ent); err != nil {
+		if e.auditFailClosed {
+			audit.RecordBlocked()
+			log.Printf("audit unavailable, withholding result: %v", err)
+			return ErrAuditUnavailable
+		}
 		log.Printf("warning: error writing audit log: %v", err)
 	}
+	return nil
 }
 
 // ParseHostKey converts an authorized_keys line into an ssh.PublicKey.

--- a/internal/broker/filetransfer.go
+++ b/internal/broker/filetransfer.go
@@ -88,10 +88,12 @@ func (e *Engine) PutFile(ctx context.Context, c Caller, host, path string, conte
 	}
 	sum := sha256.Sum256(content)
 	digest := hex.EncodeToString(sum[:])
-	e.auditE(audit.Entry{
+	if err := e.auditE(audit.Entry{
 		Caller: c.ID, Host: host, Serial: res.Serial, Outcome: "file_put",
 		Command: fmt.Sprintf("path=%s bytes=%d sha256=%s", path, len(content), digest),
-	})
+	}); err != nil {
+		return nil, err
+	}
 	return &FileTransferResult{Size: len(content), SHA256: digest, Serial: res.Serial, Warnings: res.Warnings}, nil
 }
 
@@ -121,9 +123,11 @@ func (e *Engine) GetFile(ctx context.Context, c Caller, host, path string, maxBy
 	}
 	sum := sha256.Sum256(data)
 	digest := hex.EncodeToString(sum[:])
-	e.auditE(audit.Entry{
+	if err := e.auditE(audit.Entry{
 		Caller: c.ID, Host: host, Serial: res.Serial, Outcome: "file_get",
 		Command: fmt.Sprintf("path=%s bytes=%d sha256=%s", path, len(data), digest),
-	})
+	}); err != nil {
+		return nil, err
+	}
 	return &FileTransferResult{Content: data, Size: len(data), SHA256: digest, Serial: res.Serial, Warnings: res.Warnings}, nil
 }

--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"sort"
 	"time"
 
@@ -144,7 +143,11 @@ func (e *Engine) K8sExecute(ctx context.Context, c Caller, cluster string, actio
 	if runErr != nil {
 		outcome = "error"
 	}
-	e.auditK8s(c, cluster, canonical, issued.Serial, outcome, issued.Decision, runErr, manifest...)
+	// Fail-closed gate: withhold the result if the completion record cannot be
+	// persisted (the action already ran — the documented residual).
+	if aerr := e.auditK8s(c, cluster, canonical, issued.Serial, outcome, issued.Decision, runErr, manifest...); aerr != nil {
+		return nil, aerr
+	}
 	if runErr != nil {
 		return nil, runErr
 	}
@@ -188,7 +191,10 @@ func resourceTable(ci signer.ClusterInfo) (map[string]k8s.ResourceDef, error) {
 // auditK8s records a k8s execution entry. The canonical action is the Command;
 // a k8s_apply manifest is never logged verbatim (it can carry a Secret) — its
 // sha256 rides in body_sha256.
-func (e *Engine) auditK8s(c Caller, cluster, canonical string, serial uint64, outcome string, dec *signer.DecisionInfo, err error, manifest ...byte) {
+// auditK8s records a k8s action decision. Like auditE it returns an error in
+// fail-closed mode so the "executed" caller withholds the result; the denial and
+// error call sites treat it best-effort (the action did not complete anyway).
+func (e *Engine) auditK8s(c Caller, cluster, canonical string, serial uint64, outcome string, dec *signer.DecisionInfo, err error, manifest ...byte) error {
 	e.mu.RLock()
 	ci, ok := e.clusters[cluster]
 	e.mu.RUnlock()
@@ -224,7 +230,5 @@ func (e *Engine) auditK8s(c Caller, cluster, canonical string, serial uint64, ou
 		ent.Err = err.Error()
 	}
 	eventsTotal.With(outcome).Inc()
-	if aerr := e.auditLog.Append(ent); aerr != nil {
-		log.Printf("warning: error writing audit log: %v", aerr)
-	}
+	return e.appendAudit(ent)
 }

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -212,6 +212,15 @@ func (m *sessionManager) add(s *liveSession) error {
 	return nil
 }
 
+// remove deletes a session from the live set without closing it (the caller owns
+// the teardown). Used to roll back an add when the session must not become usable
+// — e.g. its open record could not be persisted in fail-closed audit mode.
+func (m *sessionManager) remove(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, id)
+}
+
 // checkoutOwned looks up a session and, if caller owns it, marks one command in
 // flight (busy++, lastUsed=now) and returns owned=true. It returns found=false
 // for an unknown id and owned=false (WITHOUT mutating any state) when caller
@@ -345,10 +354,11 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 		return nil, err
 	}
 
-	// Start recording for shell/pty sessions when a recording directory is set.
-	e.startSessionRecording(s)
-
-	e.auditE(audit.Entry{
+	// Fail-closed gate: audit the open before starting recording or handing the
+	// session to the caller. If the record cannot be persisted, tear the session
+	// down so it never becomes usable (and no subsequent ssh_session_exec can run
+	// against an unrecorded session).
+	if err := e.auditE(audit.Entry{
 		Caller:    c.ID,
 		Host:      host,
 		Serial:    serial,
@@ -357,7 +367,14 @@ func (e *Engine) OpenSession(ctx context.Context, c Caller, host, mode string, t
 		Command:   "mode=" + mode,
 		Elevation: opts.elevationLabel(),
 		PTY:       opts.PTY,
-	})
+	}); err != nil {
+		e.sessions.remove(s.id)
+		s.close()
+		return nil, err
+	}
+
+	// Start recording for shell/pty sessions when a recording directory is set.
+	e.startSessionRecording(s)
 	return &SessionResult{SessionID: s.id, Serial: serial}, nil
 }
 
@@ -491,7 +508,9 @@ func (e *Engine) SessionExec(ctx context.Context, c Caller, sessionID, command s
 		return nil, fmt.Errorf("session execution: %w", err)
 	}
 
-	e.auditE(audit.Entry{
+	// Fail-closed gate: withhold the output if this per-command record cannot be
+	// persisted (the session_open record already gated the session's existence).
+	if err := e.auditE(audit.Entry{
 		Caller:    c.ID,
 		Host:      s.host,
 		Serial:    s.serial,
@@ -506,7 +525,9 @@ func (e *Engine) SessionExec(ctx context.Context, c Caller, sessionID, command s
 		PTY:        s.pty,
 		PolicyRule: decisionRule(dec),
 		Warning:    strings.Join(warnings, "; "),
-	})
+	}); err != nil {
+		return nil, err
+	}
 	return &Result{Stdout: res.Stdout, Stderr: res.Stderr, ExitCode: res.ExitCode, Serial: s.serial, Warnings: warnings}, nil
 }
 

--- a/signer.example.json
+++ b/signer.example.json
@@ -30,6 +30,14 @@
 
   "audit_log": "signer_audit.log",
   "audit_key": "pki/signer_audit.seed",
+
+  // What happens when the audit log cannot be written. "closed" (default): the
+  // sign request is denied with 500 "audit unavailable" — no signed record, no
+  // certificate (the availability trade: a full disk stops issuance until fixed;
+  // watch audit_append_failures_total / audit_blocked_total). "open": log the
+  // error and issue anyway (the pre-2.0 behaviour). Omit for the secure default.
+  "audit_fail_mode": "closed",
+
   "max_ttl_seconds": 300,
 
   // Optional: if > 0, the signer polls this file's mtime every N seconds and


### PR DESCRIPTION
**Closes #184. Closes #133.** Third and final of three secure-by-default flips (v2.0.0).

## What changes
When the audit log cannot be written, the audited action is now **denied** instead of proceeding unrecorded — "no signed audit record, no action". New `audit_fail_mode: "closed" | "open"` on **both** the signer and broker configs, default **`closed`**.

### Signer — the load-bearing gate
`auditEmission` (SSH `/v1/sign`) and `auditK8s` (k8s `/v1/sign`) return an error in closed mode, so a failed **issuance** audit means the certificate/bound token is **never written to the response** → `500 "audit unavailable"`. Because credentials are per-operation ephemeral certs with a force-command, gating issuance transitively covers one-shot exec, sessions, and file transfers (this is exactly what #133 asked for). The 8 inline append-and-log copies are centralized on the fail-closed `appendAudit` helper; denials, reads, and admin mutations (reload/freeze/grant/policy) stay best-effort — the issuance gate is the backstop.

### Broker — defence in depth
`auditE`/`auditK8s` fail-closed at the **action-completion** boundaries (`ssh_execute`, session open / `ssh_session_exec`, file transfer, k8s), **withholding the result** (`500 "audit unavailable"`). `session_open` tears the just-opened session down so no subsequent `ssh_session_exec` can run against an unrecorded session. The remote side effect of a post-execution audit failure already happened — the documented residual — but the output is never returned without a durable trace.

## Escape hatch / migration
- Keep the audit filesystem healthy — a full/unwritable audit disk now **stops actions until resolved** (self-heals once fixed; see the new "audit unavailable" runbook in Operations).
- Set `audit_fail_mode: "open"` (read at startup) to restore the pre-2.0 log-and-proceed behaviour.

## Details
- `audit.FailClosed` parses the mode (shared by both services); new `audit_blocked_total` metric counts denied actions alongside `audit_append_failures_total`.
- Signer **429 rate-limit** rejections stay deliberately un-audited (the log must not amplify a flood) and are unaffected.
- The control plane forwards signing to the signer, whose issuance audit is the hard gate, so its own forward-record stays best-effort (outside #184's stated broker+signer scope).

## Tests
- Force an unwritable log (opened, then its backing dir removed): signer `appendAudit` and broker `auditE` → `errAuditUnavailable`/`ErrAuditUnavailable` in closed mode, `nil` in open mode.
- `/v1/sign` via the frozen denial: closed + broken log → `500` and `audit_blocked_total` increments; open → the normal `403`.
- `audit.FailClosed` parsing table; `classifyError(ErrAuditUnavailable) → 500`.
- Full `go test -race ./...` green; `make docs-check` green; confcheck anti-drift green.

## Docs
THREAT_MODEL gap #9 rewritten (fail-closed by default, opt-out documented); OPERATIONS runbook + metrics table (`audit_blocked_total`); API `500` row on `/v1/sign`; `signer.example.json` / `config.example.json` comments; CHANGELOG breaking-changes bullet.