### PR TITLE
feat(monitor): add /readyz readiness probe distinct from liveness (#213)

### DIFF
--- a/cmd/mcp-broker/main.go
+++ b/cmd/mcp-broker/main.go
@@ -59,6 +59,9 @@ func main() {
 
 	srv := mcpserver.New(eng, stdioCaller, cfg.ApprovalViaElicitation)
 
+	// A stdio process has no main listener to gate on, so it is ready for the
+	// /readyz probe (if a monitor listener is configured) once the engine is up.
+	monitor.SetReady(true)
 	log.Printf("mcp-broker (stdio) ready; %d hosts configured", len(eng.Servers()))
 	if err := srv.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		log.Fatalf("MCP server: %v", err)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+- **`/readyz` readiness probe (#213)** — the monitoring listener now serves
+  `/readyz` next to `/healthz`. It returns `503` until the service's main mTLS
+  listener is bound and accepting (for the stdio broker: once its engine is up),
+  and flips back to `503` during graceful shutdown — so an orchestrator does not
+  route traffic to a not-yet-ready or draining instance. `/healthz` stays pure
+  liveness (always `200` while the process serves).
+
 ### Performance
 - **Concurrency & allocation polish (#215)** — three low-severity hot-path
   hygiene fixes: labelled metric increments (`monitor.Vec.With`) are now lock-free

--- a/internal/httpserve/httpserve.go
+++ b/internal/httpserve/httpserve.go
@@ -9,11 +9,14 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/luisgf/infrabroker/internal/monitor"
 )
 
 // RunTLS serves srv over TLS (the certificate is taken from srv.TLSConfig, so
@@ -22,9 +25,23 @@ import (
 // within shutdownTimeout and returns, allowing the caller's defers to run. A
 // serve error before shutdown is fatal. name labels the log lines.
 func RunTLS(srv *http.Server, name string, shutdownTimeout time.Duration) {
+	// Bind the listener explicitly (rather than letting ListenAndServeTLS bind
+	// internally) so readiness flips true only once the socket is actually
+	// accepting — the monitor /readyz probe comes up earlier (#213). A bind
+	// failure is fatal, exactly as ListenAndServeTLS's would be.
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("%s: listen %s: %v", name, addr, err)
+	}
+	monitor.SetReady(true)
+
 	errc := make(chan error, 1)
 	go func() {
-		if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.ServeTLS(ln, "", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errc <- err
 		}
 	}()
@@ -38,6 +55,8 @@ func RunTLS(srv *http.Server, name string, shutdownTimeout time.Duration) {
 	case sig := <-stop:
 		log.Printf("%s: received %s, shutting down...", name, sig)
 	}
+	// Stop reporting ready so an orchestrator drains us before shutdown completes.
+	monitor.SetReady(false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -173,13 +173,35 @@ func Handler() http.Handler {
 	})
 }
 
+// ready gates the /readyz probe. It starts false — the monitor listener (which
+// serves /readyz) comes up before the main listener binds — and a service flips
+// it true once its main listener is accepting, so an orchestrator does not route
+// traffic to a not-yet-ready instance (#213). Distinct from /healthz, which
+// reflects liveness only.
+var ready atomic.Bool
+
+// SetReady marks the service ready (true) or draining/not-yet-ready (false) for
+// the /readyz probe. httpserve.RunTLS calls it once the main TLS listener binds
+// (and false on shutdown); a listener-less service (the stdio broker) sets it
+// once its engine is up.
+func SetReady(r bool) { ready.Store(r) }
+
 // Mux returns the monitoring mux: /healthz (liveness, always 200 while the
-// process serves) and /metrics.
+// process serves), /readyz (readiness, 200 only once SetReady(true)), and
+// /metrics.
 func Mux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		fmt.Fprintln(w, "ok")
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if !ready.Load() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		fmt.Fprintln(w, "ready")
 	})
 	mux.Handle("/metrics", Handler())
 	return mux

--- a/internal/monitor/readyz_test.go
+++ b/internal/monitor/readyz_test.go
@@ -1,0 +1,35 @@
+package monitor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestReadyzGate pins #213: /readyz is 503 until SetReady(true) and 200 after,
+// while /healthz (liveness) stays 200 regardless. Serial: it toggles the global
+// readiness flag.
+func TestReadyzGate(t *testing.T) {
+	defer SetReady(false)
+	mux := Mux()
+
+	code := func(path string) int {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec.Code
+	}
+
+	SetReady(false)
+	if got := code("/readyz"); got != http.StatusServiceUnavailable {
+		t.Errorf("/readyz before ready = %d, want 503", got)
+	}
+	// Liveness is independent of readiness.
+	if got := code("/healthz"); got != http.StatusOK {
+		t.Errorf("/healthz = %d, want 200 (liveness, independent of readiness)", got)
+	}
+
+	SetReady(true)
+	if got := code("/readyz"); got != http.StatusOK {
+		t.Errorf("/readyz after SetReady(true) = %d, want 200", got)
+	}
+}


### PR DESCRIPTION
## What

`/healthz` was always 200 (liveness only). There was **no readiness probe**, and the monitor listener comes up **before** the main listener binds — so an orchestrator could route traffic to a not-yet-ready instance.

## Fix

- `monitor` serves **`/readyz`** next to `/healthz`, gated by a `ready` flag (`SetReady`). It is `503` until ready, `200` after.
- `httpserve.RunTLS` now binds the listener **explicitly** and flips `ready=true` once the socket is accepting (and `false` on graceful shutdown, so a draining instance is drained first). This covers **signer / control-plane / broker / mcp-broker-http** centrally.
- The listener-less **stdio broker** sets `ready` once its engine is up.
- `/healthz` stays pure liveness (always `200` while the process serves).

## Tests

`/readyz` is 503 before `SetReady(true)` and 200 after; `/healthz` stays 200 regardless.

`make verify` green.

Closes #213