### PR TITLE
fix(config): harden atomic config rewrite — exclusive temp, explicit mode, fsync

### DIFF
--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -1292,18 +1292,46 @@ func jsonPtrEscape(s string) string {
 	return s
 }
 
-// writeConfigAtomic writes b to path via a temp file + rename, preserving the
-// existing file's permissions (0640 for a new file).
+// writeConfigAtomic writes b to path via a fresh temp file + rename, preserving
+// the existing file's permissions (0640 for a new file). The temp is created
+// exclusively with a random name (never a fixed path+".tmp"), so a stale or
+// planted <config>.tmp cannot have its wider mode adopted; the mode is set
+// explicitly and the file and its directory are fsync'd for crash durability.
 func writeConfigAtomic(path string, b []byte) error {
 	mode := os.FileMode(0o640)
 	if fi, err := os.Stat(path); err == nil {
 		mode = fi.Mode().Perm()
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, mode); err != nil {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }() // no-op once the rename succeeds
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	if d, err := os.Open(dir); err == nil { // best-effort: make the rename durable
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
 }
 
 // readSignerURL extracts the "listen" field from signer.json to build the HTTP URL.

--- a/cmd/broker-ctl/main_test.go
+++ b/cmd/broker-ctl/main_test.go
@@ -12,6 +12,36 @@ import (
 	"github.com/luisgf/infrabroker/internal/audit"
 )
 
+// TestWriteConfigAtomicPreservesModeNoLitter is the #220 guard: the atomic
+// rewrite keeps the config's existing permissions rather than adopting a
+// stale/planted temp's mode, and leaves no temp file behind.
+func TestWriteConfigAtomicPreservesModeNoLitter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broker-ctl.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	fi0, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := fi0.Mode().Perm()
+
+	if err := writeConfigAtomic(path, []byte(`{"b":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != `{"b":2}` {
+		t.Errorf("content = %q, want {\"b\":2}", got)
+	}
+	if fi, _ := os.Stat(path); fi.Mode().Perm() != want {
+		t.Errorf("permissions changed from %o to %o (must not widen)", want, fi.Mode().Perm())
+	}
+	if entries, _ := os.ReadDir(dir); len(entries) != 1 || entries[0].Name() != "broker-ctl.json" {
+		t.Errorf("expected only broker-ctl.json (no temp litter), got %v", entries)
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // testAuditKey returns a deterministic Ed25519 key (seed = 0x02 * 32).

--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -212,18 +213,47 @@ func editAllow(orig []byte, host, pattern string, add bool) ([]byte, error) {
 	return confcheck.Patch(orig, patch)
 }
 
-// atomicWrite writes b to path via a temp file + rename, preserving the existing
-// file's permissions.
+// atomicWrite writes b to path via a fresh temp file + rename, preserving the
+// existing file's permissions. The temp is created exclusively with a random
+// name (never a fixed path+".tmp"), so a stale or planted signer.json.tmp cannot
+// have its wider mode adopted over this secret; the mode is set explicitly, and
+// the file and its directory are fsync'd so a crash cannot leave a truncated or
+// non-durable config.
 func atomicWrite(path string, b []byte) error {
 	mode := os.FileMode(0o600)
 	if fi, err := os.Stat(path); err == nil {
 		mode = fi.Mode().Perm()
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, mode); err != nil {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }() // no-op once the rename succeeds
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	if d, err := os.Open(dir); err == nil { // best-effort: make the rename durable
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
 }
 
 // auditPolicy records a policy mutation attempt in the signed audit log.

--- a/cmd/signer/policy_test.go
+++ b/cmd/signer/policy_test.go
@@ -4,12 +4,46 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/signer"
 )
+
+// TestAtomicWritePreservesModeNoLitter is the #220 guard: the rewrite keeps the
+// config's existing (narrow) permissions rather than adopting a stale/planted
+// temp's mode, and leaves no temp file behind (a fresh O_EXCL temp, not a fixed
+// path+".tmp").
+func TestAtomicWritePreservesModeNoLitter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signer.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fi0, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := fi0.Mode().Perm()
+
+	if err := atomicWrite(path, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != `{"a":1}` {
+		t.Errorf("content = %q, want {\"a\":1}", got)
+	}
+	if fi, _ := os.Stat(path); fi.Mode().Perm() != want {
+		t.Errorf("permissions changed from %o to %o (must not widen)", want, fi.Mode().Perm())
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 || entries[0].Name() != "signer.json" {
+		t.Errorf("expected only signer.json (no temp litter), got %v", entries)
+	}
+}
 
 const policyFixture = `{
   "_comment": "top-level note",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Security
+- **Harden the atomic config rewrite (#220)** — the signer policy-mutation write
+  and `broker-ctl`'s config write now create the temp file exclusively with a
+  random name (never a fixed `<config>.tmp`), set its mode explicitly, and fsync
+  the file and its directory before/after the rename. Previously a stale or
+  planted `<config>.tmp` could have its wider permissions adopted over the
+  secret (`signer.json` holds CA-key/audit-key paths), and a crash mid-write
+  could truncate the config.
 - **Reject duplicate JSON keys in config files (#216)** — `confcheck` now fails
   closed when any config object carries the same key twice, instead of silently
   resolving it last-wins. Previously the typed loader (`encoding/json`, last-wins)


### PR DESCRIPTION
## Problem

The signer's `atomicWrite` (policy-mutation persistence) and `broker-ctl`'s `writeConfigAtomic` both wrote to a **fixed** `path + ".tmp"` via `os.WriteFile` (`O_CREATE|O_TRUNC`):

- If `signer.json.tmp` already existed — a crash leftover, or planted by anyone who can write the config dir — `os.WriteFile`'s `perm` arg is **ignored** and the pre-existing mode is kept, then `Rename` installs that mode over the secret. A `0644` stale temp silently **widens `signer.json`** (which holds CA-key/audit-key paths and the full policy) to world-readable.
- Neither `fsync`'d the temp before the rename nor the directory after, so a crash between write and durability can leave a **truncated/zero-length** config that then fails to parse.

## Fix

Both functions now:
- create the temp **exclusively with a random name** via `os.CreateTemp` (no fixed `<config>.tmp` to hijack);
- `Chmod` it to the preserved mode **explicitly** (never inherits a stale mode);
- `Sync` the file **before** the rename;
- best-effort `fsync` the **directory** after the rename.

A stale or planted `<config>.tmp` is now irrelevant, permissions can't widen, and a crash can't truncate the live config.

## Tests
- `cmd/signer`: `TestAtomicWritePreservesModeNoLitter`
- `cmd/broker-ctl`: `TestWriteConfigAtomicPreservesModeNoLitter`

Each asserts the rewrite preserves the file's prior (narrow) mode and leaves no temp file behind.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #220