### PR TITLE
fix(signer): make freeze mutations durable against power loss (#210)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **Freezes are durable against power loss, not just an app crash (#210)** — the
+  state DB runs `synchronous=NORMAL`, which fsyncs only at a WAL checkpoint, so a
+  committed freeze whose frames were not yet checkpointed was lost on power loss /
+  kernel panic before the auto-checkpoint — and a lost freeze fails **open** (the
+  blocked subject regains access on restart). A freeze `Add`/`Remove` now forces a
+  full WAL checkpoint (fsync of the WAL and the DB) before returning success, so a
+  freeze that the API acknowledged survives power loss. Grants and approve-and-learn
+  waivers stay `NORMAL` — a lost widening fails safe.
+
 ## [v2.1.0] - 2026-07-10
 
 Correctness and hardening follow-up to the v2.0.0 secure-by-default major: the

--- a/internal/signer/freeze.go
+++ b/internal/signer/freeze.go
@@ -122,6 +122,29 @@ func NewFreezeStoreDB(db *sql.DB) (*FreezeStore, error) {
 // one, and production deployments should set state_db instead.
 func (s *FreezeStore) Volatile() bool { return s.db == nil }
 
+// checkpointDurable forces the just-committed freeze mutation all the way to disk.
+// The state db runs synchronous=NORMAL (fsync only at a checkpoint), which is
+// crash-safe against an application crash but NOT against a power loss / kernel
+// panic before the ~1000-page auto-checkpoint: a committed freeze whose WAL frames
+// are not yet checkpointed is lost, and a lost freeze fails OPEN — the blocked
+// subject silently regains access (#210). A FULL WAL checkpoint fsyncs the WAL and
+// then the database file before returning, so once it succeeds the freeze survives
+// power loss. Run ONLY on the rare freeze Add/Remove; grants and approve-and-learn
+// waivers stay NORMAL because a lost widening fails safe (policy narrows).
+func checkpointDurable(db *sql.DB) error {
+	var busy, logFrames, checkpointed int
+	if err := db.QueryRow(`PRAGMA wal_checkpoint(FULL)`).Scan(&busy, &logFrames, &checkpointed); err != nil {
+		return fmt.Errorf("durable checkpoint: %w", err)
+	}
+	// busy != 0 means the checkpoint could not flush every frame (a reader/writer
+	// held the WAL back). With the state db's single connection this should not
+	// happen; fail closed rather than report a durability we did not achieve.
+	if busy != 0 {
+		return fmt.Errorf("durable checkpoint did not complete (busy=%d)", busy)
+	}
+	return nil
+}
+
 // Add freezes subj. Write-through, insert-first: if it cannot be persisted the
 // call fails and the in-memory set does not diverge from disk (an in-memory-only
 // freeze would vanish on restart — fail-open). Re-freezing a subject refreshes
@@ -144,6 +167,9 @@ func (s *FreezeStore) Add(subj FreezeSubject, reason, by string, now time.Time) 
 			subj.Kind, subj.Value, reason, by, e.FrozenAt.Unix()); err != nil {
 			return false, fmt.Errorf("persisting freeze: %w", err)
 		}
+		if err := checkpointDurable(s.db); err != nil {
+			return false, fmt.Errorf("persisting freeze: %w", err)
+		}
 	}
 	_, existed := s.frozen[subj]
 	s.frozen[subj] = e
@@ -162,6 +188,9 @@ func (s *FreezeStore) Remove(subj FreezeSubject) (bool, error) {
 	}
 	if s.db != nil {
 		if _, err := s.db.Exec(`DELETE FROM freezes WHERE kind = ? AND value = ?`, subj.Kind, subj.Value); err != nil {
+			return false, fmt.Errorf("removing freeze in state db: %w", err)
+		}
+		if err := checkpointDurable(s.db); err != nil {
 			return false, fmt.Errorf("removing freeze in state db: %w", err)
 		}
 	}

--- a/internal/signer/freeze_durability_test.go
+++ b/internal/signer/freeze_durability_test.go
@@ -1,0 +1,79 @@
+package signer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// copyMainDBFile copies ONLY the main SQLite database file (not the -wal/-shm
+// sidecars). In WAL mode the main file is stable between checkpoints, so a copy
+// taken while the source is open (never cleanly closed) is a faithful stand-in
+// for what survives a power loss: the fsynced main db, minus the WAL frames that
+// synchronous=NORMAL had not yet flushed.
+func copyMainDBFile(t *testing.T, src, dst string) {
+	t.Helper()
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, b, 0o600); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}
+
+// TestFreezeSurvivesSimulatedPowerLoss pins #210: a freeze committed via the API
+// (Add returning success) must survive a power loss, not just an application
+// crash. The state db runs synchronous=NORMAL (fsync only at a checkpoint), so
+// without the durability checkpoint the committed freeze lived only in the
+// un-fsynced WAL and vanished on power loss — the blocked subject regaining
+// access (fail-open on break-glass).
+//
+// The source db is deliberately left OPEN throughout (never cleanly closed, which
+// would checkpoint on close and mask the bug); "power loss" is modelled by copying
+// only the main db file and reopening that copy.
+func TestFreezeSurvivesSimulatedPowerLoss(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+	db := openStateDB(t, dbPath)
+	fs, err := NewFreezeStoreDB(db)
+	if err != nil {
+		t.Fatalf("NewFreezeStoreDB: %v", err)
+	}
+
+	subj := FreezeSubject{Kind: FreezeCaller, Value: "compromised"}
+	if _, err := fs.Add(subj, "incident", "admin", time.Now()); err != nil {
+		t.Fatalf("Add (the API returns 200 here): %v", err)
+	}
+
+	// Power loss right after the API returned 200: main db survives, WAL is lost.
+	crashPath := filepath.Join(dir, "crash.db")
+	copyMainDBFile(t, dbPath, crashPath)
+
+	fs2, err := NewFreezeStoreDB(openStateDB(t, crashPath))
+	if err != nil {
+		t.Fatalf("reopen after power loss: %v", err)
+	}
+	if _, frozen := fs2.Frozen("compromised", ""); !frozen {
+		t.Fatal("a committed freeze must survive power loss (WAL lost, main db intact) (#210)")
+	}
+
+	// An unfreeze is durable too: after Remove, the deletion must survive power
+	// loss so a released subject is not re-blocked on restart. (Add checkpointed the
+	// freeze into the main db, so without Remove's checkpoint the copy would still
+	// carry it.)
+	if _, err := fs.Remove(subj); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	crashPath2 := filepath.Join(dir, "crash2.db")
+	copyMainDBFile(t, dbPath, crashPath2)
+
+	fs3, err := NewFreezeStoreDB(openStateDB(t, crashPath2))
+	if err != nil {
+		t.Fatalf("reopen after unfreeze power loss: %v", err)
+	}
+	if _, frozen := fs3.Frozen("compromised", ""); frozen {
+		t.Fatal("an unfreeze must survive power loss too (#210)")
+	}
+}


### PR DESCRIPTION
## What

The state DB uses `synchronous=NORMAL` (WAL), which fsyncs only at a checkpoint — safe against an **application** crash but not a **power loss / kernel panic** before the ~1000-page auto-checkpoint. A committed freeze whose WAL frames weren't yet checkpointed was lost on power loss, and **a lost freeze fails open**: the subject the operator blocked regains access on restart.

## Fix

`FreezeStore.Add`/`Remove` now run a **full WAL checkpoint** (`checkpointDurable` → `PRAGMA wal_checkpoint(FULL)`, which fsyncs the WAL then the DB; fail-closed on a non-zero `busy`) before returning success. Only the rare freeze mutation pays it — grants and approve-and-learn waivers stay `NORMAL`, because a lost widening fails safe (policy narrows).

## Test

Simulates power loss by copying **only the main DB file** (the un-fsynced WAL is "lost") while the source stays open (never cleanly closed, which would checkpoint on close and mask the bug), then reopens the copy and asserts the freeze — and a later unfreeze — survive. Verified it fails without the checkpoint.

`make verify` green.

Closes #210