### PR TITLE
fix(ca): bound the ssh-agent CA signer's post-dial socket I/O

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Security
+- **Bound the ssh-agent CA signer's socket I/O (#241)** — the agent-backed CA
+  (`ca_keys.type=agent`) set a dial timeout but no deadline on the subsequent
+  agent-protocol round trips (list keys + sign), so a wedged or hostile agent
+  could block a sign request — and leak its handler goroutine — indefinitely. An
+  overall I/O deadline (`agentOpTimeout`, 10s) now bounds it, matching the AKV
+  backend's bounded call.
 - **Approval bridge renders Slack cards injection-free (#239)** — the Slack
   approval notification put the broker-supplied command/host/caller into a
   Markdown block, so a crafted `require_approval` command could inject a clickable

--- a/internal/ca/agent.go
+++ b/internal/ca/agent.go
@@ -15,6 +15,12 @@ import (
 // agentDialTimeout bounds each connection to the ssh-agent socket.
 const agentDialTimeout = 5 * time.Second
 
+// agentOpTimeout bounds the agent-protocol round trips (list keys + sign) after
+// the dial, so a wedged or hostile agent cannot block a sign request — and thus
+// its handler goroutine — indefinitely (the dial timeout alone does not cover
+// the I/O that follows it).
+const agentOpTimeout = 10 * time.Second
+
 // loadCAFromAgent returns a CA signer whose private key lives in a running
 // ssh-agent — e.g. a YubiKey PIV slot, a SoftHSM token, or a TPM, loaded with
 // `ssh-add -s <pkcs11.so>` (stock OpenSSH, no cgo in this process). The private
@@ -40,7 +46,7 @@ func loadCAFromAgent(cfg CAKeyConfig) (ssh.Signer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("agent CA: parsing public key %s: %w", cfg.PublicKeyPath, err)
 	}
-	s := &agentSigner{socket: socket, pub: pub}
+	s := &agentSigner{socket: socket, pub: pub, opTimeout: agentOpTimeout}
 	// Fail-fast: confirm the pinned key is present in the agent now, so a
 	// misconfiguration surfaces at startup rather than on the first sign.
 	if err := s.withSigner(func(ssh.Signer) error { return nil }); err != nil {
@@ -53,8 +59,9 @@ func loadCAFromAgent(cfg CAKeyConfig) (ssh.Signer, error) {
 // ssh-agent for every signature, so a dropped agent connection does not
 // permanently break signing on a long-running signer.
 type agentSigner struct {
-	socket string
-	pub    ssh.PublicKey
+	socket    string
+	pub       ssh.PublicKey
+	opTimeout time.Duration // deadline for the post-dial agent I/O (list + sign)
 }
 
 func (s *agentSigner) PublicKey() ssh.PublicKey { return s.pub }
@@ -91,6 +98,9 @@ func (s *agentSigner) withSigner(fn func(ssh.Signer) error) error {
 		return fmt.Errorf("agent CA: dialing ssh-agent at %s: %w", s.socket, err)
 	}
 	defer conn.Close()
+	// Bound the post-dial agent I/O (Signers + Sign); DialTimeout covers only the
+	// connect, so without a deadline a wedged agent blocks the sign forever.
+	_ = conn.SetDeadline(time.Now().Add(s.opTimeout))
 	signer, err := matchAgentSigner(agent.NewClient(conn), s.pub)
 	if err != nil {
 		return err

--- a/internal/ca/agent_test.go
+++ b/internal/ca/agent_test.go
@@ -96,6 +96,53 @@ func TestAgentCASignsCert(t *testing.T) {
 	}
 }
 
+// TestAgentCADeadlineBoundsWedgedAgent pins #241: a wedged agent — one that
+// accepts the connection but never speaks the agent protocol — must not block a
+// sign (and thus its handler goroutine) forever. The post-dial I/O is bounded by
+// the signer's opTimeout, so withSigner returns an error promptly instead of
+// hanging. Without the deadline this test would block until its own 3s guard.
+func TestAgentCADeadlineBoundsWedgedAgent(t *testing.T) {
+	t.Parallel()
+	// A short temp dir: the macOS unix-socket path limit (~104 bytes) is tight, and
+	// t.TempDir() embeds this long test name.
+	dir, err := os.MkdirTemp("", "ag")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		<-stop // hold the connection open, never responding
+	}()
+
+	caPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	sshCAPub, _ := ssh.NewPublicKey(caPub)
+	s := &agentSigner{socket: sock, pub: sshCAPub, opTimeout: 150 * time.Millisecond}
+
+	done := make(chan error, 1)
+	go func() { done <- s.withSigner(func(ssh.Signer) error { return nil }) }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("withSigner against a wedged agent must return an error, not succeed")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("withSigner blocked past the deadline on a wedged agent")
+	}
+}
+
 // TestAgentCAFailFast: LoadCA reports a misconfigured agent backend at startup.
 func TestAgentCAFailFast(t *testing.T) {
 	caPub, _, _ := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
## Problem

`agentSigner.withSigner` (the `ca_keys.type=agent` / ssh-agent CA custody path, #122) set `agentDialTimeout` on the **connect** but never a deadline on the agent-protocol round trips that follow — `matchAgentSigner`'s `Signers()` (list keys) and the `Sign()` call:

```go
conn, err := net.DialTimeout("unix", s.socket, agentDialTimeout) // dial only
...
signer, err := matchAgentSigner(agent.NewClient(conn), s.pub) // Signers(): no deadline
...
return fn(signer)                                             // Sign(): no deadline
```

A wedged or hostile ssh-agent on that unix socket could block a sign request **forever**. The signer's HTTP `WriteTimeout` (30s) only fails the client-facing write, not the handler goroutine, and `BuildAndSign`'s `ctx` is not plumbed into the agent I/O — so each such request **leaks a blocked goroutine**. Inconsistent with the AKV backend, which bounds its network call (10s). Availability only, and requires a wedged/hostile *local* agent (a trusted component) — low severity.

## Fix

Set `conn.SetDeadline(now + opTimeout)` right after the dial. `opTimeout` defaults to the new `agentOpTimeout` (10s); it's a per-signer field so a test can lower it (no global mutation → parallel-safe). `Signers()` / `Sign()` now fail fast instead of hanging.

## Tests
`TestAgentCADeadlineBoundsWedgedAgent` (new): a unix socket that accepts but never speaks the agent protocol; `withSigner` returns an error in ~150ms instead of blocking (guarded by a 3s ceiling). Without the deadline it would block to that ceiling.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #241