### PR TITLE
fix(audit): verify --all must ignore the audit-repair quarantine file

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,13 @@
   `pem`, naming the offending group.
 
 ### Fixed
+- **`audit verify --all` ignores the `audit repair` quarantine file (#245)** —
+  segment discovery globbed `<log>.*`, which also matched the quarantine file
+  `audit repair` leaves behind (`<log>.corrupt-<ts>`), so verifying a
+  correctly-repaired chain ran `Verify()` over the quarantined (malformed) bytes
+  and falsely reported the chain as broken. Discovery now recognises only true
+  rotation segments (a `<log>.<timestamp>` suffix), single-sourced with the
+  rotation format.
 - **Document that `state_db` persists the freeze set (#227)** — the signer
   `state_db` field doc (and the generated config reference) listed only grants and
   waivers, omitting the kill-switch freeze set it also persists — the persistence

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -47,6 +47,12 @@ const (
 // the disk from filling up and writes from failing silently.
 const AuditLogMaxSize int64 = 100 * 1024 * 1024 // 100 MiB
 
+// rotationTimeFormat is the timestamp suffix a rotated segment carries
+// (<log>.<rotationTimeFormat>). Single-sourced so segment DISCOVERY (verify.go)
+// recognises exactly what rotation WRITES — and nothing else (e.g. the
+// `audit repair` quarantine file <log>.corrupt-<ts>).
+const rotationTimeFormat = "20060102T150405Z"
+
 // Entry is an audit record. It never contains the key or the certificate, only
 // metadata (including the cert fingerprint and its serial).
 type Entry struct {
@@ -205,7 +211,7 @@ func (l *Log) maybeRotate() {
 	if err != nil || info.Size() < l.maxFileSize {
 		return
 	}
-	rotPath := l.path + "." + time.Now().UTC().Format("20060102T150405Z")
+	rotPath := l.path + "." + time.Now().UTC().Format(rotationTimeFormat)
 	// Close and drop the handle up front. From here l.f is either reassigned to
 	// a valid file or left nil — it is NEVER left pointing at the closed handle,
 	// so a reopen failure cannot silently turn every later Append into a write

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+	"time"
 )
 
 // Verify checks sequence monotonicity, the prev_hash chain and, when pub is
@@ -161,17 +163,27 @@ func VerifySegments(logPath string, pub ed25519.PublicKey, reportf func(string, 
 	return total, errs
 }
 
-// discoverSegments returns the rotated segments of logPath (matching
-// "<logPath>.*", sorted oldest→newest — the timestamp suffix 20060102T150405Z
-// sorts chronologically) followed by the active file. Active rotation in
-// maybeRotate names rotated files this way.
+// discoverSegments returns the rotated segments of logPath followed by the
+// active file, sorted oldest→newest (the timestamp suffix sorts chronologically).
+// Only true rotation segments are included: a name matches only if its suffix
+// after "<logPath>." parses as rotationTimeFormat — the exact format maybeRotate
+// writes. This deliberately excludes sibling files that share the "<logPath>."
+// glob prefix but are NOT segments, notably the `audit repair` quarantine file
+// (<logPath>.corrupt-<ts>), whose quarantined bytes are malformed by definition
+// and would otherwise make `verify --all` falsely report a repaired chain broken.
 func discoverSegments(logPath string) ([]string, error) {
 	matches, err := filepath.Glob(logPath + ".*")
 	if err != nil {
 		return nil, err
 	}
-	sort.Strings(matches)
-	files := matches
+	prefix := logPath + "."
+	var files []string
+	for _, m := range matches {
+		if _, perr := time.Parse(rotationTimeFormat, strings.TrimPrefix(m, prefix)); perr == nil {
+			files = append(files, m)
+		}
+	}
+	sort.Strings(files)
 	if _, err := os.Stat(logPath); err == nil {
 		files = append(files, logPath)
 	}

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -337,6 +337,39 @@ func TestVerifySegmentsBrokenLink(t *testing.T) {
 	}
 }
 
+// TestVerifySegmentsIgnoresQuarantineFile pins #245: `audit repair` leaves a
+// quarantine file named <log>.corrupt-<ts>, which shares the <log>.* glob prefix
+// but is NOT a rotation segment. discoverSegments must skip it, so `verify --all`
+// does not run Verify() over the (malformed by definition) quarantined bytes and
+// falsely report a correctly-repaired chain as broken.
+func TestVerifySegmentsIgnoresQuarantineFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	active := filepath.Join(dir, "audit.log")
+	rotated := active + ".20260101T000000Z"
+	last := writeSegment(t, rotated, 1, "", 3)
+	writeSegment(t, active, 4, last, 2)
+
+	// The quarantine file the repair command leaves behind: torn, malformed bytes.
+	quarantine := active + ".corrupt-20260101T010000Z"
+	if err := os.WriteFile(quarantine, []byte("{not valid json, torn record"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	segs, err := discoverSegments(active)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range segs {
+		if s == quarantine {
+			t.Errorf("the quarantine file must not be discovered as a segment: %v", segs)
+		}
+	}
+	if _, errs := VerifySegments(active, nil, discardReport); errs != 0 {
+		t.Fatalf("a valid chain beside a quarantine file must verify cleanly, errs=%d", errs)
+	}
+}
+
 // ── FileBounds ───────────────────────────────────────────────────────────────
 
 func TestFileBounds(t *testing.T) {


### PR DESCRIPTION
## Problem

`discoverSegments` (used by `broker-ctl audit verify --all`) enumerated rotated segments with a bare glob:

```go
matches, err := filepath.Glob(logPath + ".*")
```

Rotated segments are named `<log>.<20060102T150405Z>` (`log.go` `maybeRotate`), but `broker-ctl audit repair --apply` writes its quarantine file as **`<log>.corrupt-<ts>`**, which **also** matches `<log>.*` — with no filter. So `audit verify --all` ran `Verify()` over the quarantine file, whose contents are by definition the **torn/malformed** bytes that were quarantined, and reported the audit chain as **broken** even though the repaired chain is fully intact.

The repair command explicitly tells the operator to *keep* the quarantine file for forensics, so the recommended steady state after an incident is exactly the one that breaks `verify --all` — training operators to dismiss `verify` errors right when they matter most. (Fail-safe — a false positive, never hiding tampering — but it defeats the repair→verify recovery workflow.)

## Fix

Restrict `discoverSegments` to names whose suffix after `<log>.` parses as the rotation timestamp format, so the quarantine file (and any other sibling) is excluded. The format is single-sourced as `rotationTimeFormat` in `log.go`, shared by `maybeRotate` (writes) and `discoverSegments` (reads), so discovery recognises exactly what rotation writes and cannot drift.

## Tests
`TestVerifySegmentsIgnoresQuarantineFile` (new): a valid rotated+active chain with a `<log>.corrupt-<ts>` quarantine file beside it — the quarantine file is not discovered as a segment, and `VerifySegments` returns `errs == 0`. Existing `TestVerifySegments*` still pass.

## Verification
`make verify` green (gofmt, `go vet`, build, `go test -race ./...`, govulncheck, docs-gen drift gate, `mkdocs --strict`).

Closes #245