### PR TITLE
docs(readme): drop stale "audit fail-open" non-goal (v2.0.0 is fail-closed by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Full reference: [API.md](docs/API.md).
 The security posture — trust boundaries, the layered controls (RBAC, command
 policy, approval gate, guardrails, source-address/TTL pinning, chained audit),
 and the **explicit non-goals** (`mode=exec` sessions are broker-preflighted but
-not host-enforced, no KRL, secrets logged verbatim, audit fail-open, …) — is documented in
+not host-enforced, no KRL, secrets logged verbatim, …) — is documented in
 [THREAT_MODEL.md](docs/THREAT_MODEL.md).
 
 To report a vulnerability, see [SECURITY.md](docs/SECURITY.md). CI enforces `gofmt`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,12 @@
   key on disk. It now fails when any `ca_keys` group (or the legacy `ca_key`) uses
   `pem`, naming the offending group.
 
+### Fixed
+- **README no longer lists "audit fail-open" as a non-goal (#219)** — corrected a
+  stale Security-section statement that contradicted the v2.0.0 fail-closed-by-
+  default audit flip (#200); the linked `THREAT_MODEL.md` already documents
+  fail-open as an explicit opt-out.
+
 ### Added
 - **Kill-switch revocation-poll observability (#217)** — the broker now exports
   `broker_revocation_poll_errors_total` (failed freeze-set fetches) and


### PR DESCRIPTION
## Problem

The README Security section listed **"audit fail-open"** among the explicit non-goals:

> the **explicit non-goals** (`mode=exec` sessions are broker-preflighted but not host-enforced, no KRL, secrets logged verbatim, **audit fail-open**, …)

v2.0.0 flipped audit append to **fail-closed by default** (`audit_fail_mode: "closed"`, #200) as a breaking change. The very doc this sentence links to now says the opposite (`THREAT_MODEL.md` gap #9: *"Audit failure is fail-closed by default"*), both example configs ship `audit_fail_mode: "closed"`, and the CHANGELOG headlines it as breaking — so the front page asserted the reverse of a flagship v2.0.0 control.

## Fix

Remove the stale `audit fail-open,` item from the non-goals list. The neighboring non-goals (`mode=exec` not host-enforced, no KRL, secrets logged verbatim) remain accurate; fail-open is now an explicit opt-out documented in THREAT_MODEL.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #219