### PR TITLE
fix(broker-ctl): doctor CA-custody check must flag local pem in any ca_keys group

### DIFF
--- a/cmd/broker-ctl/doctor.go
+++ b/cmd/broker-ctl/doctor.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/luisgf/infrabroker/internal/confcheck"
@@ -141,18 +142,25 @@ func checkSignerConfig(path string) []doctorFinding {
 		}
 	}
 
-	// CA custody.
-	caType := ""
-	if d, ok := sc.CAKeys["_default"]; ok {
-		caType = d.Type
-	} else if sc.CAKey != "" {
-		caType = "pem" // legacy ca_key is a local PEM path
+	// CA custody. internal/ca loads EVERY ca_keys group, not just _default, so a
+	// local `pem` key in ANY group — plus the legacy single ca_key — is a
+	// production smell, not only in the default. Flag every pem-backed group; a
+	// non-pem _default alongside a per-group pem override must not read as PASS.
+	var pemGroups []string
+	for name, d := range sc.CAKeys {
+		if d.Type == "pem" {
+			pemGroups = append(pemGroups, name)
+		}
 	}
-	switch caType {
-	case "":
+	if _, hasDefault := sc.CAKeys["_default"]; !hasDefault && sc.CAKey != "" {
+		pemGroups = append(pemGroups, "ca_key (legacy)")
+	}
+	sort.Strings(pemGroups)
+	switch {
+	case len(sc.CAKeys) == 0 && sc.CAKey == "":
 		add(docWARN, "CA custody configured", "no `ca_key`/`ca_keys` — the signer has no CA to sign with.")
-	case "pem":
-		add(docFAIL, "CA custody not local PEM", "CA custody is `pem` (a local key file). Use `akv` (Azure Key Vault) or `agent` (ssh-agent/hardware) in production; `pem` is lab-only.")
+	case len(pemGroups) > 0:
+		add(docFAIL, "CA custody not local PEM", fmt.Sprintf("CA custody is local `pem` (a key file on disk) for: %s. Use `akv` (Azure Key Vault) or `agent` (ssh-agent/hardware) in production; `pem` is lab-only.", strings.Join(pemGroups, ", ")))
 	default:
 		add(docPASS, "CA custody not local PEM", "")
 	}

--- a/cmd/broker-ctl/doctor_test.go
+++ b/cmd/broker-ctl/doctor_test.go
@@ -110,6 +110,42 @@ func TestCheckSignerConfig(t *testing.T) {
 	}
 }
 
+// TestCheckSignerConfigCAKeysPerGroupPem is the #218 guard: internal/ca loads
+// every ca_keys group, so a per-group local `pem` override must FAIL even when
+// _default uses a hardware/KMS backend — otherwise the preflight green-lights a
+// lab-only CA custody in production.
+func TestCheckSignerConfigCAKeysPerGroupPem(t *testing.T) {
+	t.Parallel()
+
+	// _default is akv (secure) but a "legacy" group is a local pem key on disk.
+	mixed := writeTmp(t, "mixed.json", `{
+		"callers": {"broker-1": {"allowed_groups": ["web"]}},
+		"ca_keys": {
+			"_default": {"type": "akv", "vault_url": "x", "key_name": "y"},
+			"legacy": {"type": "pem", "path": "pki/legacy_ca"}
+		},
+		"monitor_listen": "127.0.0.1:9160"
+	}`)
+	got := findByCheck(checkSignerConfig(mixed), "CA custody")
+	if got.level != docFAIL {
+		t.Errorf("a per-group pem override must FAIL, got %q", got.level)
+	}
+	if !strings.Contains(got.fix, "legacy") {
+		t.Errorf("the FAIL must name the offending group: %q", got.fix)
+	}
+
+	// Every group on a non-pem backend → PASS.
+	secure := writeTmp(t, "secure.json", `{
+		"ca_keys": {
+			"_default": {"type": "akv", "vault_url": "x", "key_name": "y"},
+			"ed25519": {"type": "agent", "public_key_path": "pki/ca.pub"}
+		}
+	}`)
+	if got := findByCheck(checkSignerConfig(secure), "CA custody"); got.level != docPASS {
+		t.Errorf("all-KMS/agent custody must PASS, got %q", got.level)
+	}
+}
+
 func TestCheckControlPlaneConfig(t *testing.T) {
 	t.Parallel()
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,12 @@
   while the occurrence the runtime actually enforces stayed untouched. A config
   with a duplicated key now fails to load (signer refuses to start) or edit
   (the mutation API returns an error and audits `policy-failed`).
+- **`doctor --security` flags local `pem` CA custody in any group (#218)** — the
+  preflight's CA-custody check previously inspected only `ca_keys._default` (or
+  the legacy `ca_key`), so a per-group `pem` override alongside a hardware/KMS
+  `_default` false-PASSed even though that group's hosts are signed by a local
+  key on disk. It now fails when any `ca_keys` group (or the legacy `ca_key`) uses
+  `pem`, naming the offending group.
 
 ### Added
 - **Kill-switch revocation-poll observability (#217)** — the broker now exports


### PR DESCRIPTION
## Problem

The `doctor --security` CA-custody preflight inspected **only** `ca_keys._default` (or the legacy `ca_key`), then PASSed *"CA custody not local PEM"* for any non-pem default. But `internal/ca` loads **every** `ca_keys` group, and mixing backends is documented (AKV can't hold Ed25519 → use `agent` or `pem` for that group). So a production `signer.json` like:

```json
"ca_keys": {
  "_default": {"type": "akv", ...},
  "legacy":   {"type": "pem", "path": "/etc/infrabroker/pki/legacy_ca"}
}
```

computed `caType = "akv"` → **PASS**, while the `legacy` group's hosts are in fact signed by a **local key on disk** — the lab-only custody this check exists to catch. The preflight green-lit the deploy.

## Fix

Scan every `ca_keys` entry (plus the legacy `ca_key`) and **FAIL** when any is `pem`, naming the offending group(s). All-`akv`/`agent` custody still PASSes; no CA configured still WARNs. Group names are sorted for deterministic output.

## Tests
`cmd/broker-ctl`: `TestCheckSignerConfigCAKeysPerGroupPem` — a per-group `pem` override alongside an `akv` `_default` FAILs and names the group; an all-`akv`/`agent` config PASSes. The existing legacy-`ca_key` FAIL case is unchanged.

## Verification
`make verify` green: gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`.

Closes #218