### PR TITLE
fix(k8s): audit dry-run decisions and stop leaking the API-server URL (#204)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Security
+- **k8s dry-runs are audited and transport errors hide the API server (#204)** —
+  the Kubernetes path had two gaps: a dry-run returned its policy decision without
+  any broker audit entry, so an agent could enumerate the whole k8s ActionPolicy
+  surface (allowed / approval-gated verbs, resources, namespaces) leaving no
+  trace; and a transport error wrapped the raw `*url.Error`, leaking the full
+  API-server address to the model. Dry-run decisions now audit
+  `dry_run_allowed`/`dry_run_denied` (like the SSH path), and a connection failure
+  returns only the method, REST path, and an address-free cause.
 - **Freeze coverage closes the forwarder and `/v1/clusters` gaps (#203)** — the
   signer's freeze check ran only on the *resolved* caller, so a trusted forwarder
   acting via `on_behalf_of` was never freeze-checked on its own mTLS CN — freezing

--- a/internal/broker/k8s.go
+++ b/internal/broker/k8s.go
@@ -124,6 +124,16 @@ func (e *Engine) K8sExecute(ctx context.Context, c Caller, cluster string, actio
 		return nil, err
 	}
 	if dryRun {
+		// Audit the dry-run decision so an agent cannot silently enumerate the whole
+		// k8s ActionPolicy surface (allowed / approval-gated verbs, resources,
+		// namespaces). Best-effort, mirroring the SSH dry-run path (engine.go):
+		// nothing ran and no token was minted, so there is no result to withhold.
+		// Outcome convention matches the signer's k8s dry-run audit (#204).
+		outcome := "dry_run_allowed"
+		if issued.Decision != nil && !issued.Decision.Allowed {
+			outcome = "dry_run_denied"
+		}
+		_ = e.auditK8s(c, cluster, canonical, 0, outcome, issued.Decision, nil)
 		return &K8sResult{DryRun: issued.Decision}, nil
 	}
 	if issued.K8sToken == "" {

--- a/internal/broker/k8s_dryrun_audit_test.go
+++ b/internal/broker/k8s_dryrun_audit_test.go
@@ -1,0 +1,57 @@
+package broker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// TestK8sExecuteDryRunAudits pins #204: a k8s dry-run must leave an audit trail
+// (dry_run_allowed / dry_run_denied), like the SSH dry-run path. Without it an
+// agent could enumerate the whole k8s ActionPolicy surface silently.
+func TestK8sExecuteDryRunAudits(t *testing.T) {
+	sgn := &fakeK8sSigner{allow: map[string]bool{"get pods prod/web-1": true}}
+	e, _ := newK8sEngine(t, sgn)
+	caller := Caller{ID: "alice", Groups: []string{"platform"}}
+
+	// Allowed dry-run: returns the decision, no token minted, no cluster call.
+	res, err := e.K8sExecute(context.Background(), caller, "prod-k8s",
+		signer.K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-1"},
+		nil, true /* dryRun */, K8sExecuteOpts{})
+	if err != nil {
+		t.Fatalf("allowed dry-run: %v", err)
+	}
+	if res.DryRun == nil || !res.DryRun.Allowed {
+		t.Fatalf("expected an allowed dry-run decision, got %+v", res.DryRun)
+	}
+
+	// Denied dry-run: a resource the policy does not allow still returns a
+	// decision (not an error) and must be audited too.
+	res, err = e.K8sExecute(context.Background(), caller, "prod-k8s",
+		signer.K8sAction{Verb: "get", Resource: "pods", Namespace: "prod", Name: "web-2"},
+		nil, true, K8sExecuteOpts{})
+	if err != nil {
+		t.Fatalf("denied dry-run should return a decision, not an error: %v", err)
+	}
+	if res.DryRun == nil || res.DryRun.Allowed {
+		t.Fatalf("expected a denied dry-run decision, got %+v", res.DryRun)
+	}
+
+	var sawAllowed, sawDenied bool
+	for _, l := range readAuditLog(t, e) {
+		if strings.Contains(l, "dry_run_allowed") {
+			sawAllowed = true
+		}
+		if strings.Contains(l, "dry_run_denied") {
+			sawDenied = true
+		}
+	}
+	if !sawAllowed {
+		t.Error("allowed k8s dry-run was not audited (dry_run_allowed missing)")
+	}
+	if !sawDenied {
+		t.Error("denied k8s dry-run was not audited (dry_run_denied missing)")
+	}
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -114,7 +115,11 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return "", 0, fmt.Errorf("k8s: %s %s: %w", method, path, err)
+		// Never wrap the raw error: a *url.Error (and the *net.OpError beneath it)
+		// embeds the request URL / dial address — the API-server host and port —
+		// which the broker must never surface to the model. Report only the
+		// method+path and a coarse, address-free cause (#204).
+		return "", 0, fmt.Errorf("k8s: %s %s: %s", method, path, transportErrorCause(err))
 	}
 	defer resp.Body.Close()
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
@@ -125,6 +130,25 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 		return "", resp.StatusCode, fmt.Errorf("k8s: %s %s: %s", method, path, statusMessage(rb, resp.StatusCode))
 	}
 	return string(rb), resp.StatusCode, nil
+}
+
+// transportErrorCause classifies an http.Client.Do error into an address-free
+// message. The underlying *url.Error / *net.OpError text carries the API-server
+// host and port, which must never reach the model (#204), so only the shape of
+// the failure is surfaced — enough to tell a connectivity problem from a policy
+// denial, without the address.
+func transportErrorCause(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "request canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "request timed out"
+	}
+	var uerr *url.Error
+	if errors.As(err, &uerr) && uerr.Timeout() {
+		return "request timed out"
+	}
+	return "could not reach the API server"
 }
 
 // statusMessage extracts the message from a Kubernetes Status error body.

--- a/internal/k8s/client_transport_test.go
+++ b/internal/k8s/client_transport_test.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDoHidesAPIServerAddressOnTransportError pins #204: a call against an
+// unreachable API server must return an error to the model that contains
+// neither the host nor the port. The transport-error branch used to wrap the
+// raw *url.Error, whose text is `METHOD "https://host:port/path": <cause>`.
+func TestDoHidesAPIServerAddressOnTransportError(t *testing.T) {
+	t.Parallel()
+	const host = "k8s-secret-host.invalid" // RFC 6761: never resolves
+	const port = "6443"
+
+	// newFakeAPI only supplies a parseable CA PEM; the client points elsewhere.
+	f := newFakeAPI(t)
+	c, err := NewClient(Target{APIServer: "https://" + host + ":" + port, CAPEM: f.caPEM}, "tok", time.Second)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = c.Get(context.Background(), mustDef(t, "pods"), "default", "web-1")
+	if err == nil {
+		t.Fatal("expected a transport error against an unreachable API server")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, host) {
+		t.Errorf("error leaks the API-server host: %q", msg)
+	}
+	if strings.Contains(msg, port) {
+		t.Errorf("error leaks the API-server port: %q", msg)
+	}
+	// The method and the address-free REST path are still surfaced, so the model
+	// can tell what failed without learning where the API server lives.
+	if !strings.Contains(msg, "GET") || !strings.Contains(msg, "/api/v1/namespaces/default/pods/web-1") {
+		t.Errorf("error should still name the method and REST path: %q", msg)
+	}
+}


### PR DESCRIPTION
## What

Two independent gaps on the Kubernetes broker path:

1. **Dry-run decisions were not audited.** `K8sExecute` returned on `dryRun` with no `auditK8s` call, so an agent could enumerate the whole k8s ActionPolicy surface (allowed / approval-gated verbs, resources, namespaces) leaving **no trace** in the broker audit log.
2. **The API-server URL leaked to the model on transport errors.** The transport-error branch wrapped the raw `*url.Error` (whose text is `METHOD "https://host:port/path": <cause>`), violating the invariant that the broker never exposes the API-server address to the model.

## Fix

- Audit `dry_run_allowed`/`dry_run_denied` before the `if dryRun` return — best-effort, mirroring the SSH dry-run path; outcome convention matches the signer's k8s dry-run audit.
- On the transport-error branch, return only the method, REST path, and an **address-free** cause (`transportErrorCause`). The non-2xx branch was already clean (uses `path` + the API Status message).

## Tests

- A k8s dry-run (allowed and denied) produces an audit entry.
- A call against an unreachable API server returns an error containing **neither the host nor the port**, while still naming the method and REST path.

`make verify` green.

Closes #204