### PR TITLE
chore: v2.0.0 release (changelog + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## [v2.0.0] - 2026-07-10
+
+First major release. The headline is **secure-by-default**: the three fail-open
+defaults an operator could reasonably mistake for protection — `callers` RBAC,
+audit-append, and the kill-switch freeze without `state_db` — are flipped to
+fail-closed, each with a documented opt-out. Alongside them ship the kill switch
+/ revocation, in-conversation approvals, the multi-platform approval bridge,
+per-agent IdP identity, ssh-agent CA custody, JSONC config files, and the
+`doctor --security` preflight.
 
 ### Breaking changes
 - **`callers` RBAC is now default-deny (#184)** — once the signer's `callers`

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,23 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-04 (v1.38.0, pasada de auditoría + `broker-ctl audit repair`).
+> actualización: 2026-07-10 (v2.0.0, secure-by-default: tres defaults fail-open volteados).
 >
 > Estado reciente:
+> - **v2.0.0** (primer major): **secure-by-default** — se voltean a fail-closed
+>   los tres defaults fail-open que un operador podía confundir con protección,
+>   cada uno con su opt-out documentado: (1) la tabla `callers` no vacía es
+>   autoritativa y **default-deny** (un CN no listado no ve/firma ningún host;
+>   escape: `_default` con grupos, o tabla vacía = sin RBAC) [#184]; (2) el
+>   **audit append es fail-closed** vía `audit_fail_mode` (default `closed`): sin
+>   registro durable no hay acción — el signer no devuelve cert (gate real,
+>   cubre exec/sesiones/file-transfer) y el broker retiene el resultado; métrica
+>   `audit_blocked_total`; escape: `"open"` [#184, cierra #133]; (3) un **freeze
+>   volátil** (signer sin `state_db`) se **rechaza** con 409 salvo
+>   `allow_volatile`/`--volatile` [#184]. Acompañan: kill switch/revocación
+>   (#117), aprobaciones in-conversation (#118), approval-bridge multiplataforma
+>   (#120), identidad IdP por agente (#121), custodia de CA en ssh-agent (#122),
+>   configs JSONC (#183) y `doctor --security` (#134). Tres commits `!`.
 > - **v1.38.0**: pasada de auditoría de seguridad/correctitud (6 hallazgos: 5
 >   fixes low + `broker-ctl audit repair`). El signer sigue fail-closed ante un
 >   registro final de auditoría truncado; `audit repair` es la ruta explícita de

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "1.38.0",
+  "version": "2.0.0",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:1.38.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:2.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release commit for **v2.0.0** — the first major. Prepared via the `/release` skill.

## Why MAJOR
Three breaking `!` changes flip the product's fail-open defaults to secure-by-default (all merged, `#184` + `#133` closed):
- **`callers` RBAC default-deny** (#198) — a non-empty `callers` table denies unlisted CNs.
- **Volatile freeze rejected** (#199) — a freeze without `state_db` needs `--volatile`.
- **Audit append fail-closed** (#200) — `audit_fail_mode` defaults to `closed`.

Each ships with a documented opt-out; see the **Breaking changes** section of the changelog for per-flip migration lines.

## What's in this PR
- `docs/CHANGELOG.md` — `[Unreleased]` folded into `## [v2.0.0] - 2026-07-10` with a one-line theme. The section already accumulated the full slate through `/issue` (kill switch #117, in-conversation approvals #118, dry-run reason codes #119, approval bridge #120, per-agent IdP #121, ssh-agent CA custody #122, JSONC configs #183, `doctor --security` #134, mesh guide #137, quickstart #182, plus the security fixes); cross-checked against `git log v1.38.0..HEAD` (66 commits) — the remainder are doc-only corrections this changelog doesn't bullet individually.
- `server.json` — `version` and OCI `identifier` → `2.0.0` (`mcp-publisher validate` ✅).
- `docs/HANDOFF.md` — header date/version + a `v2.0.0` "Estado reciente" bullet.

## Gate
`make verify` green locally (gofmt, vet, build, `go test -race ./...`, govulncheck = no vulnerabilities, docs drift, strict mkdocs).

## Human gates (per the release skill)
This PR is **not** auto-merged. After review + merge, the annotated tag `v2.0.0` is pushed to fire `release.yml` (goreleaser → GitHub release + multi-arch ghcr image; `mcp-registry` job → MCP Registry). Both the merge and the tag push are human-authorized, irreversible steps.