### PR TITLE
fix(signer): grant creation refuses a frozen subject, serialised under writeMu

### DIFF
--- a/cmd/signer/grants.go
+++ b/cmd/signer/grants.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"regexp"
@@ -40,9 +41,10 @@ func (s *server) policyAdmin(r *http.Request) (caller string, authd, authz bool)
 // set of allow patterns that expire on their own. Auth is mTLS + reload_callers
 // (same "may change policy" tier as the mutation API). The grant is refused
 // unless the host is allowlist-active — on a default-allow/denylist host it would
-// be a no-op and, if applied, would invert the host to default-deny. Regexes are
-// validated by GrantStore.Add. Grants live in memory only (never persisted) and
-// every attempt is recorded in the signed audit log.
+// be a no-op and, if applied, would invert the host to default-deny — and refused
+// (409) for a subject that is currently frozen, under writeMu so it cannot race a
+// concurrent freeze. Regexes are validated by GrantStore.Add. Every attempt is
+// recorded in the signed audit log.
 func (s *server) handleGrantCreate(w http.ResponseWriter, r *http.Request) {
 	caller, authd, authz := s.policyAdmin(r)
 	if !authd {
@@ -82,6 +84,21 @@ func (s *server) handleGrantCreate(w http.ResponseWriter, r *http.Request) {
 	if !allowlist {
 		err := errors.New("host is not allowlist-active: a widen-only grant is a no-op here (it would invert the host to default-deny)")
 		s.auditGrant(caller, host, "", req.Allow, "grant-failed", err)
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+
+	// Serialise with freeze mutations (handleFreeze holds writeMu across
+	// freezes.Add + grants.RevokeForSubject) and refuse a grant for a subject that
+	// is currently frozen. Without this, a grant added concurrently with — or after
+	// — a freeze survives the freeze's revocation and reactivates the moment the
+	// subject is unfrozen (#224). A host-wide grant (no caller/end_user scope) is
+	// unaffected: Frozen("","") is false.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if subj, frozen := s.freezes.Frozen(req.Caller, req.EndUser); frozen {
+		err := fmt.Errorf("subject is frozen: %s=%s", subj.Kind, subj.Value)
+		s.auditGrant(caller, host, "", req.Allow, "grant-denied", err)
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}

--- a/cmd/signer/grants_http_test.go
+++ b/cmd/signer/grants_http_test.go
@@ -180,6 +180,39 @@ func TestGrantEndpointsEndToEnd(t *testing.T) {
 	}
 }
 
+// TestGrantCreateRefusesFrozenSubject pins #224: a grant scoped to a frozen
+// caller/end_user is refused (409) and never stored, so it cannot survive the
+// freeze's revocation and reactivate the moment the subject is unfrozen. A
+// non-frozen subject is unaffected.
+func TestGrantCreateRefusesFrozenSubject(t *testing.T) {
+	t.Parallel()
+	srv := grantTestServer(t, 0)
+	srv.freezes = signer.NewFreezeStore()
+	if _, err := srv.freezes.Add(signer.FreezeSubject{Kind: signer.FreezeCaller, Value: "brk1"}, "", "admin", time.Now()); err != nil {
+		t.Fatalf("freeze add: %v", err)
+	}
+	mux := grantMux(srv)
+
+	// A grant scoped to the frozen caller is refused (409) and not stored.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/policy/hosts/web01/grants", "admin",
+		map[string]any{"allow": []string{"^systemctl restart nginx$"}, "ttl_seconds": 600, "caller": "brk1"}))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("grant for a frozen caller → status %d, want 409 (body %s)", rec.Code, rec.Body.String())
+	}
+	if n := len(srv.grants.List(time.Now())); n != 0 {
+		t.Errorf("a refused grant must not be stored, found %d", n)
+	}
+
+	// A grant for a non-frozen subject still succeeds.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/policy/hosts/web01/grants", "admin",
+		map[string]any{"allow": []string{"^uptime -p$"}, "ttl_seconds": 600, "caller": "brk2"}))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("grant for a non-frozen caller → status %d, want 201 (body %s)", rec.Code, rec.Body.String())
+	}
+}
+
 func TestGrantEndpointAuthAndValidation(t *testing.T) {
 	t.Parallel()
 	srv := grantTestServer(t, time.Hour) // cap grant TTL at 1h

--- a/docs/API.md
+++ b/docs/API.md
@@ -364,7 +364,7 @@ curl --cert admin.crt --key admin.key --cacert signer-ca.crt \
 | `403 Forbidden` | Caller CN not in `reload_callers`. |
 | `400 Bad Request` | Empty `allow`, `ttl_seconds ≤ 0`, an invalid regex, or `ttl_seconds` above `max_grant_ttl_seconds`. |
 | `404 Not Found` | Unknown host. |
-| `409 Conflict` | Host is not allowlist-active (a widen-only grant would be a no-op / would invert it). |
+| `409 Conflict` | Host is not allowlist-active (a widen-only grant would be a no-op / would invert it), **or** the grant's `caller`/`end_user` scope is currently frozen (a grant cannot be created for a subject the kill switch has frozen). |
 
 #### List — `GET /v1/policy/grants`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Security
+- **Grant creation refuses a frozen subject and is serialised with freezes (#224)**
+  — `POST /v1/policy/hosts/{host}/grants` now takes the config write lock and
+  rejects (`409`) a grant scoped to a `caller`/`end_user` that is currently frozen.
+  Previously it took no lock and never consulted the freeze set, so a grant added
+  concurrently with — or after — a freeze survived the freeze's revocation and
+  reactivated the moment the subject was unfrozen.
 - **`doctor --security` redact check tests efficacy, not presence (#223)** — a
   `redact` block that sets `disable_defaults` with no `patterns` is a zero-rule
   no-op (secrets stored verbatim), yet the preflight reported PASS for any


### PR DESCRIPTION
## Problem

`handleFreeze` claims atomicity — *"serialise freeze mutations with the other config mutations so the freeze and its grant revocation apply as one step"* — and holds `s.writeMu` across `freezes.Add` + `grants.RevokeForSubject`. But `handleGrantCreate` took **no lock** and **never consulted the freeze set**.

So admin A freezing `caller=brk1` (which revokes brk1's grants) can race admin B creating a brk1-scoped grant: if B's `Add` lands after A's revoke iteration, a brk1 grant survives the freeze. It's inert while brk1 is frozen (the sign path denies frozen subjects before grant evaluation), but **reactivates the moment brk1 is unfrozen** (if still within TTL). Because grant-add never checked the freeze set, the same stale grant could even be created directly against an already-frozen subject.

## Fix

`handleGrantCreate` now takes `s.writeMu` for the mutation and rejects (`409`) a grant whose `caller`/`end_user` scope is currently frozen. A host-wide grant (no scope) is unaffected — `Frozen("","")` is false.

No lock-order inversion: `snapshot()` releases `s.mu` before `writeMu` is taken, so `handleGrantCreate` never nests `s.mu` inside `writeMu` (the order `mutateAllow` uses); `-race` tests pass.

## Tests
`TestGrantCreateRefusesFrozenSubject` (new): a grant for a frozen caller → `409`, not stored; a non-frozen subject → `201`.

`docs/API.md` grant status table updated with the frozen-subject `409`.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #224