### PR TITLE
perf(broker): coalesce the per-connection host-table refetch (#208)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Performance
+- **Coalesce the per-connection host-table refetch (remote mode) (#208)** — every
+  one-shot `Execute`/`OpenSession` in remote mode did a synchronous `GET /v1/hosts`
+  and reparsed the whole host table before signing, so a single `ssh_execute` to a
+  direct host cost **two** signer round-trips on top of the per-hop `POST /v1/sign`.
+  The refetch is now coalesced with a short freshness TTL (~3s); the 5-minute
+  background poller keeps the table fresh and `/v1/sign` is the authoritative gate,
+  so under sustained load `Execute` issues one signer round-trip in the common
+  case. Session-exec preflight still refetches uncoalesced, so a host-connectivity
+  change is caught promptly.
+
 ### Security
 - **Secure-by-default: warn on allow-all RBAC and ignore `self_approve` on
   `_default` (#207)** — two config foot-guns. An empty `callers` table means

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -363,6 +363,13 @@ type Engine struct {
 
 	mu    sync.RWMutex
 	hosts map[string]signer.HostInfo // cache refreshed periodically (remote mode)
+	// lastHostRefresh is when hosts was last loaded from the signer (initial load,
+	// background poller, or a per-connection refetch). refreshHostsForNewConnection
+	// uses it to coalesce the hot-path refetch: within hostRefreshCoalesce of a
+	// load the poller has already kept the table fresh, so Execute makes only the
+	// authoritative /v1/sign call, not a redundant /v1/hosts round-trip too (#208).
+	// Guarded by mu.
+	lastHostRefresh time.Time
 	// clusters is the k8s cluster connectivity cache, refreshed alongside hosts
 	// (remote mode). Empty when no k8s target is configured.
 	clusters map[string]signer.ClusterInfo
@@ -566,6 +573,7 @@ func (e *Engine) initRemoteMode(fetcher hostFetcher) error {
 		return fmt.Errorf("initial host load from signer: %w", err)
 	}
 	e.hosts = h
+	e.lastHostRefresh = time.Now()
 	log.Printf("hosts loaded from signer: %d entries", len(h))
 
 	// Optional k8s target: load the cluster list too. A signer with no clusters
@@ -669,6 +677,7 @@ func (e *Engine) startHostRefresh(interval time.Duration) {
 				}
 				e.mu.Lock()
 				e.hosts = h
+				e.lastHostRefresh = time.Now()
 				e.mu.Unlock()
 				log.Printf("hosts reloaded from signer: %d entries", len(h))
 				if e.clusterFetcher != nil {
@@ -890,6 +899,7 @@ func (e *Engine) refreshHostsNow(ctx context.Context) error {
 	}
 	e.mu.Lock()
 	e.hosts = h
+	e.lastHostRefresh = time.Now()
 	e.mu.Unlock()
 	return nil
 }
@@ -904,7 +914,30 @@ func (e *Engine) currentConnectivitySignature(ctx context.Context, host string) 
 	return e.connectivitySignature(host)
 }
 
+// hostRefreshCoalesce bounds how stale the cached host view may be before a new
+// connection forces a synchronous refetch. The 5-minute background poller keeps
+// the table fresh and /v1/sign is the authoritative gate, so a per-request
+// refetch only needs to catch a very recent host change — coalescing it removes
+// the redundant second signer round-trip on the hot path (#208).
+const hostRefreshCoalesce = 3 * time.Second
+
+// refreshHostsForNewConnection refreshes the remote host view before opening a
+// connection, coalescing so a burst of one-shot Execute/OpenSession calls does
+// not each pay a full /v1/hosts round-trip on top of /v1/sign. It refetches only
+// when the cache has not been refreshed within hostRefreshCoalesce; the
+// background poller and the authoritative /v1/sign gate cover the rest. A no-op
+// in local mode. Session-exec preflight keeps using refreshHostsNow, which is
+// never coalesced, so a host-connectivity change is still caught promptly.
 func (e *Engine) refreshHostsForNewConnection(ctx context.Context) error {
+	if e.fetcher == nil {
+		return nil
+	}
+	e.mu.RLock()
+	fresh := !e.lastHostRefresh.IsZero() && time.Since(e.lastHostRefresh) < hostRefreshCoalesce
+	e.mu.RUnlock()
+	if fresh {
+		return nil
+	}
 	if err := e.refreshHostsNow(ctx); err != nil {
 		return fmt.Errorf("%w: refreshing host list: %v", ErrUpstream, err)
 	}

--- a/internal/broker/host_refetch_test.go
+++ b/internal/broker/host_refetch_test.go
@@ -1,0 +1,47 @@
+package broker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRefreshHostsForNewConnectionCoalesces pins #208: a burst of one-shot
+// connections must not each pay a /v1/hosts round-trip on top of /v1/sign. The
+// per-connection refetch is coalesced within hostRefreshCoalesce, so under
+// sustained load Execute issues a single signer round-trip in the common case.
+func TestRefreshHostsForNewConnectionCoalesces(t *testing.T) {
+	var calls int32
+	e := &Engine{fetcher: countingFetcher{n: &calls}}
+	ctx := context.Background()
+
+	// Cold cache (lastHostRefresh zero) → one refetch.
+	if err := e.refreshHostsForNewConnection(ctx); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	// Again within the coalesce window → reuse the cached view, no second fetch.
+	if err := e.refreshHostsForNewConnection(ctx); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("within the coalesce window a new connection must reuse the cached host view: FetchHosts called %d times, want 1", got)
+	}
+
+	// Age the cache past the window → the next new connection refetches.
+	e.mu.Lock()
+	e.lastHostRefresh = time.Now().Add(-2 * hostRefreshCoalesce)
+	e.mu.Unlock()
+	if err := e.refreshHostsForNewConnection(ctx); err != nil {
+		t.Fatalf("post-expiry refresh: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("after the coalesce window a new connection must refetch: FetchHosts called %d times, want 2", got)
+	}
+
+	// Local mode (no fetcher) never refetches.
+	local := &Engine{}
+	if err := local.refreshHostsForNewConnection(ctx); err != nil {
+		t.Fatalf("local mode refresh: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Every one-shot `Execute`/`OpenSession` in remote mode did a synchronous `GET /v1/hosts` and reparsed the entire host table before signing — redundant with the 5-minute background poller and adding a full RTT + whole-table reparse to the hottest path, on top of the per-hop `POST /v1/sign`. A single `ssh_execute` to a direct host issued **2 signer round-trips**.

## Fix

Coalesce the refetch with a short freshness TTL (`hostRefreshCoalesce`, ~3s): `lastHostRefresh` records the last successful host load (initial load, background poller, and `refreshHostsNow`), and `refreshHostsForNewConnection` skips the refetch when the cache was refreshed within the window. The poller keeps the table fresh and `/v1/sign` is the authoritative gate.

Session-exec preflight still calls `refreshHostsNow` (never coalesced), so a host-connectivity change is caught promptly.

## Tests

Within the coalesce window a new connection reuses the cached host view (one `FetchHosts`); past the window it refetches; local mode never refetches.

`make verify` green.

Closes #208