### PR TITLE
fix(signer): GET /v1/revocations provenance is reload_callers-only

### DIFF
--- a/cmd/signer/freeze_http_test.go
+++ b/cmd/signer/freeze_http_test.go
@@ -142,15 +142,19 @@ func TestFreezeDeniesSignAndUnfreezeRestores(t *testing.T) {
 		t.Errorf("sign as brk2 must not be frozen-denied; body = %q", rec.Body.String())
 	}
 
-	// revocations lists brk1.
+	// revocations lists brk1; a non-admin broker (brk2) sees the subject but not
+	// the freezing admin's CN — provenance is reload_callers-only (#221).
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, grantRequest(http.MethodGet, "/v1/revocations", "brk2", nil))
 	var frozen []signer.FrozenEntry
 	if err := json.Unmarshal(rec.Body.Bytes(), &frozen); err != nil {
 		t.Fatalf("decode revocations: %v", err)
 	}
-	if len(frozen) != 1 || frozen[0].Kind != signer.FreezeCaller || frozen[0].Value != "brk1" || frozen[0].FrozenBy != "admin" {
-		t.Fatalf("revocations = %+v, want one caller=brk1 by admin", frozen)
+	if len(frozen) != 1 || frozen[0].Kind != signer.FreezeCaller || frozen[0].Value != "brk1" {
+		t.Fatalf("revocations = %+v, want one caller=brk1", frozen)
+	}
+	if frozen[0].FrozenBy != "" {
+		t.Errorf("a non-admin must not see frozen_by, got %q", frozen[0].FrozenBy)
 	}
 
 	// Unfreeze restores brk1 (freeze gate no longer fires).
@@ -161,6 +165,48 @@ func TestFreezeDeniesSignAndUnfreezeRestores(t *testing.T) {
 	}
 	if rec := signAs("brk1"); strings.Contains(rec.Body.String(), "subject is frozen") {
 		t.Errorf("brk1 must not be frozen-denied after unfreeze; body = %q", rec.Body.String())
+	}
+}
+
+// TestRevocationsProvenanceAdminOnly pins #221: GET /v1/revocations exposes the
+// free-text reason and the freezing admin's CN only to the reload_callers tier;
+// an ordinary broker sees the subject (kind+value) but not the provenance.
+func TestRevocationsProvenanceAdminOnly(t *testing.T) {
+	t.Parallel()
+	srv := freezeTestServer(t)
+	mux := freezeMux(srv)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin",
+		map[string]any{"kind": "caller", "value": "brk1", "reason": "compromised-key"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze: status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	get := func(cn string) signer.FrozenEntry {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, grantRequest(http.MethodGet, "/v1/revocations", cn, nil))
+		var f []signer.FrozenEntry
+		if err := json.Unmarshal(rec.Body.Bytes(), &f); err != nil {
+			t.Fatalf("decode revocations for %s: %v", cn, err)
+		}
+		if len(f) != 1 {
+			t.Fatalf("want 1 entry for %s, got %d", cn, len(f))
+		}
+		return f[0]
+	}
+
+	// admin (reload_callers) sees full provenance.
+	if a := get("admin"); a.Reason != "compromised-key" || a.FrozenBy != "admin" {
+		t.Errorf("admin must see provenance, got reason=%q frozen_by=%q", a.Reason, a.FrozenBy)
+	}
+	// A non-admin broker sees the subject but neither the reason nor the admin CN.
+	b := get("brk2")
+	if b.Kind != signer.FreezeCaller || b.Value != "brk1" {
+		t.Errorf("non-admin must still see the subject, got %+v", b)
+	}
+	if b.Reason != "" || b.FrozenBy != "" {
+		t.Errorf("non-admin must not see provenance, got reason=%q frozen_by=%q", b.Reason, b.FrozenBy)
 	}
 }
 

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -998,13 +998,28 @@ func (s *server) handleUnfreeze(w http.ResponseWriter, r *http.Request) {
 
 // handleRevocations serves GET /v1/revocations: the current freeze set, for
 // brokers to poll and kill matching live sessions. Any authenticated mTLS caller
-// may read it (operational data the broker needs), like GET /v1/hosts.
+// may read it (operational data the broker needs), but provenance is admin-only:
+// the free-text reason and the freezing admin's CN are dropped for ordinary
+// brokers, which need only the subject (kind+value) to match sessions. Only the
+// reload_callers tier — which can already freeze/unfreeze — sees the full record.
 func (s *server) handleRevocations(w http.ResponseWriter, r *http.Request) {
-	if _, err := auth.CallerCN(r); err != nil {
+	caller, err := auth.CallerCN(r)
+	if err != nil {
 		http.Error(w, "unauthenticated", http.StatusUnauthorized)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.freezes.List())
+	entries := s.freezes.List()
+	s.mu.RLock()
+	_, admin := s.reloadCN[caller]
+	s.mu.RUnlock()
+	if !admin {
+		redacted := make([]signer.FrozenEntry, len(entries))
+		for i, e := range entries {
+			redacted[i] = signer.FrozenEntry{FreezeSubject: e.FreezeSubject, FrozenAt: e.FrozenAt}
+		}
+		entries = redacted
+	}
+	writeJSON(w, http.StatusOK, entries)
 }
 
 // auditFreeze records a freeze/unfreeze in the audit log. subj.Value and reason

--- a/docs/API.md
+++ b/docs/API.md
@@ -464,7 +464,10 @@ kill its live sessions (#117). A **freeze subject** is a `{ "kind": ..., "value"
   broker needs, like `GET /v1/hosts`). Returns the current freeze set:
   `[{ "kind": "caller", "value": "broker-1", "reason": "...", "frozen_by":
   "admin", "frozen_at": "2026-07-09T06:00:00Z" }]`. Brokers poll it to force-close
-  matching live sessions.
+  matching live sessions. **Provenance is `reload_callers`-only**: the free-text
+  `reason` and the freezing admin's CN (`frozen_by`) are returned only to the
+  admin tier; an ordinary broker sees just `kind`, `value`, and `frozen_at`
+  (all it needs to match sessions).
 
 Enforcement points: a frozen subject is rejected at `POST /v1/sign` (audited
 `frozen_denied`) and `GET /v1/hosts`. The freeze set is persisted in `state_db`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Security
+- **`GET /v1/revocations` provenance is admin-only (#221)** — the free-text
+  freeze `reason` and the freezing admin's CN (`frozen_by`) are now returned only
+  to the `reload_callers` tier. An ordinary (or v2.0.0 default-denied) broker sees
+  just the subject (`kind`, `value`) and `frozen_at`, which is all it needs to
+  match and kill sessions — it no longer enumerates every operator note and admin
+  identity across the fleet.
 - **Harden the atomic config rewrite (#220)** — the signer policy-mutation write
   and `broker-ctl`'s config write now create the temp file exclusively with a
   random name (never a fixed `<config>.tmp`), set its mode explicitly, and fsync


### PR DESCRIPTION
## Problem

`handleRevocations` returned the **full** freeze set — including each entry's free-text `reason` and the freezing admin's CN (`frozen_by`) — to **any** authenticated mTLS caller. Its "like `GET /v1/hosts`" justification was imperfect: `/v1/hosts` is group-filtered, so a v2.0.0 default-denied broker sees nothing there, whereas `/v1/revocations` applied **no** filter.

So a broker CN absent from the `callers` table (signs nothing, sees no hosts, no clusters) could still `GET /v1/revocations` and enumerate every frozen subject, the operator's free-text reason (e.g. `"employee under investigation"`), and the freezing admin's CN across the whole fleet — exactly the information a default-denied caller shouldn't have.

## Fix

Return provenance (`reason`, `frozen_by`) only to the `reload_callers` admin tier — which can already freeze/unfreeze. An ordinary broker gets `kind` + `value` + `frozen_at`, which is all the poll needs to match and force-close sessions.

## Tests
- `TestRevocationsProvenanceAdminOnly` (new): after an admin freeze with a reason, the admin GET sees `reason` + `frozen_by`; a non-admin broker sees the subject but empty provenance.
- `TestFreezeDeniesSignAndUnfreezeRestores` (updated): the non-admin reader now asserts `frozen_by` is redacted.

`docs/API.md` updated to state provenance is `reload_callers`-only.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #221