### PR TITLE
perf(audit): group-commit the audit-log fsync (#209)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Performance
+- **Group-commit the audit-log fsync (#209)** — `Append` held the log mutex across
+  the synchronous `fsync`, so every audited action process-wide serialised behind
+  one fsync (~1/fsync-latency, ≈100-200/s on a 5-10ms disk) — and with the v2.0.0
+  fail-closed audit that fsync sits on the critical path of every request. The
+  fsync is now group-committed: appends write and advance the hash chain under the
+  lock in strict order, then batch the durability fsync so N concurrent appends
+  cost ~one fsync instead of N. Fail-closed durability is unchanged — an append
+  still returns success only once its bytes are on disk — and rotation flushes the
+  old file before closing it.
+
 ### Security
 - **Freezes are durable against power loss, not just an app crash (#210)** — the
   state DB runs `synchronous=NORMAL`, which fsyncs only at a WAL checkpoint, so a

--- a/internal/audit/group_commit_test.go
+++ b/internal/audit/group_commit_test.go
@@ -1,0 +1,215 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestAppendConcurrentChainIntact pins the correctness half of #209: many
+// goroutines appending at once (the group-commit path) must still produce a
+// totally-ordered, unbroken, fully-durable hash chain — every entry persisted,
+// contiguous seq, valid signatures. Runs under `go test -race`.
+func TestAppendConcurrentChainIntact(t *testing.T) {
+	t.Parallel()
+	l, path := openTmp(t)
+
+	const workers, per = 12, 40
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < per; i++ {
+				if err := l.Append(Entry{Caller: "c", Host: "h:22", Command: "id", Outcome: "executed"}); err != nil {
+					t.Errorf("Append: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	l.Close()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	total, errs := Verify(f, pub(testKey()), discardReport)
+	if total != workers*per || errs != 0 {
+		t.Fatalf("Verify = (%d,%d); want (%d,0) — chain broken or entries lost under concurrency", total, errs, workers*per)
+	}
+}
+
+// blockingSink blocks the FIRST Sync until released, counting every Sync. It lets
+// a test park one append inside its fsync (as the group-commit leader) while
+// others queue behind it.
+type blockingSink struct {
+	inner   logFile
+	calls   atomic.Int32
+	entered chan struct{} // closed when the first Sync is entered
+	release chan struct{} // the first Sync blocks until this is closed
+}
+
+func (s *blockingSink) Write(p []byte) (int, error) { return s.inner.Write(p) }
+func (s *blockingSink) Stat() (os.FileInfo, error)  { return s.inner.Stat() }
+func (s *blockingSink) Close() error                { return s.inner.Close() }
+func (s *blockingSink) Sync() error {
+	if s.calls.Add(1) == 1 {
+		close(s.entered)
+		<-s.release
+	}
+	return s.inner.Sync()
+}
+
+// waitWriteCount blocks until the log has committed at least n writes, i.e. all n
+// appends have written their line and parked (the leader in Sync, the rest in
+// cond.Wait).
+func waitWriteCount(t *testing.T, l *Log, n uint64) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		l.mu.Lock()
+		wc := l.writeCount
+		l.mu.Unlock()
+		if wc >= n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for writeCount=%d (have %d)", n, wc)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestAppendGroupCommitBatchesFsync pins the performance half of #209: N
+// concurrent appends must NOT cost N fsyncs. One append is parked inside its
+// fsync as the leader; the rest write and queue behind it; when the leader is
+// released a single follower fsyncs all of them at once — 2 fsyncs for N appends
+// (the leader, then one batched sync), not N. Before the fix each Append fsynced
+// under the lock, so this would be N.
+func TestAppendGroupCommitBatchesFsync(t *testing.T) {
+	l, path := openTmp(t)
+	sink := &blockingSink{inner: l.f, entered: make(chan struct{}), release: make(chan struct{})}
+	l.f = sink
+
+	const n = 8
+	var wg sync.WaitGroup
+
+	// The first append becomes the leader and blocks inside Sync.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := l.Append(Entry{Outcome: "a0"}); err != nil {
+			t.Errorf("Append a0: %v", err)
+		}
+	}()
+	<-sink.entered // the leader is now inside its fsync
+
+	// The rest write and queue as followers behind the blocked leader.
+	for i := 1; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := l.Append(Entry{Outcome: fmt.Sprintf("a%d", i)}); err != nil {
+				t.Errorf("Append a%d: %v", i, err)
+			}
+		}(i)
+	}
+	waitWriteCount(t, l, n) // all n written and parked
+
+	close(sink.release) // let the leader's fsync complete; one follower syncs the rest
+	wg.Wait()
+
+	if got := sink.calls.Load(); got != 2 {
+		t.Fatalf("group commit: %d fsyncs for %d concurrent appends, want 2 (leader + one batched sync)", got, n)
+	}
+
+	l.Close()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if total, errs := Verify(f, pub(testKey()), discardReport); total != n || errs != 0 {
+		t.Fatalf("Verify = (%d,%d); want (%d,0)", total, errs, n)
+	}
+}
+
+// TestRotationDeferredOnFsyncFailure pins the group-commit rotation barrier
+// (#209): maybeRotate flushes the old file before closing it, and if that
+// pre-rotation fsync fails it DEFERS rotation rather than closing an un-fsynced
+// file (which would lose the pending appends on power loss). Once fsync recovers,
+// rotation proceeds and the cross-segment chain stays intact.
+func TestRotationDeferredOnFsyncFailure(t *testing.T) {
+	l, path := openTmp(t)
+	l.maxFileSize = 1 // any non-empty file makes the next append want to rotate
+
+	if err := l.Append(Entry{Outcome: "a"}); err != nil {
+		t.Fatalf("Append a: %v", err)
+	}
+
+	// Inject an fsync failure: the next append's pre-rotation fsync fails, so
+	// rotation is deferred (no segment created) and the append itself errors.
+	sink := &faultySink{inner: l.f, failSync: true}
+	l.f = sink
+	if err := l.Append(Entry{Outcome: "b"}); err == nil {
+		t.Fatal("Append must fail while the fsync is failing")
+	}
+	if segs, _ := discoverSegments(path); len(segs) != 1 {
+		t.Fatalf("rotation must be deferred on an fsync failure (no segment); segments=%v", segs)
+	}
+
+	// fsync recovers: the next append rotates cleanly and the chain across the
+	// rotation boundary verifies.
+	sink.failSync = false
+	if err := l.Append(Entry{Outcome: "c"}); err != nil {
+		t.Fatalf("post-recovery Append: %v", err)
+	}
+	l.Close()
+	if total, errs := VerifySegments(path, pub(testKey()), discardReport); errs != 0 {
+		t.Fatalf("VerifySegments = (%d,%d); chain broken across the deferred-then-performed rotation", total, errs)
+	}
+}
+
+// latencySink injects a fixed per-Sync delay to model fsync latency in the
+// benchmark below.
+type latencySink struct {
+	inner logFile
+	delay time.Duration
+}
+
+func (s *latencySink) Write(p []byte) (int, error) { return s.inner.Write(p) }
+func (s *latencySink) Stat() (os.FileInfo, error)  { return s.inner.Stat() }
+func (s *latencySink) Close() error                { return s.inner.Close() }
+func (s *latencySink) Sync() error {
+	time.Sleep(s.delay)
+	return s.inner.Sync()
+}
+
+// BenchmarkAppendParallelSlowFsync demonstrates the #209 acceptance: with a
+// simulated per-fsync latency, concurrent audited-action throughput is no longer
+// capped at 1/fsync. Group commit lets parallel appends share a single fsync, so
+// throughput scales well past the ~1/delay ceiling the old per-append fsync
+// imposed. Run: go test ./internal/audit/ -run x -bench AppendParallelSlowFsync
+func BenchmarkAppendParallelSlowFsync(b *testing.B) {
+	l, err := Open(fmt.Sprintf("%s/audit.log", b.TempDir()), testKey())
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	b.Cleanup(func() { l.Close() })
+	l.f = &latencySink{inner: l.f, delay: 2 * time.Millisecond}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := l.Append(Entry{Outcome: "bench"}); err != nil {
+				b.Fatalf("Append: %v", err)
+			}
+		}
+	})
+}

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -121,6 +121,18 @@ type Log struct {
 	// then prepends a newline so it cannot concatenate two JSON records on one
 	// physical line.
 	needsNewline bool
+
+	// Group-commit fsync state (all under mu). Append writes the line and advances
+	// the hash chain under mu — in strict total order — then batches the durability
+	// fsync: one goroutine (the leader) fsyncs while the rest wait, so N concurrent
+	// appends cost ~1 fsync instead of N and throughput is no longer capped at
+	// 1/fsync (#209). Fail-closed durability is preserved: an Append returns success
+	// only once syncedCount has advanced past its own writeCount, i.e. its bytes are
+	// on disk. writeCount is monotonic across rotations (unlike the per-file seq).
+	syncCond    *sync.Cond
+	writeCount  uint64 // committed writes so far (never resets)
+	syncedCount uint64 // highest writeCount durably fsynced
+	syncing     bool   // a leader is fsyncing right now
 }
 
 // Open opens (or creates) the audit file in append mode and prepares signing.
@@ -133,6 +145,7 @@ func Open(path string, signKey ed25519.PrivateKey) (*Log, error) {
 		signKey:     signKey,
 		maxFileSize: AuditLogMaxSize,
 	}
+	l.syncCond = sync.NewCond(&l.mu)
 	// A4: restore the chain from the existing log (if any).
 	if err := l.restoreChain(); err != nil {
 		return nil, fmt.Errorf("restoring audit chain: %w", err)
@@ -211,6 +224,22 @@ func (l *Log) maybeRotate() {
 	if err != nil || info.Size() < l.maxFileSize {
 		return
 	}
+	// Group-commit barrier: a leader may be fsyncing l.f right now (mu released),
+	// and appends whose bytes are in this file may not be fsynced yet. Wait for the
+	// leader to finish, then flush the file ourselves before closing it — otherwise
+	// closing would lose those un-fsynced bytes (Close does not fsync). If the flush
+	// fails, DEFER rotation (do not close an unsynced file): the pending appends'
+	// own syncTo retries on the still-open file, and rotation retries next append.
+	for l.syncing {
+		l.syncCond.Wait()
+	}
+	if err := l.f.Sync(); err != nil {
+		log.Printf("warning: audit log rotation deferred: pre-rotation fsync failed: %v", err)
+		l.syncCond.Broadcast()
+		return
+	}
+	l.syncedCount = l.writeCount
+	l.syncCond.Broadcast()
 	rotPath := l.path + "." + time.Now().UTC().Format(rotationTimeFormat)
 	// Close and drop the handle up front. From here l.f is either reassigned to
 	// a valid file or left nil — it is NEVER left pointing at the closed handle,
@@ -383,9 +412,43 @@ func (l *Log) doAppend(e Entry) error {
 	l.seq = seq
 	sum := sha256.Sum256(line)
 	l.prevHash = hex.EncodeToString(sum[:])
+	l.writeCount++
+	myCount := l.writeCount
 
-	if err := l.f.Sync(); err != nil {
-		return fmt.Errorf("fsync log: %w", err)
+	return l.syncTo(myCount)
+}
+
+// syncTo blocks until every write up to and including count is durably fsynced,
+// then returns nil (fail-closed: an Append returns success only once its bytes
+// are on disk). Group commit: the first waiter becomes the leader and fsyncs with
+// mu RELEASED, so concurrent Appends queue behind one fsync instead of each
+// paying their own; the rest wait and return once the leader's sync covered them.
+// If the leader's own fsync fails it returns that error; a follower woken by a
+// failed sync retries as the next leader. Called with mu held; returns with mu
+// held so the caller's deferred Unlock runs exactly once.
+func (l *Log) syncTo(count uint64) error {
+	for l.syncedCount < count {
+		if l.syncing {
+			l.syncCond.Wait() // a leader is syncing; wait and re-check
+			continue
+		}
+		// Become the leader. Capture the file and target under mu; maybeRotate and
+		// Close wait for l.syncing to clear, so l.f stays valid across the unlocked
+		// fsync and cannot be closed under us.
+		l.syncing = true
+		f := l.f
+		target := l.writeCount
+		l.mu.Unlock()
+		serr := f.Sync()
+		l.mu.Lock()
+		l.syncing = false
+		if serr == nil && target > l.syncedCount {
+			l.syncedCount = target
+		}
+		l.syncCond.Broadcast()
+		if serr != nil {
+			return fmt.Errorf("fsync log: %w", serr)
+		}
 	}
 	return nil
 }
@@ -394,6 +457,11 @@ func (l *Log) doAppend(e Entry) error {
 func (l *Log) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	// Wait for any in-flight group-commit fsync so we do not close the file out
+	// from under the leader.
+	for l.syncing {
+		l.syncCond.Wait()
+	}
 	if l.f == nil { // a prior open failure left no handle to close
 		return nil
 	}


### PR DESCRIPTION
## What

`audit.Append` held `l.mu` across the synchronous `f.Sync()`, so **every audited action process-wide serialised behind one fsync** (~1/fsync-latency, ≈100-200/s on a 5-10ms disk). With the v2.0.0 fail-closed audit, that fsync sits on the critical path of every request.

## Fix

Group-commit the fsync. Appends still write the line and advance the hash chain **under the lock, in strict total order** (unchanged). The durability fsync is then batched via `syncTo`: the first waiter becomes the leader and fsyncs with the lock **released** while the rest queue behind it; each returns once the leader's sync covered its write. So **N concurrent appends cost ~one fsync instead of N**.

- A monotonic `writeCount`/`syncedCount` pair (monotonic across rotations, unlike the per-file `seq`) tracks durability. An append returns success **only once `syncedCount` passed its own write** — fail-closed durability is preserved.
- `maybeRotate` and `Close` wait for an in-flight leader before touching the file; `maybeRotate` fsyncs the old file before closing it, and **defers rotation if that fsync fails** (never closes an un-fsynced file), so a deferred append is never lost on rotation.

## Tests

- Chain intact + all entries durable under concurrency (`-race`).
- A blocking sink deterministically proves batching: **2 fsyncs for 8 concurrent appends**, not 8.
- Rotation defers on an fsync failure, then rotates cleanly on recovery with the cross-segment chain intact.
- `BenchmarkAppendParallelSlowFsync` shows throughput past the 1/fsync ceiling. The existing fsync-fault test still passes.

`make verify` green (incl. `-race`).

Closes #209