### PR TITLE
perf: lock-free metric increments, hostKeyCache eviction, poll ticker (#215)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Performance
+- **Concurrency & allocation polish (#215)** — three low-severity hot-path
+  hygiene fixes: labelled metric increments (`monitor.Vec.With`) are now lock-free
+  via a `sync.Map`, so a high-RPS `signRequestsTotal.With(...).Inc()` no longer
+  serialises every observation behind one family mutex; the broker evicts stale
+  `hostKeyCache` entries on each host refresh, so a rotated host key no longer
+  leaves its old (and negative-cached) parse behind forever; and the approval poll
+  loop reuses one `time.Ticker` instead of allocating a fresh `time.After` timer
+  every 2s.
 - **Group-commit the audit-log fsync (#209)** — `Append` held the log mutex across
   the synchronous `fsync`, so every audited action process-wide serialised behind
   one fsync (~1/fsync-latency, ≈100-200/s on a 5-10ms disk) — and with the v2.0.0

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -679,6 +679,7 @@ func (e *Engine) startHostRefresh(interval time.Duration) {
 				e.hosts = h
 				e.lastHostRefresh = time.Now()
 				e.mu.Unlock()
+				e.pruneHostKeyCache()
 				log.Printf("hosts reloaded from signer: %d entries", len(h))
 				if e.clusterFetcher != nil {
 					cl, err := e.clusterFetcher.FetchClusters(context.Background(), "")
@@ -901,6 +902,7 @@ func (e *Engine) refreshHostsNow(ctx context.Context) error {
 	e.hosts = h
 	e.lastHostRefresh = time.Now()
 	e.mu.Unlock()
+	e.pruneHostKeyCache()
 	return nil
 }
 
@@ -1463,4 +1465,28 @@ func (e *Engine) parseHostKeyCached(line string) (ssh.PublicKey, error) {
 	}
 	e.hostKeyCache.Store(line, pk)
 	return pk, nil
+}
+
+// pruneHostKeyCache drops memoised host-key parses whose authorized_keys line is
+// no longer present in any current host. hostKeyCache is content-addressed by the
+// line, so without pruning a rotated host key leaves its old parse cached forever
+// (slow unbounded growth with every rotation). Called after a remote host refresh,
+// so e.hosts is the authoritative live set (#215).
+func (e *Engine) pruneHostKeyCache() {
+	live := make(map[string]struct{})
+	e.mu.RLock()
+	for _, hi := range e.hosts {
+		if hi.HostKey != "" {
+			live[hi.HostKey] = struct{}{}
+		}
+	}
+	e.mu.RUnlock()
+	e.hostKeyCache.Range(func(k, _ any) bool {
+		if line, ok := k.(string); ok {
+			if _, keep := live[line]; !keep {
+				e.hostKeyCache.Delete(line)
+			}
+		}
+		return true
+	})
 }

--- a/internal/broker/hostkeycache_test.go
+++ b/internal/broker/hostkeycache_test.go
@@ -1,0 +1,58 @@
+package broker
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+	"golang.org/x/crypto/ssh"
+)
+
+// hostKeyLine returns a fresh valid authorized_keys line.
+func hostKeyLine(t *testing.T) string {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("ssh pubkey: %v", err)
+	}
+	return string(ssh.MarshalAuthorizedKey(sshPub))
+}
+
+// TestPruneHostKeyCache pins #215: after a remote host refresh, memoised
+// host-key parses whose line left the live host set are evicted, so a rotated
+// key does not leave its old (and its negative-cached) entry behind forever.
+func TestPruneHostKeyCache(t *testing.T) {
+	e := &Engine{}
+	keyA := hostKeyLine(t)
+	keyB := hostKeyLine(t)
+
+	// Populate the cache: two valid keys and one negative (unparsable) entry.
+	if _, err := e.parseHostKeyCached(keyA); err != nil {
+		t.Fatalf("parse keyA: %v", err)
+	}
+	if _, err := e.parseHostKeyCached(keyB); err != nil {
+		t.Fatalf("parse keyB: %v", err)
+	}
+	if _, err := e.parseHostKeyCached("not a key"); err == nil {
+		t.Fatal("expected a parse error for garbage")
+	}
+
+	// The live host set now carries only keyA (keyB's host rotated away).
+	e.hosts = map[string]signer.HostInfo{"a": {HostKey: keyA}}
+	e.pruneHostKeyCache()
+
+	if _, ok := e.hostKeyCache.Load(keyA); !ok {
+		t.Error("a live host key must survive pruning")
+	}
+	if _, ok := e.hostKeyCache.Load(keyB); ok {
+		t.Error("a rotated-away host key must be evicted")
+	}
+	if _, ok := e.hostKeyCache.Load("not a key"); ok {
+		t.Error("a stale negative-cache entry must be evicted")
+	}
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -46,22 +46,23 @@ func (c *Counter) Add(n int64) {
 func (c *Counter) Value() int64 { return c.v.Load() }
 
 // Vec is a family of counters sharing a name and differing in one label value.
+// elems is a sync.Map so With() is lock-free on the hot path (the label already
+// exists), preserving the lock-free atomic.Int64 design under high RPS — a plain
+// map+Mutex serialised every labelled increment behind one lock (#215).
 type Vec struct {
 	label string
-	mu    sync.Mutex
-	elems map[string]*Counter
+	elems sync.Map // string → *Counter
 }
 
 // With returns the counter for the given label value, creating it on first use.
+// Lock-free once the label exists; only the first observation of a new label
+// pays a LoadOrStore.
 func (v *Vec) With(value string) *Counter {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	c, ok := v.elems[value]
-	if !ok {
-		c = &Counter{}
-		v.elems[value] = c
+	if c, ok := v.elems.Load(value); ok {
+		return c.(*Counter)
 	}
-	return c
+	c, _ := v.elems.LoadOrStore(value, &Counter{})
+	return c.(*Counter)
 }
 
 type registry struct {
@@ -101,7 +102,7 @@ func GetCounterVec(name, help, label string) *Vec {
 	defer std.mu.Unlock()
 	v, ok := std.vecs[name]
 	if !ok {
-		v = &Vec{label: label, elems: map[string]*Counter{}}
+		v = &Vec{label: label}
 		std.vecs[name] = v
 		std.order = append(std.order, name)
 		std.help[name] = help
@@ -143,16 +144,17 @@ func writeMetrics(w *strings.Builder) {
 		}
 		if v, ok := std.vecs[name]; ok {
 			fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n", name, std.help[name], name)
-			v.mu.Lock()
-			labels := make([]string, 0, len(v.elems))
-			for lv := range v.elems {
-				labels = append(labels, lv)
-			}
+			var labels []string
+			v.elems.Range(func(k, _ any) bool {
+				labels = append(labels, k.(string))
+				return true
+			})
 			sort.Strings(labels)
 			for _, lv := range labels {
-				fmt.Fprintf(w, "%s{%s=\"%s\"} %d\n", name, v.label, escapeLabel(lv), v.elems[lv].Value())
+				if c, ok := v.elems.Load(lv); ok {
+					fmt.Fprintf(w, "%s{%s=\"%s\"} %d\n", name, v.label, escapeLabel(lv), c.(*Counter).Value())
+				}
 			}
-			v.mu.Unlock()
 			continue
 		}
 		if f, ok := std.gauges[name]; ok {

--- a/internal/monitor/vec_test.go
+++ b/internal/monitor/vec_test.go
@@ -1,0 +1,42 @@
+package monitor
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestVecConcurrentLockFreeAndExposition pins #215: labelled counter increments
+// are lock-free and correct under concurrency (the sync.Map hot path), With
+// returns a stable shared *Counter per label, and the text exposition still
+// renders the family after the map→sync.Map switch. Run under `go test -race`.
+func TestVecConcurrentLockFreeAndExposition(t *testing.T) {
+	v := GetCounterVec("test_vec_polish_total", "polish help", "outcome")
+
+	const goroutines, incs = 16, 500
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < incs; i++ {
+				v.With("hot").Inc()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := v.With("hot").Value(); got != int64(goroutines*incs) {
+		t.Errorf("With(hot) = %d, want %d", got, goroutines*incs)
+	}
+	// A label must resolve to one shared counter, not a fresh one per call.
+	if v.With("hot") != v.With("hot") {
+		t.Error("With must return a stable shared *Counter for a label")
+	}
+
+	var b strings.Builder
+	writeMetrics(&b)
+	if out := b.String(); !strings.Contains(out, `test_vec_polish_total{outcome="hot"}`) {
+		t.Errorf("exposition missing the vec family after the sync.Map switch:\n%s", out)
+	}
+}

--- a/internal/signer/remote.go
+++ b/internal/signer/remote.go
@@ -319,11 +319,15 @@ func (r *Remote) pollApproval(ctx context.Context, approvalID string) (*Issued, 
 	}
 	const interval = 2 * time.Second
 	deadline := time.Now().Add(r.approvalWait)
+	// A ticker reuses one timer instead of allocating a fresh time.After timer on
+	// every poll iteration (#215).
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(interval):
+		case <-ticker.C:
 		}
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("approval not granted within deadline (id %s)", approvalID)


### PR DESCRIPTION
Three low-severity hot-path hygiene items from the 2026-07 audit.

## Changes

- **Lock-free labelled metrics.** `monitor.Vec.With` took a per-family `sync.Mutex` on **every** labelled increment, serialising e.g. `signRequestsTotal.With(outcome).Inc()` (dynamic outcome — the hot sign path) behind one lock and undoing the lock-free `atomic.Int64` counter design. `Vec` now uses a `sync.Map`, so `With` is lock-free once the label exists (this subsumes per-call-site hoisting of fixed labels, and also covers the dynamic-outcome hot path).
- **hostKeyCache eviction.** The cache (content-addressed by the authorized_keys line) was never evicted, so in remote mode a rotated host key left its old (and negative-cached) parse forever. It is now pruned to the live host set after each remote refresh.
- **Poll-loop ticker.** The approval poll reused via one `time.Ticker` instead of allocating a fresh `time.After` timer every 2s.

## Tests

- Concurrent lock-free increments are correct + the exposition still renders the family (`-race`).
- `hostKeyCache` prunes rotated-away and negative-cached lines, keeps live ones.

`make verify` green.

Closes #215