### PR TITLE
fix(bridge): render Slack approval fields as plain_text to stop approver phishing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Security
+- **Approval bridge renders Slack cards injection-free (#239)** — the Slack
+  approval notification put the broker-supplied command/host/caller into a
+  Markdown block, so a crafted `require_approval` command could inject a clickable
+  link (`<url|text>`) or break out of its code span and phish the human approver.
+  Those fields now render in a `plain_text` block (Slack mrkdwn has no backslash
+  escape, unlike the Teams Adaptive Card fix #174), so the approver always sees
+  the exact command with no injectable markup.
 - **Grant creation refuses a frozen subject and is serialised with freezes (#224)**
   — `POST /v1/policy/hosts/{host}/grants` now takes the config write lock and
   rejects (`409`) a grant scoped to a `caller`/`end_user` that is currently frozen.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -108,6 +108,10 @@ without it. A compromised broker or control plane cannot forge certificates.
   consumed-once and four-eyes guards are unchanged. For a single operator,
   #118's in-chat elicitation avoids the bridge entirely; for stronger
   attribution, approve via `broker-ctl` / the web UI (per-human mTLS certs).
+  The approver's chat card renders every broker-supplied field (command, host,
+  identities) as plain text, so a crafted command cannot inject a clickable link
+  or formatting into the approval prompt (#239 — the bridge analogue of the Teams
+  Adaptive Card escaping, #174).
 - **Audit log** is append-only, SHA-256 hash-chained, and Ed25519-signed per
   entry; any deletion/reordering/modification is detectable by replaying the
   chain. The chain stays continuous **across log rotation** — each rotated-to

--- a/internal/bridge/slack.go
+++ b/internal/bridge/slack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/socketmode"
@@ -53,25 +54,39 @@ func (a *SlackAdapter) Decisions() <-chan Decision { return a.decisions }
 // Post renders the approval as a Block Kit message with Approve / Deny buttons
 // whose value carries the request id.
 func (a *SlackAdapter) Post(ctx context.Context, ap control.Approval) error {
-	summary := fmt.Sprintf("*Approval requested* — run `%s` on `%s`", ap.Command, ap.Host)
-	detail := fmt.Sprintf("caller `%s`", ap.Caller)
+	_, _, err := a.api.PostMessageContext(ctx, a.channel, slack.MsgOptionBlocks(buildApprovalBlocks(ap)...))
+	return err
+}
+
+// buildApprovalBlocks renders the approval as Block Kit blocks: a static mrkdwn
+// header, then the broker-supplied fields (command, host, caller, end user, rule)
+// in a PLAIN-TEXT block, and the Approve/Deny buttons. The fields are rendered as
+// plain_text — not mrkdwn — so a crafted command/host/identity renders literally
+// and cannot inject a clickable link (`<url|text>`), a bare-URL auto-link, or
+// formatting into the approver's card (#239). Slack mrkdwn has no backslash escape
+// for `*`/`_`/backtick, so escaping (as the Teams Adaptive Card does, #174) is not
+// enough here — plain_text is the faithful, injection-free rendering, and it still
+// shows the approver the exact command.
+func buildApprovalBlocks(ap control.Approval) []slack.Block {
+	var b strings.Builder
+	fmt.Fprintf(&b, "run %s on %s\ncaller %s", ap.Command, ap.Host, ap.Caller)
 	if ap.EndUser != "" {
-		detail += fmt.Sprintf(" · user `%s`", ap.EndUser)
+		fmt.Fprintf(&b, " · user %s", ap.EndUser)
 	}
 	if ap.Sudo {
-		detail += " · sudo"
+		b.WriteString(" · sudo")
 	}
 	if ap.Rule != "" {
-		detail += fmt.Sprintf(" · rule `%s`", ap.Rule)
+		fmt.Fprintf(&b, " · rule %s", ap.Rule)
 	}
-	section := slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, summary+"\n"+detail, false, false), nil, nil)
+	header := slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "*Approval requested*", false, false), nil, nil)
+	body := slack.NewSectionBlock(slack.NewTextBlockObject(slack.PlainTextType, b.String(), false, false), nil, nil)
 	approve := slack.NewButtonBlockElement(actionApprove, ap.ID, slack.NewTextBlockObject(slack.PlainTextType, "Approve", false, false))
 	approve.Style = slack.StylePrimary
 	deny := slack.NewButtonBlockElement(actionDeny, ap.ID, slack.NewTextBlockObject(slack.PlainTextType, "Deny", false, false))
 	deny.Style = slack.StyleDanger
 	actions := slack.NewActionBlock("infrabroker_"+ap.ID, approve, deny)
-	_, _, err := a.api.PostMessageContext(ctx, a.channel, slack.MsgOptionBlocks(section, actions))
-	return err
+	return []slack.Block{header, body, actions}
 }
 
 // listen runs the Socket Mode loop, turning button clicks into Decisions. The

--- a/internal/bridge/slack_test.go
+++ b/internal/bridge/slack_test.go
@@ -1,0 +1,39 @@
+package bridge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+
+	"github.com/luisgf/infrabroker/internal/control"
+)
+
+// TestSlackApprovalRendersUntrustedFieldsAsPlainText pins #239: the broker-
+// supplied command/host/identity must render literally in a plain_text block,
+// never in a mrkdwn block where a crafted value could inject a clickable link
+// (<url|text>), a bare-URL auto-link, or formatting into the human approver's
+// card (approver phishing — the Slack sibling of the Teams #174 escaping).
+func TestSlackApprovalRendersUntrustedFieldsAsPlainText(t *testing.T) {
+	const inject = "x` <https://evil.example|Approve here> *urgent*"
+	ap := control.Approval{ID: "ap1", Caller: "brk1", Host: "web01", Command: inject}
+
+	blocks := buildApprovalBlocks(ap)
+
+	var plainText string
+	for _, blk := range blocks {
+		sb, ok := blk.(*slack.SectionBlock)
+		if !ok || sb.Text == nil {
+			continue
+		}
+		if sb.Text.Type == slack.MarkdownType && strings.Contains(sb.Text.Text, "evil.example") {
+			t.Errorf("untrusted command must not appear in a mrkdwn block (link-injectable): %q", sb.Text.Text)
+		}
+		if sb.Text.Type == slack.PlainTextType {
+			plainText += sb.Text.Text
+		}
+	}
+	if !strings.Contains(plainText, inject) {
+		t.Errorf("the command must render literally in a plain_text block; got %q", plainText)
+	}
+}


### PR DESCRIPTION
## Problem

`SlackAdapter.Post` (approval bridge, #120) interpolated the broker-supplied `command` / `host` / `caller` / `end_user` / `rule` into a `slack.MarkdownType` block with `verbatim=false`, wrapped in backtick code spans:

```go
summary := fmt.Sprintf("*Approval requested* — run `%s` on `%s`", ap.Command, ap.Host)
```

In Slack mrkdwn a backtick opens/closes a code span and `<url|text>` is link syntax (and with `verbatim=false`, bare URLs auto-link). So a `require_approval` command like `` x` <https://evil.example|Approve here> `` **breaks out of the code span and injects a clickable phishing link** into the human approver's card — defeating human-in-the-loop review. The Approve/Deny buttons are separate Block Kit elements so the *action* can't be forged, but the command the human reviews can be obscured and a link added.

This is the same class the project already fixed for Teams (#174, `teamsMarkdownEscaper`), but the Slack adapter never got the equivalent. It's distinct from #150 (redaction masks secrets; it does not escape markup).

## Fix

Slack mrkdwn has **no** backslash escape for `*` / `_` / backtick, so escaping (the Teams approach) isn't sufficient. Instead, render the broker-supplied fields in a **`plain_text`** block (with a static mrkdwn header only). `plain_text` does no mrkdwn processing and no URL auto-linking, so the approver sees the **exact** command with no injectable markup.

## Tests
`TestSlackApprovalRendersUntrustedFieldsAsPlainText` (new): a command containing a backtick, a `<url|text>` link, and `*bold*` renders literally in a `plain_text` block and never appears in a mrkdwn block.

`docs/THREAT_MODEL.md` bridge section notes the plain-text rendering guarantee.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #239