### PR TITLE
fix(signer): freeze the raw peer CN and gate /v1/clusters (#203)

### DIFF
--- a/cmd/signer/freeze_forwarder_test.go
+++ b/cmd/signer/freeze_forwarder_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// forwarderFreezeMux wires the endpoints whose freeze coverage #203 fixes: the
+// sign path plus the two read endpoints a frozen caller must not reach.
+func forwarderFreezeMux(s *server) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/freeze", s.handleFreeze)
+	mux.HandleFunc("/v1/sign", s.handleSign)
+	mux.HandleFunc("GET /v1/hosts", s.handleHosts)
+	mux.HandleFunc("GET /v1/clusters", s.handleClusters)
+	return mux
+}
+
+// TestFreezeForwarderCNBlocksOnBehalfOf pins #203: the freeze check must run on
+// the raw mTLS peer CN, so freezing a trusted forwarder denies /v1/sign and
+// /v1/hosts even though its requests always carry on_behalf_of. The pre-#203
+// check ran only on the resolved (on_behalf_of) caller, making a forwarder
+// freeze a no-op.
+func TestFreezeForwarderCNBlocksOnBehalfOf(t *testing.T) {
+	t.Parallel()
+	srv := freezeTestServer(t)
+	srv.forwarders = map[string]struct{}{"control-plane": {}}
+	srv.local = &captureLocalSigner{}
+	mux := forwarderFreezeMux(srv)
+
+	// A control BEFORE the freeze: the forwarder acting on behalf of broker-web is
+	// not frozen-denied (it fails later, on pubkey/host resolution, never here).
+	signOnBehalf := func() *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/sign", "control-plane", signer.WireRequest{
+			Host: "web01", Role: signer.RoleTarget, Purpose: signer.PurposeOneshot,
+			Command: "uptime", OnBehalfOf: "broker-web",
+		}))
+		return rec
+	}
+	hostsOnBehalf := func() *httptest.ResponseRecorder {
+		req := grantRequest(http.MethodGet, "/v1/hosts", "control-plane", nil)
+		req.Header.Set(signer.HeaderOnBehalfOf, "broker-web")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := signOnBehalf(); strings.Contains(rec.Body.String(), "subject is frozen") {
+		t.Fatalf("pre-freeze sign must not be frozen-denied; body = %q", rec.Body.String())
+	}
+
+	// Freeze the FORWARDER's own CN (the break-glass scenario: the control plane
+	// is compromised), not the downstream broker it acts for.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin",
+		map[string]any{"kind": "caller", "value": "control-plane"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze forwarder: status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	// Now both the sign and the hosts request carrying on_behalf_of are denied on
+	// the freeze gate, keyed on the raw forwarder CN.
+	if rec := signOnBehalf(); rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "frozen") {
+		t.Fatalf("sign as frozen forwarder (on_behalf_of): status = %d body = %q, want 403 + frozen", rec.Code, rec.Body.String())
+	}
+	if rec := hostsOnBehalf(); rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "frozen") {
+		t.Fatalf("hosts as frozen forwarder (on_behalf_of): status = %d body = %q, want 403 + frozen", rec.Code, rec.Body.String())
+	}
+}
+
+// TestFreezeDeniesClusters pins the /v1/clusters half of #203: a frozen caller
+// (directly, or a frozen forwarder acting via on_behalf_of) is denied the
+// cluster connectivity it previously could still enumerate.
+func TestFreezeDeniesClusters(t *testing.T) {
+	t.Parallel()
+	srv := freezeTestServer(t)
+	srv.forwarders = map[string]struct{}{"control-plane": {}}
+	srv.local = &captureLocalSigner{}
+	mux := forwarderFreezeMux(srv)
+
+	getClusters := func(cn, onBehalf string) *httptest.ResponseRecorder {
+		req := grantRequest(http.MethodGet, "/v1/clusters", cn, nil)
+		if onBehalf != "" {
+			req.Header.Set(signer.HeaderOnBehalfOf, onBehalf)
+		}
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Baseline: an unfrozen direct caller is not frozen-denied.
+	if rec := getClusters("brk1", ""); strings.Contains(rec.Body.String(), "subject is frozen") {
+		t.Fatalf("pre-freeze clusters must not be frozen-denied; body = %q", rec.Body.String())
+	}
+
+	// Freeze a direct caller.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin",
+		map[string]any{"kind": "caller", "value": "brk1"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze brk1: status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if rec := getClusters("brk1", ""); rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "frozen") {
+		t.Fatalf("clusters as frozen brk1: status = %d body = %q, want 403 + frozen", rec.Code, rec.Body.String())
+	}
+
+	// Freeze the forwarder CN too: a frozen forwarder acting via on_behalf_of is
+	// denied even though the resolved caller is not itself frozen.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, grantRequest(http.MethodPost, "/v1/freeze", "admin",
+		map[string]any{"kind": "caller", "value": "control-plane"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("freeze forwarder: status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if rec := getClusters("control-plane", "broker-web"); rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "frozen") {
+		t.Fatalf("clusters as frozen forwarder (on_behalf_of): status = %d body = %q, want 403 + frozen", rec.Code, rec.Body.String())
+	}
+}

--- a/cmd/signer/k8s.go
+++ b/cmd/signer/k8s.go
@@ -190,9 +190,19 @@ func (s *server) handleClusters(w http.ResponseWriter, r *http.Request) {
 	forwarders := s.forwarders
 	s.mu.RUnlock()
 
+	peerCN := caller
 	caller, ok := resolveCaller(caller, r.Header.Get(signer.HeaderOnBehalfOf), forwarders)
 	if !ok {
 		http.Error(w, "on_behalf_of not allowed for this caller", http.StatusForbidden)
+		return
+	}
+
+	// Kill switch (#203): a frozen caller learns no cluster connectivity, even
+	// though /v1/clusters mints no token (info-disclosure only — api_server,
+	// inlined CA PEM, groups). Tests the raw peer CN too, since a forwarder's
+	// traffic is always on_behalf_of.
+	if _, frozen := s.frozenSubject(peerCN, caller, ""); frozen {
+		http.Error(w, "subject is frozen", http.StatusForbidden)
 		return
 	}
 

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -514,6 +514,24 @@ func resolveCaller(mtlsCN, onBehalfOf string, forwarders map[string]struct{}) (c
 	return "", false
 }
 
+// frozenSubject reports the freeze that blocks a request, testing the resolved
+// caller and end user AND the raw mTLS peer CN (#203). The freeze check must run
+// on the peer CN because a trusted forwarder's traffic is always on_behalf_of:
+// checking only the resolved caller would make freezing the forwarder's own
+// identity — the break-glass reason the kill switch exists — a no-op. peerCN and
+// resolved coincide for a non-forwarder, so the second lookup is skipped then.
+func (s *server) frozenSubject(peerCN, resolved, endUser string) (signer.FreezeSubject, bool) {
+	if subj, frozen := s.freezes.Frozen(resolved, endUser); frozen {
+		return subj, true
+	}
+	if peerCN != resolved {
+		if subj, frozen := s.freezes.Frozen(peerCN, ""); frozen {
+			return subj, true
+		}
+	}
+	return signer.FreezeSubject{}, false
+}
+
 // reload re-reads the config file and, if valid, atomically replaces the
 // signer, the host policy, and the reload allowlist. On failure it leaves the
 // state unchanged and returns an error. Returns the number of loaded hosts.
@@ -607,7 +625,10 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	effectiveApproved := req.Approved && (isForwarder || selfApproves)
 
 	// Resolve the effective caller identity: a trusted forwarder (control plane)
-	// may act on behalf of the original broker via on_behalf_of.
+	// may act on behalf of the original broker via on_behalf_of. Capture the raw
+	// peer CN first so the freeze check below can also test the forwarder's own
+	// identity (#203).
+	peerCN := caller
 	caller, ok := resolveCaller(caller, req.OnBehalfOf, forwarders)
 	if !ok {
 		http.Error(w, "on_behalf_of not allowed for this caller", http.StatusForbidden)
@@ -627,8 +648,10 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 	// Kill switch (#117): a frozen caller CN or end user gets no new certificate.
 	// Checked before the ssh/k8s split so it covers one-shot, session open, and
 	// every session-exec preflight — all of which reach /v1/sign. caller and
-	// req.EndUser are both charset-checked above, so they are safe to audit.
-	if subj, frozen := s.freezes.Frozen(caller, req.EndUser); frozen {
+	// req.EndUser are both charset-checked above, so they are safe to audit; subj
+	// comes from the freeze set (added via a charset-validated /v1/freeze), so it
+	// is safe to audit even when the raw peer CN triggered the freeze (#203).
+	if subj, frozen := s.frozenSubject(peerCN, caller, req.EndUser); frozen {
 		signRequestsTotal.With("frozen-denied").Inc()
 		if aerr := s.appendAudit(audit.Entry{
 			Caller:  caller,
@@ -787,6 +810,7 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 
 	// A trusted forwarder can request the list on behalf of a broker
 	// (X-On-Behalf-Of header) so that group filtering matches the broker.
+	peerCN := caller
 	caller, ok := resolveCaller(caller, r.Header.Get(signer.HeaderOnBehalfOf), forwarders)
 	if !ok {
 		http.Error(w, "on_behalf_of not allowed for this caller", http.StatusForbidden)
@@ -794,9 +818,11 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Kill switch (#117): a frozen caller sees no connectivity, so it cannot even
-	// discover hosts to attempt. A match means caller equals a value that was
-	// charset-validated when it was frozen, so subj is safe to audit.
-	if subj, frozen := s.freezes.Frozen(caller, ""); frozen {
+	// discover hosts to attempt. Also test the raw peer CN so freezing a trusted
+	// forwarder (whose traffic is always on_behalf_of) blocks discovery (#203). A
+	// match means the value was charset-validated when frozen, so subj is safe to
+	// audit.
+	if subj, frozen := s.frozenSubject(peerCN, caller, ""); frozen {
 		// Best-effort: GET /v1/hosts is a read; a broken log must not turn host
 		// discovery into a 500 (only the sign path fails closed).
 		_ = s.appendAudit(audit.Entry{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Security
+- **Freeze coverage closes the forwarder and `/v1/clusters` gaps (#203)** — the
+  signer's freeze check ran only on the *resolved* caller, so a trusted forwarder
+  acting via `on_behalf_of` was never freeze-checked on its own mTLS CN — freezing
+  a compromised control plane was a near no-op. `/v1/sign` and `/v1/hosts` now also
+  test the raw peer CN, and `GET /v1/clusters` — previously unchecked — now denies
+  a frozen caller the cluster connectivity (api_server, inlined CA PEM, groups) it
+  could otherwise still enumerate.
 - **Kill switch interrupts a busy shell/PTY session promptly (#202)** — a session
   with an interactive command in flight closed its SSH shell *before* the
   transport, so teardown blocked on the shell mutex the running command held for


### PR DESCRIPTION
## What

The signer's freeze check ran on the **resolved** caller, so a trusted forwarder acting via `on_behalf_of` was never freeze-checked on its **own** mTLS CN — freezing a compromised forwarder/control-plane was a near no-op. Separately, `GET /v1/clusters` had **no freeze check at all**.

## Fix

- New `server.frozenSubject(peerCN, resolved, endUser)` tests the raw mTLS peer CN in addition to the resolved caller and end user. A forwarder's traffic is always `on_behalf_of`, so checking only the resolved caller made freezing its own identity — the break-glass reason the kill switch exists — a no-op.
- Wired into `/v1/sign` and `/v1/hosts`, and added to `handleClusters` (`/v1/clusters`), which minted no token but still leaked `api_server`, the inlined CA PEM, and groups to a frozen caller.

## Tests

- Freezing a trusted-forwarder CN denies `/v1/sign` and `/v1/hosts` even when the request carries `on_behalf_of`.
- A frozen caller (directly, and a frozen forwarder via `on_behalf_of`) is denied on `/v1/clusters`.

`make verify` green.

Closes #203