### PR TITLE
fix(signer): persist approve-and-learn waiver only after the issued-audit gate

### DIFF
--- a/cmd/signer/audit_failclosed_test.go
+++ b/cmd/signer/audit_failclosed_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ed25519"
 	"errors"
 	"net/http"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/luisgf/infrabroker/internal/audit"
 	"github.com/luisgf/infrabroker/internal/monitor"
@@ -69,6 +72,51 @@ func TestAuditFailClosedModeParsing(t *testing.T) {
 		if err == nil && got != tc.wantClosed {
 			t.Errorf("mode %q: closed = %v, want %v", tc.mode, got, tc.wantClosed)
 		}
+	}
+}
+
+// issuingApprovedSigner is a localSigner stub that issues an SSH certificate for
+// an approval-gated command, to drive handleSign's issued path in tests.
+type issuingApprovedSigner struct{}
+
+func (issuingApprovedSigner) SignIntent(context.Context, signer.Intent) (*signer.Issued, error) {
+	return &signer.Issued{
+		Certificate: &ssh.Certificate{},
+		Serial:      7,
+		Decision:    &signer.DecisionInfo{Allowed: true, RequireApproval: true},
+	}, nil
+}
+func (issuingApprovedSigner) HostAllowlistActive(string) (bool, bool) { return true, true }
+func (issuingApprovedSigner) Clusters() signer.ClusterTable           { return nil }
+
+// TestSignIssuedGateFailClosedSkipsWaiver pins #222: when a forwarder-approved,
+// learn-requesting sign reaches the issued gate but the audit append fails in
+// fail-closed mode, the request is denied (500) AND no approve-and-learn waiver
+// is persisted. Under the pre-fix ordering the waiver was written through to the
+// grant store before the gate, leaving a durable approval-bypass for a request
+// whose issuance was withheld.
+func TestSignIssuedGateFailClosedSkipsWaiver(t *testing.T) {
+	t.Parallel()
+	srv := &server{
+		local:           issuingApprovedSigner{},
+		hosts:           signer.PolicyTable{"web01": {Addr: "10.0.0.1:22", User: "deploy", Principal: "host:web01"}},
+		forwarders:      map[string]struct{}{"fwd": {}},
+		audit:           brokenAuditLog(t),
+		auditFailClosed: true,
+		grants:          signer.NewGrantStore(),
+		freezes:         signer.NewFreezeStore(),
+	}
+	rec := httptest.NewRecorder()
+	srv.handleSign(rec, signRequestAs(t, "fwd", signer.WireRequest{
+		Host: "web01", Role: signer.RoleTarget, Purpose: signer.PurposeOneshot,
+		Command: "systemctl restart nginx", OnBehalfOf: "brk1",
+		Approved: true, LearnTTLSeconds: 600, LearnApprover: "alice", LearnApprovalID: "ap1",
+	}))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("issued gate with a broken log → status %d, want 500 (body %s)", rec.Code, rec.Body.String())
+	}
+	if n := len(srv.grants.List(time.Now())); n != 0 {
+		t.Errorf("a fail-closed issuance must persist no approve-and-learn waiver, found %d grants", n)
 	}
 }
 

--- a/cmd/signer/k8s.go
+++ b/cmd/signer/k8s.go
@@ -66,15 +66,23 @@ func (s *server) handleSignK8s(w http.ResponseWriter, r *http.Request, caller st
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
+	// Persist the token result FIRST; mint the approve-and-learn waiver only after
+	// respondSignK8s confirms the bound token was issued AND its "issued" record
+	// committed, so a fail-closed audit denial cannot leave a durable, restart-
+	// surviving waiver behind (#222, k8s sibling of the SSH path).
+	if !s.respondSignK8s(w, caller, req, issued) {
+		return
+	}
 	if isForwarder && req.LearnTTLSeconds > 0 {
 		s.maybeLearnWaiver(caller, req, issued)
 	}
-	s.respondSignK8s(w, caller, req, issued)
 }
 
 // respondSignK8s audits and writes the response for the three k8s cases:
-// dry-run, approval-required, and token issued.
-func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer.WireRequest, issued *signer.Issued) {
+// dry-run, approval-required, and token issued. It returns true only in the last
+// case AND only once the "issued" record has committed, so the caller can gate
+// the approve-and-learn waiver on an issuance that actually happened.
+func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer.WireRequest, issued *signer.Issued) bool {
 	if req.DryRun {
 		outcome := "dry_run_allowed"
 		if issued.Decision != nil && !issued.Decision.Allowed {
@@ -82,23 +90,23 @@ func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer
 		}
 		if aerr := s.auditK8s(caller, req, 0, outcome, issued.Decision, nil); aerr != nil {
 			writeAuditUnavailable(w)
-			return
+			return false
 		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
-		return
+		return false
 	}
 	if issued.K8sToken == "" {
 		if aerr := s.auditK8s(caller, req, 0, "approval-required", issued.Decision, nil); aerr != nil {
 			writeAuditUnavailable(w)
-			return
+			return false
 		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
-		return
+		return false
 	}
 	// Issuance gate: no durable "issued" record, no bound token in the response.
 	if aerr := s.auditK8s(caller, req, issued.Serial, "issued", issued.Decision, nil); aerr != nil {
 		writeAuditUnavailable(w)
-		return
+		return false
 	}
 	writeJSON(w, http.StatusOK, signer.WireResponse{
 		K8sToken:       issued.K8sToken,
@@ -106,6 +114,7 @@ func (s *server) respondSignK8s(w http.ResponseWriter, caller string, req signer
 		Serial:         issued.Serial,
 		Decision:       issued.Decision,
 	})
+	return true
 }
 
 // auditK8s records a k8s issuance decision. The api_server is the audited

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -695,27 +695,36 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
+	// Persist the certificate result FIRST: respondSignResult returns true only
+	// when a certificate was issued AND its "issued" record durably committed. The
+	// self-approval marker and the approve-and-learn waiver are state-changing (the
+	// waiver is written through to state_db and survives a restart), so they must
+	// run only after that gate — otherwise a request whose issuance is denied by
+	// fail-closed audit still leaves a durable approval-bypass behind (#222).
+	if !s.respondSignResult(w, caller, req, hosts, issued) {
+		return
+	}
 	// #118: record a self-approval distinctly — four-eyes was deliberately waived
 	// for this opted-in caller (the same human requested and approved in-chat).
-	// Only when the command actually required approval.
+	// Best-effort supplementary marker, ordered after the committed "issued" record.
 	if selfApproves && !isForwarder && req.Approved && issued.Decision != nil && issued.Decision.RequireApproval {
-		// Best-effort: a supplementary marker; the "issued" gate below is what
-		// fails the sign if the log is unwritable.
 		_ = s.appendAudit(audit.Entry{Caller: caller, Host: req.Host, Outcome: "self_approved"})
 	}
-	// Approve-and-learn: mint a TTL'd approval waiver after an approved sign that
-	// requested it. The waiver is scoped to the effective caller/end-user/elevation.
-	// Honoured only from a trusted forwarder (like Approved), so a broker can
+	// Approve-and-learn: mint a TTL'd approval waiver after an approved, issued
+	// sign that requested it. Scoped to the effective caller/end-user/elevation,
+	// honoured only from a trusted forwarder (like Approved), so a broker can
 	// neither self-approve nor self-learn.
 	if isForwarder && req.LearnTTLSeconds > 0 {
 		s.maybeLearnWaiver(caller, req, issued)
 	}
-	s.respondSignResult(w, caller, req, hosts, issued)
 }
 
 // respondSignResult audits the signing result and writes the HTTP response.
-// Covers three cases: dry-run, approval-required, and cert issued.
-func (s *server) respondSignResult(w http.ResponseWriter, caller string, req signer.WireRequest, hosts signer.PolicyTable, issued *signer.Issued) {
+// Covers three cases: dry-run, approval-required, and cert issued. It returns
+// true only in the last case AND only once the "issued" record has durably
+// committed, so the caller can gate state-changing follow-ups (the self-approval
+// marker and the approve-and-learn waiver) on an issuance that actually happened.
+func (s *server) respondSignResult(w http.ResponseWriter, caller string, req signer.WireRequest, hosts signer.PolicyTable, issued *signer.Issued) bool {
 	// Dry-run: no cert issued; only the decision is returned and audited.
 	if req.DryRun {
 		outcome := "dry_run_allowed"
@@ -724,10 +733,10 @@ func (s *server) respondSignResult(w http.ResponseWriter, caller string, req sig
 		}
 		if aerr := s.auditEmission(caller, req, hosts, 0, outcome, issued.Decision, nil); aerr != nil {
 			writeAuditUnavailable(w)
-			return
+			return false
 		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
-		return
+		return false
 	}
 
 	// No certificate but allowed: the operation requires human approval and has
@@ -736,10 +745,10 @@ func (s *server) respondSignResult(w http.ResponseWriter, caller string, req sig
 	if issued.Certificate == nil {
 		if aerr := s.auditEmission(caller, req, hosts, 0, "approval-required", issued.Decision, nil); aerr != nil {
 			writeAuditUnavailable(w)
-			return
+			return false
 		}
 		writeJSON(w, http.StatusOK, signer.WireResponse{Decision: issued.Decision})
-		return
+		return false
 	}
 
 	// Issuance gate: if the "issued" record cannot be persisted in fail-closed
@@ -747,7 +756,7 @@ func (s *server) respondSignResult(w http.ResponseWriter, caller string, req sig
 	// can proceed downstream.
 	if aerr := s.auditEmission(caller, req, hosts, issued.Serial, "issued", issued.Decision, nil); aerr != nil {
 		writeAuditUnavailable(w)
-		return
+		return false
 	}
 	writeJSON(w, http.StatusOK, signer.WireResponse{
 		Certificate:     string(ssh.MarshalAuthorizedKey(issued.Certificate)),
@@ -755,6 +764,7 @@ func (s *server) respondSignResult(w http.ResponseWriter, caller string, req sig
 		ElevationPrefix: issued.ElevationPrefix,
 		Decision:        issued.Decision,
 	})
+	return true
 }
 
 // handleHosts serves GET /v1/hosts: returns the connectivity data for the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Security
+- **Approve-and-learn waiver is persisted only after the issued-audit gate (#222)**
+  — on the SSH and Kubernetes sign paths the self-approval marker and the
+  approve-and-learn waiver (a state_db-persisted, restart-surviving approval
+  bypass) now run only after a certificate/token was issued *and* its `issued`
+  record durably committed. Previously they ran before the gate, so a request
+  whose issuance was withheld by fail-closed audit could still leave a durable
+  waiver behind with its creation record dropped.
 - **`GET /v1/revocations` provenance is admin-only (#221)** — the free-text
   freeze `reason` and the freezing admin's CN (`frozen_by`) are now returned only
   to the `reload_callers` tier. An ordinary (or v2.0.0 default-denied) broker sees


### PR DESCRIPTION
## Problem

On both the SSH (`handleSign`) and Kubernetes (`handleSignK8s`) sign paths, `maybeLearnWaiver` and the `self_approved` marker ran **before** `respondSignResult`/`respondSignK8s` reached the `"issued"` audit gate.

`maybeLearnWaiver` calls `grants.Add`, which is **write-through to `state_db`** — a restart-surviving approve-and-learn waiver (four-eyes bypass for a command). So under `audit_fail_mode: "closed"`:

1. a trusted-forwarder-approved sign of a `require_approval` command with `learn_ttl_seconds > 0` succeeds in memory and **persists the waiver**;
2. the `"issued"` audit append then fails → the request is correctly denied (`500`, cert/token withheld);
3. but the durable waiver **remains**, and its `approval-waiver-created` record was dropped (best-effort). When the log recovers, the retried command issues with no fresh approval and nothing in the trail explaining it.

## Fix

`respondSignResult`/`respondSignK8s` now return whether a credential was issued **and** its `"issued"` record durably committed. The `self_approved` marker and `maybeLearnWaiver` run only when that is `true` — so a fail-closed (audit-unavailable) issuance persists no state-changing approval bypass. No behaviour change on the happy path (the waiver is still learned after a committed issuance).

## Tests
`TestSignIssuedGateFailClosedSkipsWaiver` (new): a forwarder-approved, learn-requesting sign against a broken audit log returns `500` and leaves the grant store empty. Existing `learn_test.go` (direct `maybeLearnWaiver` guards) and the sign/k8s suites are unchanged and green.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #222