### PR TITLE
fix(broker): make liveSession.close() idempotent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,11 @@
   `pem`, naming the offending group.
 
 ### Fixed
+- **`liveSession.close()` is now idempotent (#226)** — guarded with a `sync.Once`
+  so the concurrent teardown paths (kill switch, reaper, `closeAll`, and the
+  fail-closed `OpenSession` rollback) can never double-close a session's
+  conn/shell/recorder or race on the recorder field. Benign in the current build
+  (recording starts after the audit gate), but a latent data race otherwise.
 - **README no longer lists "audit fail-open" as a non-goal (#219)** — corrected a
   stale Security-section statement that contradicted the v2.0.0 fail-closed-by-
   default audit flip (#200); the linked `THREAT_MODEL.md` already documents

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -75,19 +75,28 @@ type liveSession struct {
 	// recorder captures stdin/stdout/stderr to an ASCIIcast v2 file.
 	// nil when session recording is disabled.
 	recorder *recording.Recorder
+	// closeOnce makes close() idempotent. Several teardown paths can reach the
+	// same session — the idle/lifetime reaper, the kill switch (killMatching),
+	// closeAll, and the fail-closed OpenSession rollback — and two of them can
+	// race (a revocation-poll kill landing while OpenSession rolls back). The
+	// conn/shell handles and the recorder field must be torn down exactly once,
+	// from one goroutine (#226).
+	closeOnce sync.Once
 }
 
 func (s *liveSession) close() {
-	if s.recorder != nil {
-		_ = s.recorder.Close()
-		s.recorder = nil
-	}
-	if s.shell != nil {
-		_ = s.shell.Close()
-	}
-	if s.conn != nil {
-		_ = s.conn.Close()
-	}
+	s.closeOnce.Do(func() {
+		if s.recorder != nil {
+			_ = s.recorder.Close()
+			s.recorder = nil
+		}
+		if s.shell != nil {
+			_ = s.shell.Close()
+		}
+		if s.conn != nil {
+			_ = s.conn.Close()
+		}
+	})
 }
 
 // sessionManager registers and recycles sessions by idle TTL / maximum lifetime.

--- a/internal/broker/session_test.go
+++ b/internal/broker/session_test.go
@@ -5,10 +5,12 @@ import (
 	"crypto/ed25519"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/recording"
 	"github.com/luisgf/infrabroker/internal/signer"
 )
 
@@ -317,6 +319,31 @@ func TestSessionManagerReaperCertExpiradoRespetaBusy(t *testing.T) {
 	m.reapExpired(time.Now())
 	if _, ok := peek(m, "s1"); ok {
 		t.Error("tras el checkin, la sesión con cert expirado debe recolectarse")
+	}
+}
+
+// TestLiveSessionCloseIdempotent pins #226: concurrent teardown paths (the kill
+// switch, the reaper, closeAll, the fail-closed OpenSession rollback) can reach
+// the same session, so close() must tear down conn/shell/recorder exactly once
+// and never race on the s.recorder field. Run under -race, an unguarded close()
+// reports a data race on s.recorder; the sync.Once guard makes it safe.
+func TestLiveSessionCloseIdempotent(t *testing.T) {
+	t.Parallel()
+	rec, err := recording.Open(filepath.Join(t.TempDir(), "rec.cast"), recording.Meta{})
+	if err != nil {
+		t.Fatalf("open recorder: %v", err)
+	}
+	s := &liveSession{recorder: rec}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); s.close() }()
+	}
+	wg.Wait()
+
+	if s.recorder != nil {
+		t.Error("close() must clear the recorder exactly once")
 	}
 }
 


### PR DESCRIPTION
## Problem

Several teardown paths reach the same `liveSession` — the idle/lifetime reaper, the kill switch (`killMatching`), `closeAll`, and the **fail-closed `OpenSession` rollback** (`e.sessions.remove(s.id); s.close()` after a failed `session_open` audit). Two can run concurrently: a revocation-poll kill landing in the `OpenSession` rollback window.

`close()` had no idempotency guard, so `s.conn.Close()` / `s.shell.Close()` could run twice from two goroutines, and the `if s.recorder != nil { … s.recorder = nil }` read/write could **race**. It's benign in the current build only because recording starts *after* the audit gate (so `s.recorder` is nil in that window) — a latent data race if that ordering ever changes.

## Fix

Guard the `close()` body with a `sync.Once` so conn/shell/recorder are torn down exactly once, from one goroutine, regardless of which teardown path wins.

## Tests
`TestLiveSessionCloseIdempotent` (new): 8 goroutines call `close()` concurrently on a session with a real recorder; under `-race` the unguarded version reports a data race on `s.recorder`, the guarded one is clean and closes exactly once.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #226