### PR TITLE
fix(config): reject duplicate JSON keys — loader last-wins vs policy rewrite first-match disagreement

### DIFF
--- a/cmd/signer/policy_test.go
+++ b/cmd/signer/policy_test.go
@@ -98,6 +98,27 @@ func TestEditAllowErrors(t *testing.T) {
 	}
 }
 
+// TestEditAllowRejectsDuplicateKey is the #216 guard: a host with two
+// command_policy objects must NOT be edited. The loader enforces the LAST
+// occurrence (encoding/json last-wins) while the format-preserving patch targets
+// the FIRST (hujson first-match), so an edit here would report success against a
+// shadowed occurrence and leave the effective rule untouched. The mutation path
+// must refuse it instead.
+func TestEditAllowRejectsDuplicateKey(t *testing.T) {
+	t.Parallel()
+	dup := `{
+  "hosts": {
+    "web01": {
+      "command_policy": {"mode":"allowlist","allow":[]},
+      "command_policy": {"mode":"allowlist","allow":["^rm -rf /$"]}
+    }
+  }
+}`
+	if _, err := editAllow([]byte(dup), "web01", "^rm -rf /$", false); err == nil {
+		t.Error("editAllow must refuse a config with a duplicated command_policy key")
+	}
+}
+
 // TestEditAllowPreservesLineComments is the #183 round-trip: a signer.json that
 // carries // comments has an allow rule added through the policy-mutation edit,
 // and the comments survive on disk alongside the new rule.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **Reject duplicate JSON keys in config files (#216)** — `confcheck` now fails
+  closed when any config object carries the same key twice, instead of silently
+  resolving it last-wins. Previously the typed loader (`encoding/json`, last-wins)
+  and the comment-preserving policy rewrite (`hujson`, first-match) could resolve
+  a duplicated key to *different* occurrences, so a `POST`/`DELETE /v1/policy/hosts`
+  allowlist edit could return `200` — and write a `policy-changed` audit record —
+  while the occurrence the runtime actually enforces stayed untouched. A config
+  with a duplicated key now fails to load (signer refuses to start) or edit
+  (the mutation API returns an error and audits `policy-failed`).
+
 ## [v2.0.0] - 2026-07-10
 
 First major release. The headline is **secure-by-default**: the three fail-open

--- a/internal/confcheck/confcheck.go
+++ b/internal/confcheck/confcheck.go
@@ -21,6 +21,13 @@ import (
 // applies it, so config files may carry real // comments. It does NOT touch
 // object keys, so the legacy "_*" comment-key convention — and the reserved
 // "_default" data key — keep working exactly as before.
+//
+// It also rejects duplicate object keys fail-closed: encoding/json (the loaders)
+// keeps the LAST value for a repeated key while hujson (the comment-preserving
+// Patch) resolves a JSON pointer to the FIRST, so a duplicated key would make the
+// value the runtime enforces diverge from the one a policy rewrite edits. A
+// security config must not depend on which parser wins, so a duplicate key is an
+// error here — before any load or rewrite — rather than a silent last-wins.
 func Standardize(raw []byte) ([]byte, error) {
 	// hujson.Standardize edits its input in place (comment bytes → whitespace), so
 	// copy first — callers must be able to keep the original bytes (e.g. to then
@@ -29,7 +36,59 @@ func Standardize(raw []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing JSONC: %w", err)
 	}
+	if err := rejectDuplicateKeys(b); err != nil {
+		return nil, err
+	}
 	return b, nil
+}
+
+// rejectDuplicateKeys errors if any JSON object in b (already standard JSON, so
+// comments are gone) has two members with the same name, walking the whole
+// document.
+func rejectDuplicateKeys(b []byte) error {
+	return checkDupKeys(json.NewDecoder(bytes.NewReader(b)))
+}
+
+// checkDupKeys consumes exactly one JSON value from dec, recursing into objects
+// and arrays, and returns an error on the first object carrying a repeated key.
+func checkDupKeys(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil // a scalar value: nothing to check
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]bool)
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			key := keyTok.(string) // an object member name is always a string
+			if seen[key] {
+				return fmt.Errorf("duplicate key %q in config object", key)
+			}
+			seen[key] = true
+			if err := checkDupKeys(dec); err != nil { // the member's value
+				return err
+			}
+		}
+		_, err = dec.Token() // consume the closing '}'
+		return err
+	case '[':
+		for dec.More() {
+			if err := checkDupKeys(dec); err != nil {
+				return err
+			}
+		}
+		_, err = dec.Token() // consume the closing ']'
+		return err
+	}
+	return nil
 }
 
 // Patch applies an RFC 6902 JSON Patch to raw JSONC bytes, PRESERVING the file's
@@ -39,6 +98,14 @@ func Standardize(raw []byte) ([]byte, error) {
 // operator's // comments survive an edit. A patch that does not apply (e.g. a
 // path whose parent is absent) is an error and nothing is written.
 func Patch(raw, patch []byte) ([]byte, error) {
+	// Refuse to edit a config with a duplicate key: hujson resolves a JSON pointer
+	// to the FIRST matching member, so a patch would target a different occurrence
+	// than the encoding/json loaders enforce (last-wins). Standardize runs the
+	// duplicate-key check; the bytes it returns are discarded (Patch edits raw so
+	// comments survive).
+	if _, err := Standardize(raw); err != nil {
+		return nil, err
+	}
 	v, err := hujson.Parse(raw)
 	if err != nil {
 		return nil, fmt.Errorf("parsing JSONC: %w", err)

--- a/internal/confcheck/confcheck_test.go
+++ b/internal/confcheck/confcheck_test.go
@@ -121,6 +121,68 @@ func TestStrictAcceptsJSONC(t *testing.T) {
 	}
 }
 
+func TestStandardizeRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	// encoding/json silently keeps the last value for a repeated key while hujson's
+	// Patch resolver targets the first; a duplicate key must fail closed so the two
+	// parsers can never disagree on a security config.
+	dupes := map[string]string{
+		"top-level":                   `{"name": "a", "name": "b"}`,
+		"nested security key":         `{"hosts": {"web": {"principal": "host:web", "principal": "host:evil"}}}`,
+		"duplicate command_policy":    `{"hosts": {"web": {"command_policy": {"mode": "allowlist", "allow": []}, "command_policy": {"mode": "allowlist", "allow": ["^rm -rf /$"]}}}}`,
+		"inside an array element":     `{"hosts": {"web": {"principals": [{"p": 1, "p": 2}]}}}`,
+		"duplicate with a // comment": "{\n // note\n \"a\": 1,\n \"a\": 2\n}",
+	}
+	for name, cfg := range dupes {
+		if _, err := Standardize([]byte(cfg)); err == nil {
+			t.Errorf("%s: a duplicate key must be rejected: %s", name, cfg)
+		}
+	}
+
+	// No false positives: the reserved "_default" data key appearing in two
+	// DIFFERENT objects is not a duplicate, and comment keys alongside real keys
+	// load fine.
+	ok := []string{
+		`{"ca_keys": {"_default": "k1", "prod": "k2"}, "group_command_policies": {"_default": ["base"]}}`,
+		`{"_comment": "doc", "hosts": {"web": {"groups": ["a"]}, "db": {"groups": ["b"]}}}`,
+	}
+	for _, cfg := range ok {
+		if _, err := Standardize([]byte(cfg)); err != nil {
+			t.Errorf("a duplicate-free config must pass: %s: %v", cfg, err)
+		}
+	}
+}
+
+func TestStrictRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+	// A duplicated security control must fail closed at the typed load, not be
+	// silently resolved last-wins.
+	var s sample
+	if err := Strict([]byte(`{"sign_callers": ["a"], "sign_callers": ["a", "b"]}`), &s); err == nil {
+		t.Error("Strict must reject a duplicated sign_callers key")
+	}
+}
+
+func TestPatchRejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+	// The finding scenario: a host with two command_policy objects. hujson would
+	// patch the FIRST while the loader enforces the LAST — so refuse the edit
+	// entirely rather than report success against the wrong occurrence.
+	orig := []byte(`{
+  "hosts": {
+    "web": {
+      "command_policy": { "mode": "allowlist", "allow": [] },
+      "command_policy": { "mode": "allowlist", "allow": ["^rm -rf /$"] }
+    }
+  }
+}`)
+	patch := []byte(`[{"op":"remove","path":"/hosts/web/command_policy/allow/0"}]`)
+	if _, err := Patch(orig, patch); err == nil {
+		t.Error("Patch must refuse to edit a config with a duplicate key")
+	}
+}
+
 func TestPatchPreservesComments(t *testing.T) {
 	t.Parallel()
 	orig := []byte(`{


### PR DESCRIPTION
## Problem

`confcheck.Strict` / `parseConfig` decode standardized JSONC with `encoding/json`, where **duplicate object keys resolve last-wins** and are never rejected. The comment-preserving rewrite `confcheck.Patch` uses **hujson**, whose JSON-pointer resolver returns the **first** matching member. So for a `signer.json` where one host carries a key (e.g. `command_policy`) twice:

- the loader/runtime enforces the **last** occurrence;
- a `POST`/`DELETE /v1/policy/hosts/<host>/allow` edit (`editAllow` → `confcheck.Patch`) rewrites the **first** (shadowed) occurrence;
- `mutateAllow` re-validates the result last-wins (the effective value is unchanged, so it passes), `atomicWrite` persists it, and `handlePolicyAllow` returns `200` **and writes a `policy-changed` record to the signed audit log** — while the dangerous rule stays in effect.

Duplicate keys in a security config also loaded **silently**, a hole in the v2.0.0 fail-closed-on-bad-config posture (`Strict` pass 2 rejects unknown fields but not duplicate keys).

## Fix

`confcheck.Standardize` now rejects duplicate object keys (a stdlib `json.Decoder` token walk over the standardized bytes), so **every** loader path fails closed on a duplicate; `Patch` guards the rewrite path too. Net:

- a duplicate-key config **fails to load** → the signer refuses to start (and reload/policy-read reject it);
- the policy mutation API **refuses the edit** → returns an error and audits `policy-failed`, instead of a false `200` + `policy-changed`.

No false positives: the reserved `_default` data key in two different objects, and `_*` comment keys alongside real keys, still load (per-object key tracking). No config field / flag / endpoint / CLI surface changes, so no docgen drift.

## Tests
- `internal/confcheck`: `TestStandardizeRejectsDuplicateKeys` (top-level, nested security key, duplicate `command_policy`, array-element, `//`-comment variants + no-false-positive cases), `TestStrictRejectsDuplicateKeys`, `TestPatchRejectsDuplicateKeys`.
- `cmd/signer`: `TestEditAllowRejectsDuplicateKey` — the mutation path refuses a duplicated-`command_policy` host.

## Verification
`make verify` green: gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`.

Closes #216