### PR TITLE
fix(broker-ctl): doctor redact check tests efficacy, not mere presence

### DIFF
--- a/cmd/broker-ctl/doctor.go
+++ b/cmd/broker-ctl/doctor.go
@@ -168,7 +168,7 @@ func checkSignerConfig(path string) []doctorFinding {
 	f = append(f,
 		rateLimitFinding(sc.SignRateLimitPerMin),
 		stateDBFinding(sc.StateDB, "signer"),
-		redactFinding(sc.Redact != nil, "signer.json"),
+		redactFinding(sc.Redact, "signer.json"),
 		monitorFinding(sc.MonitorListen, "signer"),
 	)
 	return f
@@ -180,7 +180,7 @@ func checkBrokerConfig(path string) []doctorFinding {
 		return []doctorFinding{{docFAIL, "config.json readable/parseable", fmt.Sprintf("could not read %s: %v", path, err)}}
 	}
 	return []doctorFinding{
-		redactFinding(bc.Redact != nil, "config.json"),
+		redactFinding(bc.Redact, "config.json"),
 		monitorFinding(bc.MonitorListen, "broker"),
 	}
 }
@@ -204,7 +204,7 @@ func checkControlPlaneConfig(path string) []doctorFinding {
 		f = append(f, doctorFinding{docPASS, "broker/approver separation (no approvers configured)", ""})
 	}
 	f = append(f, stateDBFinding(cp.StateDB, "control-plane"))
-	f = append(f, redactFinding(cp.Redact != nil, "control-plane.json"))
+	f = append(f, redactFinding(cp.Redact, "control-plane.json"))
 	f = append(f, monitorFinding(cp.MonitorListen, "control-plane"))
 	return f
 }
@@ -223,9 +223,24 @@ func stateDBFinding(path, svc string) doctorFinding {
 	return doctorFinding{docPASS, svc + " state_db set", ""}
 }
 
-func redactFinding(present bool, file string) doctorFinding {
-	if !present {
+// doctorRedact mirrors internal/redact.Config's two knobs so the preflight can
+// tell an effectively-enabled redactor from a present-but-no-op one.
+type doctorRedact struct {
+	DisableDefaults bool              `json:"disable_defaults"`
+	Patterns        []json.RawMessage `json:"patterns"`
+}
+
+func redactFinding(raw *json.RawMessage, file string) doctorFinding {
+	if raw == nil {
 		return doctorFinding{docWARN, file + " redact enabled", "no `redact` block — secrets in commands are stored verbatim in audit logs/recordings/notifications. Add `\"redact\": {}` for the built-in patterns."}
+	}
+	// A block that disables the built-in defaults and defines no patterns yields a
+	// zero-rule redactor (internal/redact.New): present but a no-op. Presence alone
+	// is not efficacy.
+	var rc doctorRedact
+	_ = json.Unmarshal(*raw, &rc)
+	if rc.DisableDefaults && len(rc.Patterns) == 0 {
+		return doctorFinding{docWARN, file + " redact enabled", "`redact` sets `disable_defaults` with no `patterns` — the redactor has zero rules and secrets are stored verbatim. Drop `disable_defaults` (to keep the built-ins) or add `patterns`."}
 	}
 	return doctorFinding{docPASS, file + " redact enabled", ""}
 }

--- a/cmd/broker-ctl/doctor_test.go
+++ b/cmd/broker-ctl/doctor_test.go
@@ -110,6 +110,40 @@ func TestCheckSignerConfig(t *testing.T) {
 	}
 }
 
+// TestRedactFindingEfficacy is the #223 guard: a redact block that disables the
+// built-in defaults and defines no patterns is a no-op redactor and must WARN,
+// not PASS on mere presence. Defaults on, or patterns present, PASS.
+func TestRedactFindingEfficacy(t *testing.T) {
+	t.Parallel()
+
+	// disable_defaults with no patterns → zero rules → WARN.
+	noop := writeTmp(t, "noop.json", `{
+		"ca_keys": {"_default": {"type": "akv", "vault_url": "x", "key_name": "y"}},
+		"redact": {"disable_defaults": true}
+	}`)
+	if got := findByCheck(checkSignerConfig(noop), "redact"); got.level != docWARN {
+		t.Errorf("a no-op redactor (disable_defaults, no patterns) must WARN, got %q", got.level)
+	}
+
+	// disable_defaults BUT with a pattern → effective → PASS.
+	custom := writeTmp(t, "custom.json", `{
+		"ca_keys": {"_default": {"type": "akv", "vault_url": "x", "key_name": "y"}},
+		"redact": {"disable_defaults": true, "patterns": [{"regex": "token=\\S+"}]}
+	}`)
+	if got := findByCheck(checkSignerConfig(custom), "redact"); got.level != docPASS {
+		t.Errorf("disable_defaults with a pattern is effective, must PASS, got %q", got.level)
+	}
+
+	// Empty block (built-in defaults on) → PASS.
+	defaults := writeTmp(t, "defaults.json", `{
+		"ca_keys": {"_default": {"type": "akv", "vault_url": "x", "key_name": "y"}},
+		"redact": {}
+	}`)
+	if got := findByCheck(checkSignerConfig(defaults), "redact"); got.level != docPASS {
+		t.Errorf("an empty redact block keeps the built-ins, must PASS, got %q", got.level)
+	}
+}
+
 // TestCheckSignerConfigCAKeysPerGroupPem is the #218 guard: internal/ca loads
 // every ca_keys group, so a per-group local `pem` override must FAIL even when
 // _default uses a hardware/KMS backend — otherwise the preflight green-lights a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Security
+- **`doctor --security` redact check tests efficacy, not presence (#223)** — a
+  `redact` block that sets `disable_defaults` with no `patterns` is a zero-rule
+  no-op (secrets stored verbatim), yet the preflight reported PASS for any
+  present block. It now WARNs on that no-op case and PASSes only when the
+  redactor actually has rules (built-in defaults on, or patterns defined).
 - **Approve-and-learn waiver is persisted only after the issued-audit gate (#222)**
   — on the SSH and Kubernetes sign paths the self-approval marker and the
   approve-and-learn waiver (a state_db-persisted, restart-surviving approval


### PR DESCRIPTION
## Problem

`redactFinding` reported **PASS** whenever a `redact` block was present (`Redact != nil`). But `internal/redact.New` adds the built-in rules only when defaults are **not** disabled:

```go
if cfg == nil || !cfg.DisableDefaults { /* add built-in rules */ }
pats = append(pats, cfg.Patterns...)
```

So a block of `{"disable_defaults": true}` with no `patterns` produces a **zero-rule, no-op redactor**, yet the doctor printed **PASS "redact enabled"** — while secrets are stored verbatim in audit logs / recordings / notifications, the precise risk the check advertises it prevents. Self-inflicted (an operator must set the escape-hatch flag), hence low severity.

## Fix

Decode the `redact` block and **WARN** when `disable_defaults` is set with no `patterns` (a no-op). **PASS** only when the redactor actually has rules (built-in defaults on, or patterns defined). A missing `redact` block still WARNs. Applies to all three services (signer / broker / control-plane).

## Tests
`TestRedactFindingEfficacy` (new): `disable_defaults` alone → WARN; `disable_defaults` + a pattern → PASS; empty block (defaults on) → PASS.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #223