### PR TITLE
fix(audit): collision-proof rotated segment names (#257)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,16 @@
   still returns success only once its bytes are on disk — and rotation flushes the
   old file before closing it.
 
+### Fixed
+- **Audit log rotation no longer overwrites a same-second segment (#257)** —
+  rotated segments were named `<log>.<second-timestamp>`, so two rotations within
+  the same second produced the same filename and `os.Rename` silently overwrote
+  the earlier segment — destroying its records and breaking the chain. Only
+  reachable with a small `max_file_size` or an extreme append rate (production's
+  100 MiB rotates far apart), but a latent audit-integrity hole. Rotation now
+  appends a `.<n>` disambiguator when the timestamped name already exists, and
+  segment discovery recognises it; plain timestamps stay backward-compatible.
+
 ### Security
 - **Freezes are durable against power loss, not just an app crash (#210)** — the
   state DB runs `synchronous=NORMAL`, which fsyncs only at a WAL checkpoint, so a

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -11,10 +11,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,10 +50,49 @@ const (
 const AuditLogMaxSize int64 = 100 * 1024 * 1024 // 100 MiB
 
 // rotationTimeFormat is the timestamp suffix a rotated segment carries
-// (<log>.<rotationTimeFormat>). Single-sourced so segment DISCOVERY (verify.go)
+// (<log>.<rotationTimeFormat>). Single-sourced with rotatedSegmentPath (writer)
+// and isRotatedSegment (reader, used by verify.go's discovery) so DISCOVERY
 // recognises exactly what rotation WRITES — and nothing else (e.g. the
-// `audit repair` quarantine file <log>.corrupt-<ts>).
+// `audit repair` quarantine file <log>.corrupt-<ts>). The format is second
+// resolution, so rotatedSegmentPath disambiguates same-second rotations.
 const rotationTimeFormat = "20060102T150405Z"
+
+// rotatedSegmentPath returns a NON-EXISTENT segment path for rotating logPath at
+// t. The base name is <logPath>.<rotationTimeFormat>; if that already exists —
+// another rotation within the same second, possible with a small max_file_size or
+// a coarse wall clock — a ".<n>" suffix is appended so os.Rename never overwrites
+// (and silently destroys) a prior segment (#257). The audit log is single-writer
+// (maybeRotate holds l.mu), so there is no rename TOCTOU here.
+func rotatedSegmentPath(logPath string, t time.Time) string {
+	base := logPath + "." + t.Format(rotationTimeFormat)
+	if _, err := os.Stat(base); errors.Is(err, os.ErrNotExist) {
+		return base
+	}
+	for n := 1; ; n++ {
+		candidate := fmt.Sprintf("%s.%d", base, n)
+		if _, err := os.Stat(candidate); errors.Is(err, os.ErrNotExist) {
+			return candidate
+		}
+	}
+}
+
+// isRotatedSegment reports whether suffix (the part after "<logPath>.") names a
+// rotated segment: the rotationTimeFormat timestamp, optionally followed by a
+// ".<n>" same-second disambiguation suffix. The timestamp format contains no dot,
+// so a dot unambiguously introduces the numeric suffix. Excludes the audit-repair
+// quarantine file (<logPath>.corrupt-<ts>), which does not parse as the format.
+func isRotatedSegment(suffix string) bool {
+	ts := suffix
+	if i := strings.IndexByte(suffix, '.'); i >= 0 {
+		tail := suffix[i+1:]
+		if tail == "" || strings.TrimLeft(tail, "0123456789") != "" {
+			return false // a dot, but not a ".<digits>" collision suffix
+		}
+		ts = suffix[:i]
+	}
+	_, err := time.Parse(rotationTimeFormat, ts)
+	return err == nil
+}
 
 // Entry is an audit record. It never contains the key or the certificate, only
 // metadata (including the cert fingerprint and its serial).
@@ -240,7 +281,7 @@ func (l *Log) maybeRotate() {
 	}
 	l.syncedCount = l.writeCount
 	l.syncCond.Broadcast()
-	rotPath := l.path + "." + time.Now().UTC().Format(rotationTimeFormat)
+	rotPath := rotatedSegmentPath(l.path, time.Now().UTC())
 	// Close and drop the handle up front. From here l.f is either reassigned to
 	// a valid file or left nil — it is NEVER left pointing at the closed handle,
 	// so a reopen failure cannot silently turn every later Append into a write

--- a/internal/audit/rotation_collision_test.go
+++ b/internal/audit/rotation_collision_test.go
@@ -1,0 +1,84 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRotatedSegmentPathCollisionAvoidance pins #257: rotatedSegmentPath never
+// returns a path that already exists, so a same-second rotation cannot rename
+// over (and destroy) a prior segment. The first name is the plain timestamp
+// (backward-compatible with pre-fix segments); collisions get a ".<n>" suffix.
+func TestRotatedSegmentPathCollisionAvoidance(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.log")
+	ts := time.Date(2026, 7, 11, 10, 22, 24, 0, time.UTC)
+	base := logPath + ".20260711T102224Z"
+
+	if got := rotatedSegmentPath(logPath, ts); got != base {
+		t.Fatalf("first rotation path = %q, want %q", got, base)
+	}
+	mustTouch(t, base)
+	if got := rotatedSegmentPath(logPath, ts); got != base+".1" {
+		t.Fatalf("second same-second rotation = %q, want %q", got, base+".1")
+	}
+	mustTouch(t, base+".1")
+	if got := rotatedSegmentPath(logPath, ts); got != base+".2" {
+		t.Fatalf("third same-second rotation = %q, want %q", got, base+".2")
+	}
+}
+
+func mustTouch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x\n"), 0o600); err != nil {
+		t.Fatalf("touch %s: %v", path, err)
+	}
+}
+
+// TestIsRotatedSegment pins that discovery recognises exactly what rotation
+// writes — the timestamp, optionally with a ".<n>" disambiguator — and nothing
+// else (notably the audit-repair quarantine file).
+func TestIsRotatedSegment(t *testing.T) {
+	for _, c := range []struct {
+		suffix string
+		want   bool
+	}{
+		{"20260711T102224Z", true},          // base
+		{"20260711T102224Z.1", true},        // same-second disambiguator
+		{"20260711T102224Z.42", true},       // multi-digit
+		{"corrupt-20260711T102224Z", false}, // audit-repair quarantine
+		{"20260711T102224Z.", false},        // trailing dot, no digits
+		{"20260711T102224Z.x", false},       // non-numeric suffix
+		{"20260711T102224Z.1.2", false},     // second dot
+		{"notatimestamp", false},
+		{"", false},
+	} {
+		if got := isRotatedSegment(c.suffix); got != c.want {
+			t.Errorf("isRotatedSegment(%q) = %v, want %v", c.suffix, got, c.want)
+		}
+	}
+}
+
+// TestRotationSameSecondNoRecordLoss pins the end-to-end #257 fix: many rotations
+// within the same second must each land in a distinct segment, so no records are
+// lost and the cross-segment chain still verifies. Before the fix, same-second
+// rotations renamed onto one filename and silently overwrote prior segments.
+func TestRotationSameSecondNoRecordLoss(t *testing.T) {
+	l, path := openTmp(t)
+	l.maxFileSize = 1 // every append after a non-empty file rotates the previous one
+
+	const n = 6
+	for i := 0; i < n; i++ {
+		if err := l.Append(Entry{Caller: "c", Host: "h:22", Command: "id", Outcome: "executed"}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	l.Close()
+
+	total, errs := VerifySegments(path, pub(testKey()), discardReport)
+	if total != n || errs != 0 {
+		t.Fatalf("VerifySegments = (%d,%d); want (%d,0) — same-second rotations lost records (#257)", total, errs, n)
+	}
+}

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 )
 
 // Verify checks sequence monotonicity, the prev_hash chain and, when pub is
@@ -164,13 +163,14 @@ func VerifySegments(logPath string, pub ed25519.PublicKey, reportf func(string, 
 }
 
 // discoverSegments returns the rotated segments of logPath followed by the
-// active file, sorted oldest→newest (the timestamp suffix sorts chronologically).
-// Only true rotation segments are included: a name matches only if its suffix
-// after "<logPath>." parses as rotationTimeFormat — the exact format maybeRotate
-// writes. This deliberately excludes sibling files that share the "<logPath>."
-// glob prefix but are NOT segments, notably the `audit repair` quarantine file
-// (<logPath>.corrupt-<ts>), whose quarantined bytes are malformed by definition
-// and would otherwise make `verify --all` falsely report a repaired chain broken.
+// active file, sorted oldest→newest (the timestamp suffix — and its ".<n>"
+// same-second disambiguator — sorts chronologically). Only true rotation
+// segments are included, recognised by isRotatedSegment (single-sourced with what
+// maybeRotate/rotatedSegmentPath write). This deliberately excludes sibling files
+// that share the "<logPath>." glob prefix but are NOT segments, notably the
+// `audit repair` quarantine file (<logPath>.corrupt-<ts>), whose quarantined bytes
+// are malformed by definition and would otherwise make `verify --all` falsely
+// report a repaired chain broken.
 func discoverSegments(logPath string) ([]string, error) {
 	matches, err := filepath.Glob(logPath + ".*")
 	if err != nil {
@@ -179,7 +179,7 @@ func discoverSegments(logPath string) ([]string, error) {
 	prefix := logPath + "."
 	var files []string
 	for _, m := range matches {
-		if _, perr := time.Parse(rotationTimeFormat, strings.TrimPrefix(m, prefix)); perr == nil {
+		if isRotatedSegment(strings.TrimPrefix(m, prefix)) {
 			files = append(files, m)
 		}
 	}


### PR DESCRIPTION
## What

Rotated segments were named `<log>.<rotationTimeFormat>` at **second** resolution, so two rotations within the same second produced the **same** filename and `os.Rename` silently **overwrote** the earlier segment — destroying its records and breaking the hash chain across the gap. Only reachable with a small `max_file_size` or an extreme append rate (production's 100 MiB rotates far apart), but a latent audit-integrity hole.

## Fix

- `rotatedSegmentPath` returns a **non-existent** path: the plain timestamp (backward-compatible with pre-fix segments) or, on collision, a `.<n>` suffix — so the rename never overwrites. Single-writer (rotation holds `l.mu`), so no rename TOCTOU.
- `isRotatedSegment` (single-sourced with the writer, used by `verify.go` discovery) recognises **both** the base timestamp and the `.<n>` form, still excluding the `audit repair` quarantine file (`<log>.corrupt-<ts>`).

## Tests

- Collision avoidance: base → `.1` → `.2`.
- Discovery predicate accepts `base`/`base.<n>`, rejects quarantine and garbage.
- Six **same-second** rotations lose **no** records and the cross-segment chain verifies.

_Found while adding a rotation-under-load test for #209; filed separately (no drive-by) and fixed here._

`make verify` green.

Closes #257