### PR TITLE
fix(signer): warn on allow-all callers and ignore self_approve on _default (#207)

### DIFF
--- a/cmd/signer/callers_warn_test.go
+++ b/cmd/signer/callers_warn_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// TestBuildStateWarnsOnEmptyCallers pins #207: an empty callers table is the one
+// genuine fail-open RBAC config (allow-all), so the signer warns at boot. buildState
+// fails later (no CA configured) but the warning is emitted before that, which is
+// all we assert. Not parallel: it swaps the global log output.
+func TestBuildStateWarnsOnEmptyCallers(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	// Empty callers table → allow-all warning.
+	_, _ = buildState(context.Background(), &Config{}, nil)
+	if !strings.Contains(buf.String(), "allow-all") {
+		t.Errorf("empty callers table must log an allow-all warning; log was:\n%s", buf.String())
+	}
+
+	// A non-empty callers table must NOT warn allow-all.
+	buf.Reset()
+	_, _ = buildState(context.Background(), &Config{Callers: signer.CallerTable{"brk": {}}}, nil)
+	if strings.Contains(buf.String(), "allow-all") {
+		t.Errorf("a non-empty callers table must not log allow-all; log was:\n%s", buf.String())
+	}
+}

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -378,11 +378,15 @@ func buildState(ctx context.Context, cfg *Config, grants signer.GrantProvider) (
 	if cfg.MaxTTLSeconds > 900 {
 		return nil, fmt.Errorf("max_ttl_seconds %d exceeds the 900s (15m) certificate cap", cfg.MaxTTLSeconds)
 	}
-	// Production-hardening nudge (broker-ctl doctor --security checks the full
-	// deploy/README checklist). A non-empty callers table is default-deny for
-	// unlisted CNs since v2.0.0, so no _default nudge is needed here.
+	// Production-hardening nudges (broker-ctl doctor --security checks the full
+	// deploy/README checklist). An empty callers table is the one genuine
+	// fail-open RBAC config (allow-all), so it is warned below; a non-empty table
+	// is default-deny for unlisted CNs since v2.0.0, so no _default nudge is needed.
 	if cfg.SignRateLimitPerMin <= 0 {
 		log.Printf("warning: sign_rate_limit_per_min is not set — no per-caller signing cap (see: broker-ctl doctor --security)")
+	}
+	if len(cfg.Callers) == 0 {
+		log.Printf("warning: callers table is empty — RBAC is allow-all: every authenticated mTLS client CN is unrestricted (see: broker-ctl doctor --security)")
 	}
 	// Compile + validate the host policies before touching anything so an invalid
 	// reload (bad command_policy regex, unknown mode, dangling jump, unknown group

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Security
+- **Secure-by-default: warn on allow-all RBAC and ignore `self_approve` on
+  `_default` (#207)** — two config foot-guns. An empty `callers` table means
+  allow-all (the one genuine fail-open RBAC config) but only the opt-in
+  `broker-ctl doctor --security` flagged it; the signer now logs a clear allow-all
+  warning at boot. And `callers._default.self_approve: true` used to waive
+  four-eyes for *every* unlisted CN through `_default` inheritance —
+  `self_approve` is now honoured only on an explicit CN.
 - **Session recording is observable, can be strict, and the recorder race is
   fixed (#206)** — interactive-session recording write failures were silently
   discarded with no signal, so recording (a potential compliance control) could

--- a/internal/mcpserver/approval_test.go
+++ b/internal/mcpserver/approval_test.go
@@ -142,11 +142,15 @@ func TestCallerTableMaySelfApprove(t *testing.T) {
 		t.Error("broker-2 did not opt in")
 	}
 	if tbl.MaySelfApprove("unknown") {
-		t.Error("unknown caller must not self-approve without a _default opt-in")
+		t.Error("unknown caller must not self-approve without an explicit opt-in")
 	}
-	// A _default opt-in applies to unlisted callers.
+	// self_approve on _default is IGNORED (#207): a single _default entry must not
+	// waive four-eyes for every unlisted caller. Explicit CNs keep their opt-in.
 	tbl["_default"] = signer.CallerPolicy{SelfApprove: true}
-	if !tbl.MaySelfApprove("unknown") {
-		t.Error("_default self-approve should apply to unlisted callers")
+	if tbl.MaySelfApprove("unknown") {
+		t.Error("_default self_approve must NOT let an unlisted caller self-approve")
+	}
+	if !tbl.MaySelfApprove("broker-1") {
+		t.Error("an explicit self_approve CN must still self-approve alongside _default")
 	}
 }

--- a/internal/signer/selfapprove_test.go
+++ b/internal/signer/selfapprove_test.go
@@ -1,0 +1,39 @@
+package signer
+
+import "testing"
+
+// TestMaySelfApproveIgnoresDefault pins #207: self_approve is honoured only on an
+// explicit CN, never inherited from the _default entry — otherwise a single
+// _default entry would waive four-eyes for every unlisted caller.
+func TestMaySelfApproveIgnoresDefault(t *testing.T) {
+	t.Parallel()
+
+	// self_approve set only on _default: no unlisted CN, and not the literal
+	// "_default" CN, may self-approve.
+	onlyDefault := CallerTable{DefaultCallerKey: {SelfApprove: true}}
+	if onlyDefault.MaySelfApprove("some-broker") {
+		t.Error("an unlisted CN must not inherit self_approve from _default")
+	}
+	if onlyDefault.MaySelfApprove(DefaultCallerKey) {
+		t.Error("the literal _default CN must not self-approve")
+	}
+
+	// An explicit CN with self_approve still works; _default does not widen it to
+	// other callers.
+	mixed := CallerTable{
+		"stdio-broker":   {SelfApprove: true},
+		DefaultCallerKey: {SelfApprove: true},
+	}
+	if !mixed.MaySelfApprove("stdio-broker") {
+		t.Error("an explicit CN with self_approve must self-approve")
+	}
+	if mixed.MaySelfApprove("other-broker") {
+		t.Error("an unlisted CN must not self-approve even when _default sets self_approve")
+	}
+
+	// A listed CN without self_approve does not self-approve.
+	listed := CallerTable{"broker": {AllowedGroups: []string{"g"}}}
+	if listed.MaySelfApprove("broker") {
+		t.Error("a listed CN without self_approve must not self-approve")
+	}
+}

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -795,18 +795,26 @@ type CallerPolicy struct {
 	// (#118, in-conversation approvals via MCP elicitation). It deliberately
 	// waives four-eyes for that CN — the operator opts in a specific stdio broker
 	// where the requesting human and the approving human are the same person.
-	// Off by default; every other CN keeps "a broker cannot self-approve".
+	// Off by default; every other CN keeps "a broker cannot self-approve". Set on
+	// the _default entry it is IGNORED (it must name an explicit CN), so it cannot
+	// waive four-eyes for every unlisted caller at once — see MaySelfApprove (#207).
 	SelfApprove bool `json:"self_approve,omitempty"`
 }
 
 // MaySelfApprove reports whether the caller CN may approve its own
 // require_approval commands (#118). Used to widen the signer's Approved gate,
 // which otherwise honours `approved` only from trusted_forwarders.
+//
+// self_approve is honoured ONLY on an explicit CN, never inherited from the
+// _default entry: _default applies to every unlisted CN, so honouring
+// self_approve there would waive four-eyes for every caller — the opposite of
+// opting in one specific stdio broker (#207). A certificate whose CN is literally
+// "_default" is treated as unlisted here too.
 func (t CallerTable) MaySelfApprove(cn string) bool {
-	if cp, ok := t[cn]; ok {
-		return cp.SelfApprove
+	if cn == DefaultCallerKey {
+		return false
 	}
-	if cp, ok := t[DefaultCallerKey]; ok {
+	if cp, ok := t[cn]; ok {
 		return cp.SelfApprove
 	}
 	return false


### PR DESCRIPTION
## What

Two `secure-by-default` config foot-guns around the `callers` RBAC table:

1. `callers: {}` (empty) means **allow-all** — the one genuine fail-open RBAC config — but only the opt-in `broker-ctl doctor --security` flagged it.
2. `callers._default.self_approve: true` waived four-eyes for **every** unlisted CN via `_default` inheritance — the opposite of the "only a specific opted-in stdio broker" intent.

## Fix

- `buildState` now logs a clear **allow-all warning** at boot (and on any reload that leaves the table empty), alongside the existing rate-limit nudge.
- `CallerTable.MaySelfApprove` now honours `self_approve` **only on an explicit CN**, never inherited from `_default` (a literal `_default` CN is treated as unlisted too).

## Tests

- Empty callers table logs the allow-all warning; a non-empty table does not.
- `self_approve` set only on `_default` does not let unlisted CNs self-approve; an explicit `self_approve` CN still can. (Updated the existing mcpserver test that asserted the old `_default` inheritance.)

`make verify` green.

Closes #207