### PR TITLE
fix(broker-ctl): doctor must WARN when ca_keys has no resolvable default CA

### DIFF
--- a/cmd/broker-ctl/doctor.go
+++ b/cmd/broker-ctl/doctor.go
@@ -152,13 +152,18 @@ func checkSignerConfig(path string) []doctorFinding {
 			pemGroups = append(pemGroups, name)
 		}
 	}
-	if _, hasDefault := sc.CAKeys["_default"]; !hasDefault && sc.CAKey != "" {
+	_, hasDefault := sc.CAKeys["_default"]
+	if !hasDefault && sc.CAKey != "" {
 		pemGroups = append(pemGroups, "ca_key (legacy)")
 	}
 	sort.Strings(pemGroups)
 	switch {
-	case len(sc.CAKeys) == 0 && sc.CAKey == "":
-		add(docWARN, "CA custody configured", "no `ca_key`/`ca_keys` — the signer has no CA to sign with.")
+	case !hasDefault && sc.CAKey == "":
+		// No resolvable default CA — either nothing configured, or ca_keys groups
+		// with no `_default` and no legacy `ca_key`. LoadGroupCAs requires a
+		// default, so the signer refuses to start; flag it rather than PASS a
+		// config that cannot boot.
+		add(docWARN, "CA custody configured", "no default CA — set `ca_key` or `ca_keys._default` (the signer refuses to start without one).")
 	case len(pemGroups) > 0:
 		add(docFAIL, "CA custody not local PEM", fmt.Sprintf("CA custody is local `pem` (a key file on disk) for: %s. Use `akv` (Azure Key Vault) or `agent` (ssh-agent/hardware) in production; `pem` is lab-only.", strings.Join(pemGroups, ", ")))
 	default:

--- a/cmd/broker-ctl/doctor_test.go
+++ b/cmd/broker-ctl/doctor_test.go
@@ -144,6 +144,19 @@ func TestRedactFindingEfficacy(t *testing.T) {
 	}
 }
 
+// TestCheckSignerConfigCAKeysNoDefault pins #240: a ca_keys config with no
+// _default (and no legacy ca_key) has no resolvable default CA — the signer
+// refuses to start (LoadGroupCAs) — so the preflight must WARN, not PASS.
+func TestCheckSignerConfigCAKeysNoDefault(t *testing.T) {
+	t.Parallel()
+	noDefault := writeTmp(t, "nodefault.json", `{
+		"ca_keys": {"groupA": {"type": "akv", "vault_url": "x", "key_name": "y"}}
+	}`)
+	if got := findByCheck(checkSignerConfig(noDefault), "CA custody"); got.level != docWARN {
+		t.Errorf("ca_keys without a _default must WARN (no resolvable default CA), got %q", got.level)
+	}
+}
+
 // TestCheckSignerConfigCAKeysPerGroupPem is the #218 guard: internal/ca loads
 // every ca_keys group, so a per-group local `pem` override must FAIL even when
 // _default uses a hardware/KMS backend — otherwise the preflight green-lights a


### PR DESCRIPTION
## Problem

A regression from #218 (unreleased). The CA-custody switch's no-CA WARN case was `len(sc.CAKeys) == 0 && sc.CAKey == ""`, so a config with `ca_keys` **groups but no `_default`** and no legacy `ca_key`:

```json
{ "ca_keys": { "groupA": {"type": "akv", "vault_url": "x", "key_name": "y"} } }
```

fell through to the `default:` **PASS** branch. But `internal/ca` `LoadGroupCAs` requires a default (*"no default CA key configured: set ca_key or ca_keys._default"*) and the signer **refuses to start** on it. So `doctor --security` green-lit a config that cannot boot. Pre-#218, this input WARNed.

## Fix

Change the WARN case to `!hasDefault && sc.CAKey == ""` (where `hasDefault` is whether `ca_keys` has a `_default`). This subsumes the empty case, restores the WARN for a `_default`-less `ca_keys`, and keeps the #218 per-group-`pem` FAIL intact.

No security exposure (fail-closed at startup, no key widened) — a preflight-fidelity fix. No changelog entry: it corrects the still-unreleased #218 whose bullet already documents the CA-custody behavior.

## Tests
`TestCheckSignerConfigCAKeysNoDefault` (new): `ca_keys` without a `_default` → WARN. The existing `TestCheckSignerConfigCAKeysPerGroupPem` (per-group `pem` → FAIL) still passes.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #240