### PR TITLE
chore: v2.1.0 release (changelog + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## [Unreleased]
+## [v2.1.0] - 2026-07-10
+
+Correctness and hardening follow-up to the v2.0.0 secure-by-default major: the
+kill switch now interrupts a busy PTY session and covers a frozen forwarder's own
+CN and `/v1/clusters`; the Kubernetes path audits dry-runs and stops leaking the
+API-server address; session recording is observable and can be made strict; and
+config-loading, CA-custody preflight, and revocation-poll observability are all
+tightened. **Upgrade note:** the control-plane four-eyes audit is now fail-closed
+by default (`audit_fail_mode=closed`), completing the audit flip v2.0.0 left out —
+set `audit_fail_mode=open` to keep the previous log-and-continue behaviour.
 
 ### Performance
 - **Coalesce the per-connection host-table refetch (remote mode) (#208)** — every

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,18 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-10 (v2.0.0, secure-by-default: tres defaults fail-open volteados).
+> actualización: 2026-07-10 (v2.1.0, hardening post-v2.0.0: kill-switch, audit fail-closed del control-plane, k8s/recording/freeze).
 >
 > Estado reciente:
+> - **v2.1.0**: pasada de correctitud y hardening tras el major v2.0.0 — el kill
+>   switch corta un PTY ocupado (#202) y cubre el CN crudo de un forwarder frozen
+>   y `/v1/clusters` (#203); el audit four-eyes del control-plane es **fail-closed
+>   por defecto** (`audit_fail_mode`, #205, completa el flip que v2.0.0 dejó fuera);
+>   el camino k8s audita dry-runs y no filtra la dirección del API server (#204);
+>   la grabación de sesión es observable y puede ser estricta (#206); y se endurecen
+>   la carga de config, el preflight de custodia CA y la observabilidad del
+>   revocation-poll (#216–#245). Sin `feat:`; superficies nuevas aditivas con
+>   defaults seguros y opt-out documentado.
 > - **v2.0.0** (primer major): **secure-by-default** — se voltean a fail-closed
 >   los tres defaults fail-open que un operador podía confundir con protección,
 >   cada uno con su opt-out documentado: (1) la tabla `callers` no vacía es

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:2.0.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:2.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Cuts **v2.1.0** — a MINOR bump over v2.0.0 folding everything merged since the tag: milestone 1 (`#202`–`#208`) plus the post-v2.0.0 architecture-audit fixes (`#216`–`#245`).

## Version rationale (MINOR)

No `feat:` commits — everything is `fix:`/`perf:` — but the release adds **additive user-facing surfaces** with safe defaults (control-plane `audit_fail_mode`, broker `session_recording_strict`, kill-switch revocation-poll metrics). It's the correctness/hardening follow-up that completes the v2.0.0 secure-by-default direction, not a new posture shift, so MINOR rather than MAJOR.

## Upgrade note

The **control-plane four-eyes audit is now fail-closed by default** (`audit_fail_mode=closed`), completing the audit flip v2.0.0 left out — an approval whose audit append fails is now rejected (503) rather than granted. Set `audit_fail_mode=open` to keep the previous log-and-continue behaviour.

## Files

- `docs/CHANGELOG.md` — `[Unreleased]` folded into `## [v2.1.0] - 2026-07-10` with a release theme.
- `server.json` — `version` → `2.1.0`, OCI identifier → `ghcr.io/luisgf/infrabroker:2.1.0` (`mcp-publisher validate` ✅).
- `docs/HANDOFF.md` — header + v2.1.0 bullet.

`make verify` green (gofmt/vet/build/race + govulncheck + docs drift + strict mkdocs).

**Release PR — human review + merge (not auto-merged).** After merge I'll tag `v2.1.0` on the merged commit and push it (with your go-ahead), which fires `release.yml` (goreleaser + mcp-registry).