### PR TITLE
refactor(broker-ctl): route HTTP through one doJSON helper with bounded reads (#212)

### DIFF
--- a/cmd/broker-ctl/cluster.go
+++ b/cmd/broker-ctl/cluster.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -53,19 +51,8 @@ func cmdClusterList(args []string) {
 	resolveSignerTarget(fs)
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
 
-	resp, err := client.Get(base + "/v1/clusters")
-	if err != nil {
-		fatalf("GET %s/v1/clusters: %v", base, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the request (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
 	var clusters map[string]wireClusterInfo
-	if err := json.Unmarshal(rb, &clusters); err != nil {
-		fatalf("decoding clusters: %v", err)
-	}
+	doJSON(client, http.MethodGet, base+"/v1/clusters", nil, &clusters)
 	if len(clusters) == 0 {
 		fmt.Println("(no kubernetes clusters configured or visible to this caller)")
 		return

--- a/cmd/broker-ctl/freeze.go
+++ b/cmd/broker-ctl/freeze.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/signer"
@@ -70,26 +67,12 @@ func cmdFreeze(args []string) {
 // `broker-ctl freeze` and `broker-ctl session kill`. allowVolatile opts into a
 // memory-only freeze on a signer with no state_db (otherwise refused, HTTP 409).
 func freezePost(client *http.Client, base, kind, value, reason string, allowVolatile bool) {
-	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value, "reason": reason, "allow_volatile": allowVolatile})
-	req, err := http.NewRequest(http.MethodPost, base+"/v1/freeze", bytes.NewReader(body))
-	if err != nil {
-		fatalf("request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		fatalf("POST %s/v1/freeze: %v", base, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the freeze (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
 	var result struct {
 		NewlyFrozen   bool `json:"newly_frozen"`
 		GrantsRevoked int  `json:"grants_revoked"`
 	}
-	_ = json.Unmarshal(rb, &result)
+	doJSON(client, http.MethodPost, base+"/v1/freeze",
+		map[string]any{"kind": kind, "value": value, "reason": reason, "allow_volatile": allowVolatile}, &result)
 	state := "frozen"
 	if !result.NewlyFrozen {
 		state = "already frozen (refreshed)"
@@ -138,25 +121,10 @@ func cmdUnfreeze(args []string) {
 	resolveSignerTarget(fs)
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
-	body, _ := json.Marshal(map[string]any{"kind": kind, "value": value})
-	req, err := http.NewRequest(http.MethodPost, base+"/v1/unfreeze", bytes.NewReader(body))
-	if err != nil {
-		fatalf("request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		fatalf("POST %s/v1/unfreeze: %v", base, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the unfreeze (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
 	var result struct {
 		WasFrozen bool `json:"was_frozen"`
 	}
-	_ = json.Unmarshal(rb, &result)
+	doJSON(client, http.MethodPost, base+"/v1/unfreeze", map[string]any{"kind": kind, "value": value}, &result)
 	if result.WasFrozen {
 		fmt.Printf("unfrozen %s=%s\n", kind, value)
 	} else {
@@ -178,15 +146,7 @@ func cmdRevocations(args []string) {
 	resolveSignerTarget(fs)
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
-	resp, err := client.Get(base + "/v1/revocations")
-	if err != nil {
-		fatalf("GET %s/v1/revocations: %v", base, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the request (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
+	rb := doJSON(client, http.MethodGet, base+"/v1/revocations", nil, nil)
 	if *asJSON {
 		os.Stdout.Write(rb)
 		if len(rb) > 0 && rb[len(rb)-1] != '\n' {

--- a/cmd/broker-ctl/httpjson.go
+++ b/cmd/broker-ctl/httpjson.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// maxRespBytes bounds every broker-ctl HTTP response read, matching the
+// io.LimitReader discipline of the internal clients (internal/bridge/cpclient,
+// internal/signer/remote) instead of the previously-unbounded io.ReadAll: a
+// hostile or malfunctioning peer cannot make the CLI allocate without limit.
+const maxRespBytes = 4 << 20 // 4 MiB
+
+// doJSON performs an mTLS JSON request against the signer / control plane and
+// returns the response body, read bounded to maxRespBytes. It marshals reqBody as
+// the request body when non-nil (with Content-Type: application/json), exits via
+// fatalf on a transport error or a non-2xx status, and decodes the body into out
+// when out is non-nil. Callers that need the raw bytes (e.g. a --json passthrough
+// or a conditional decode) pass a nil out and use the return value.
+//
+// It collapses the ~marshal → NewRequest → Do → ReadAll → status-check → Unmarshal
+// block that every broker-ctl command otherwise repeats, and is the single place
+// the response size is bounded.
+func doJSON(client *http.Client, method, url string, reqBody, out any) []byte {
+	var body io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			fatalf("encoding request for %s: %v", url, err)
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		fatalf("building request %s %s: %v", method, url, err)
+	}
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		fatalf("%s %s: %v", method, url, err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+	if resp.StatusCode/100 != 2 {
+		fatalf("%s %s failed (HTTP %d): %s", method, url, resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	if out != nil {
+		if err := json.Unmarshal(rb, out); err != nil {
+			fatalf("decoding response from %s: %v", url, err)
+		}
+	}
+	return rb
+}

--- a/cmd/broker-ctl/httpjson_test.go
+++ b/cmd/broker-ctl/httpjson_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDoJSONDecodesSuccess: a 200 + JSON body decodes into out and the raw bytes
+// are returned for callers that also want them.
+func TestDoJSONDecodesSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":"g1","expires_at":"soon"}`)
+	}))
+	defer srv.Close()
+
+	var out struct {
+		ID        string `json:"id"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	rb := doJSON(srv.Client(), http.MethodGet, srv.URL, nil, &out)
+	if out.ID != "g1" || out.ExpiresAt != "soon" {
+		t.Fatalf("decoded %+v, want {g1 soon}", out)
+	}
+	if len(rb) == 0 {
+		t.Error("doJSON returned no raw bytes")
+	}
+}
+
+// TestDoJSONAccepts2xx: a 201 Created (what POST .../grants returns) is a success,
+// not an error — a naive `!= 200` check would have wrongly failed it.
+func TestDoJSONAccepts2xx(t *testing.T) {
+	var gotBody bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = r.ContentLength > 0 && r.Header.Get("Content-Type") == "application/json"
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"g1"}`)
+	}))
+	defer srv.Close()
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	doJSON(srv.Client(), http.MethodPost, srv.URL, map[string]any{"allow": "^ls"}, &out)
+	if out.ID != "g1" {
+		t.Fatalf("id=%q, want g1", out.ID)
+	}
+	if !gotBody {
+		t.Error("a non-nil reqBody must be sent as application/json")
+	}
+}
+
+// TestDoJSONBoundsResponse: a peer streaming more than the cap must not make the
+// CLI read without limit — doJSON stops at maxRespBytes (#212).
+func TestDoJSONBoundsResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(make([]byte, maxRespBytes+4096))
+	}))
+	defer srv.Close()
+
+	rb := doJSON(srv.Client(), http.MethodGet, srv.URL, nil, nil) // nil out → no decode
+	if len(rb) != maxRespBytes {
+		t.Fatalf("read %d bytes, want the %d-byte cap", len(rb), maxRespBytes)
+	}
+}

--- a/cmd/broker-ctl/main.go
+++ b/cmd/broker-ctl/main.go
@@ -24,8 +24,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/ed25519"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -44,6 +42,7 @@ import (
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/auth"
 	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/version"
 )
@@ -581,7 +580,9 @@ func fetchRemoteHosts(client *http.Client, base string) (map[string]hostEntry, e
 		return nil, fmt.Errorf("GET %s/v1/policy/hosts: %w", base, err)
 	}
 	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
+	// This helper returns a tailored error+hint rather than fatalf, so it stays
+	// off the shared doJSON path — but the read is bounded the same way (#212).
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("signer rejected the request (HTTP %d): %s\nhint: the client cert CN must be in the signer's reload_callers (GET /v1/hosts is the caller-scoped connectivity view)",
 			resp.StatusCode, strings.TrimSpace(string(rb)))
@@ -1089,7 +1090,7 @@ func approvalFlags(fs *flag.FlagSet) (url, cert, key, ca *string) {
 }
 
 func approvalClient(cert, key, ca string) *http.Client {
-	tlsCfg, err := buildTLSConfig(cert, key, ca)
+	tlsCfg, err := auth.ClientTLSConfig(cert, key, ca)
 	if err != nil {
 		fatalf("TLS: %v", err)
 	}
@@ -1104,15 +1105,7 @@ func cmdApprovalList(args []string) {
 	resolveControlPlaneTarget(fs)
 
 	client := approvalClient(*cert, *key, *ca)
-	resp, err := client.Get("https://" + *url + "/v1/approvals")
-	if err != nil {
-		fatalf("GET /v1/approvals: %v", err)
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("control plane returned %d: %s", resp.StatusCode, bytes.TrimSpace(body))
-	}
+	body := doJSON(client, http.MethodGet, "https://"+*url+"/v1/approvals", nil, nil)
 	if *asJSON {
 		fmt.Println(string(body))
 		return
@@ -1182,18 +1175,8 @@ func cmdApprovalDecide(args []string, approve bool) {
 		body["learn"] = true
 		body["ttl_seconds"] = int(learnTTL.Seconds())
 	}
-	payload, _ := json.Marshal(body)
-
 	client := approvalClient(*cert, *key, *ca)
-	resp, err := client.Post("https://"+*url+"/v1/approvals/"+id, "application/json", bytes.NewReader(payload))
-	if err != nil {
-		fatalf("POST /v1/approvals/%s: %v", id, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("control plane rejected decision (HTTP %d): %s", resp.StatusCode, bytes.TrimSpace(rb))
-	}
+	doJSON(client, http.MethodPost, "https://"+*url+"/v1/approvals/"+id, body, nil)
 	verb := "denied"
 	if approve {
 		verb = "approved"
@@ -1369,26 +1352,7 @@ func readSignerURL(configPath string) (string, error) {
 	return cfg.Listen, nil
 }
 
-// ── TLS / PID helpers ─────────────────────────────────────────────────────────
-
-func buildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, fmt.Errorf("loading client cert: %w", err)
-	}
-	caData, err := os.ReadFile(caFile)
-	if err != nil {
-		return nil, fmt.Errorf("reading CA: %w", err)
-	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(caData) {
-		return nil, errors.New("invalid CA PEM")
-	}
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      pool,
-	}, nil
-}
+// ── PID helpers ───────────────────────────────────────────────────────────────
 
 func readPID(pidFile string) (int, error) {
 	data, err := os.ReadFile(pidFile)

--- a/cmd/broker-ctl/policy.go
+++ b/cmd/broker-ctl/policy.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -14,6 +12,7 @@ import (
 	"time"
 
 	"github.com/luisgf/infrabroker/internal/audit"
+	"github.com/luisgf/infrabroker/internal/auth"
 	"github.com/luisgf/infrabroker/internal/confcheck"
 	"github.com/luisgf/infrabroker/internal/policyrec"
 	"github.com/luisgf/infrabroker/internal/signer"
@@ -77,7 +76,7 @@ func policyHTTP(url, cert, key, ca string) (*http.Client, string) {
 		}
 		url = s
 	}
-	tlsCfg, err := buildTLSConfig(cert, key, ca)
+	tlsCfg, err := auth.ClientTLSConfig(cert, key, ca)
 	if err != nil {
 		fatalf("TLS: %v", err)
 	}
@@ -110,29 +109,14 @@ func cmdPolicyGrant(args []string) {
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
 	endpoint := base + "/v1/policy/hosts/" + url.PathEscape(*host) + "/grants"
-	body, _ := json.Marshal(map[string]any{
-		"allow": []string{*allow}, "ttl_seconds": int(ttl.Seconds()),
-		"caller": *scopeCaller, "end_user": *scopeUser,
-	})
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		fatalf("request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		fatalf("POST %s: %v", endpoint, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusCreated {
-		fatalf("signer rejected the grant (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
 	var result struct {
 		ID        string `json:"id"`
 		ExpiresAt string `json:"expires_at"`
 	}
-	_ = json.Unmarshal(rb, &result)
+	doJSON(client, http.MethodPost, endpoint, map[string]any{
+		"allow": []string{*allow}, "ttl_seconds": int(ttl.Seconds()),
+		"caller": *scopeCaller, "end_user": *scopeUser,
+	}, &result)
 	fmt.Printf("granted on %s: allow %q for %s (id %s, expires %s)\n",
 		*host, *allow, *ttl, result.ID, result.ExpiresAt)
 }
@@ -150,15 +134,7 @@ func cmdPolicyGrants(args []string) {
 	resolveSignerTarget(fs)
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
-	resp, err := client.Get(base + "/v1/policy/grants")
-	if err != nil {
-		fatalf("GET %s/v1/policy/grants: %v", base, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the request (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
+	rb := doJSON(client, http.MethodGet, base+"/v1/policy/grants", nil, nil)
 	if *asJSON {
 		os.Stdout.Write(rb)
 		if len(rb) > 0 && rb[len(rb)-1] != '\n' {
@@ -227,19 +203,7 @@ func cmdPolicyRevoke(args []string) {
 
 	client, base := policyHTTP(*urlFlag, *cert, *key, *ca)
 	endpoint := base + "/v1/policy/grants/" + url.PathEscape(id)
-	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
-	if err != nil {
-		fatalf("request: %v", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		fatalf("DELETE %s: %v", endpoint, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the revoke (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
+	doJSON(client, http.MethodDelete, endpoint, nil, nil)
 	fmt.Printf("revoked grant %s\n", id)
 }
 
@@ -274,25 +238,10 @@ func cmdPolicyMutate(args []string, add bool) {
 	if !add {
 		method = http.MethodDelete
 	}
-	body, _ := json.Marshal(map[string]string{"pattern": *allow})
-	req, err := http.NewRequest(method, endpoint, bytes.NewReader(body))
-	if err != nil {
-		fatalf("request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		fatalf("%s %s: %v", method, endpoint, err)
-	}
-	defer resp.Body.Close()
-	rb, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fatalf("signer rejected the change (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(rb)))
-	}
 	var result struct {
 		Hosts int `json:"hosts"`
 	}
-	_ = json.Unmarshal(rb, &result)
+	doJSON(client, method, endpoint, map[string]string{"pattern": *allow}, &result)
 	fmt.Printf("allow %q %s on %s (hosts: %d)\n", *allow, past, *host, result.Hosts)
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -89,6 +89,17 @@
   freeze that the API acknowledged survives power loss. Grants and approve-and-learn
   waivers stay `NORMAL` — a lost widening fails safe.
 
+### Internal
+- **broker-ctl HTTP/TLS de-duplication + bounded response reads (#212)** — the
+  ~marshal → request → read → status-check → decode block that every `broker-ctl`
+  command repeated is now a single `doJSON` helper, and every response read is
+  bounded (`io.LimitReader`, 4 MiB) instead of an unbounded `io.ReadAll`, matching
+  the internal clients — a hostile or malfunctioning signer/control-plane can no
+  longer make the CLI allocate without limit. `broker-ctl` also drops its private
+  `buildTLSConfig` for the shared `internal/auth.ClientTLSConfig`, which pins
+  **TLS 1.3** as the client minimum (the old copy set none). No command behaviour
+  or output changes.
+
 ## [v2.1.0] - 2026-07-10
 
 Correctness and hardening follow-up to the v2.0.0 secure-by-default major: the


### PR DESCRIPTION
## Summary

Every `broker-ctl` command repeated the same `marshal → NewRequest → Do → ReadAll
→ status-check → Unmarshal` block, and each read used an **unbounded** `io.ReadAll`
— inconsistent with the `io.LimitReader`-bounded internal clients
(`internal/signer/remote`, `internal/bridge/cpclient`).

## Change

- **`doJSON(client, method, url, reqBody, out)`** (new `httpjson.go`): marshals
  `reqBody` when non-nil (Content-Type `application/json`), reads the response
  **bounded to `maxRespBytes` (4 MiB)**, `fatalf`s on a transport error or non-2xx
  status, decodes into `out` when non-nil, and returns the raw bytes for `--json`
  passthroughs / conditional decodes.
- All **10** call sites across `cluster.go` / `freeze.go` / `policy.go` /
  `main.go` go through it. `fetchRemoteHosts` keeps its tailored error+hint but
  its read is bounded the same way → **all 11** previously-unbounded reads are now
  capped.
- Status check accepts any **2xx** (POST `.../grants` returns **201**), preserving
  the one non-200 success path.
- Drops broker-ctl's private `buildTLSConfig` for the shared
  `internal/auth.ClientTLSConfig`, which additionally pins **TLS 1.3** as the
  client minimum (the removed copy set none).

**No command behaviour or output changes.** Net: the call sites shrink, one mTLS
duplicate and 11 unbounded reads go away.

## Acceptance criterion (issue)

> broker-ctl HTTP calls go through one helper; all response reads are size-bounded.

Both met. Tests (`httpjson_test.go`) cover the happy-path decode, 2xx acceptance,
and the response-size bound.

`make verify` green (gofmt, vet, build, race tests, govulncheck clean, docs gate).

Closes #212