### PR TITLE
docs(audit): document WORM/SIEM export sidecar pattern + Vector reference (#139)

### DIFF
--- a/deploy/vector.example.toml
+++ b/deploy/vector.example.toml
@@ -1,0 +1,68 @@
+# infrabroker — reference log-shipper config for exporting the signed audit log
+# to WORM (S3 Object Lock) and, optionally, a SIEM.
+# See docs/OPERATIONS.md § "Exporting the audit log to WORM / SIEM".
+#
+# This is a STARTING POINT, not a drop-in: adjust the paths, bucket, region and
+# endpoints, and validate it in your environment before deploying:
+#     vector validate deploy/vector.example.toml
+#
+# The audit log is append-only JSONL — one Ed25519-signed, hash-chained entry per
+# line. Ship each line VERBATIM and IN ORDER: do not parse-and-re-encode it, and
+# do not reorder lines, so the exported copy stays verifiable with
+#     broker-ctl audit verify --all --key <seed>
+# Secrets are already redacted before an entry is signed, so nothing sensitive
+# leaves the host (see the redact config).
+
+data_dir = "/var/lib/vector"
+
+# ── Source: the active audit file(s) plus their rotated segments ──────────────
+# Rotation writes <log>.<YYYYMMDDTHHMMSSZ>[.<n>] segments; the globs follow both
+# the live file and every segment. The audit-repair quarantine file
+# (<log>.corrupt-*) is excluded — it is quarantined, not part of the chain.
+[sources.infrabroker_audit]
+type = "file"
+include = [
+  "/var/lib/infrabroker/signer/audit.log*",
+  "/var/lib/infrabroker/signer/signer_audit.log*",
+]
+exclude = ["/var/lib/infrabroker/signer/*.corrupt-*"]
+read_from = "beginning"
+# Follow a file across the rotation rename rather than re-reading the new inode.
+fingerprint.strategy = "device_and_inode"
+
+# ── WORM sink: S3 with Object Lock (immutable, tamper-proof retention) ─────────
+# The authoritative archive. The bucket MUST have Object Lock enabled with a
+# retention rule (e.g. COMPLIANCE mode, N days) so a host compromise cannot delete
+# or rewrite already-shipped records. Vector writes gzipped batches of the raw
+# lines; reassemble them in key order to run `broker-ctl audit verify --all`.
+# Credentials come from the standard AWS chain (prefer an IAM role, not static keys).
+[sinks.audit_worm_s3]
+type = "aws_s3"
+inputs = ["infrabroker_audit"]
+bucket = "my-infrabroker-audit"
+region = "eu-west-1"
+key_prefix = "audit/%Y/%m/%d/"
+compression = "gzip"
+encoding.codec = "text" # emit the raw line (.message) verbatim — never re-encode
+
+# ── SIEM sink (optional): syslog over TLS for search / alerting ───────────────
+# Best-effort operational visibility — dashboards and alerts on outcome=denied,
+# anomaly=…, approval_* — NOT the authoritative copy (that is the WORM archive
+# above; syslog may reorder or truncate long lines).
+# [sinks.audit_siem_syslog]
+# type = "socket"
+# inputs = ["infrabroker_audit"]
+# mode = "tcp"
+# address = "siem.internal:6514"
+# encoding.codec = "text"
+# tls.enabled = true
+
+# ── SIEM sink (optional): Grafana Loki ────────────────────────────────────────
+# [sinks.audit_siem_loki]
+# type = "loki"
+# inputs = ["infrabroker_audit"]
+# endpoint = "https://loki.internal:3100"
+# encoding.codec = "text"
+# [sinks.audit_siem_loki.labels]
+# app = "infrabroker"
+# path = "{{ file }}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,14 @@
   --shell-parse=false` authors the opt-out.
 
 ### Added
+- **Audit-log export to WORM / SIEM — documented sidecar pattern (#139)** — the
+  signed, hash-chained audit JSONL can now be shipped off-host with a standard log
+  shipper as a **sidecar**: a new OPERATIONS section ("Exporting the audit log to
+  WORM / SIEM") plus a ready-to-adapt `deploy/vector.example.toml` cover shipping to
+  **S3 Object Lock** (immutable, authoritative — the exported copy still passes
+  `broker-ctl audit verify --all`) and to **syslog / Loki** for SIEM search and
+  alerting. infrabroker does not push logs itself, so a slow or unreachable SIEM
+  never blocks an action; secrets are already redacted before an entry is signed.
 - **Approval-bridge four-eyes via `--identity-map` (#214)** — the control plane's
   self-approval guard compares the request's originator against the *bridge's*
   approver CN, which never collides, so a human who both originated a request and

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -239,7 +239,12 @@ política, transporte, auditoría, CLI y documentación generada.
   continúa; toggle para bloquear emisión/ejecución sin traza (gap #9). Desde
   v1.26.0 el fallo es observable: contador `audit_append_failures_total` en
   `/metrics` (`monitor_listen`) — alertar sobre cualquier incremento.
-- [ ] **Logs a almacenamiento WORM** (S3/GCS/Loki/SIEM).
+- [x] **Logs a almacenamiento WORM** (S3/GCS/Loki/SIEM) (#139): patrón **sidecar**
+  documentado en OPERATIONS § "Exporting the audit log to WORM / SIEM" + config de
+  referencia `deploy/vector.example.toml`. infrabroker no empuja logs (nunca bloquea
+  el path fail-closed); el shipper tailea el JSONL firmado y la copia exportada
+  sigue pasando `broker-ctl audit verify --all`. Construir un exporter integrado se
+  descartó por menor valor/mantenimiento frente a Vector/Fluent Bit.
 - [ ] **Sesiones/aprobaciones multi-instancia**: externalizar estado a Redis (gap #5).
 - [x] **`default_deny` en `callers`** (v2.0.0): una tabla `callers` no vacía es
   autoritativa y default-deny — un CN no listado no ve ningún host. `_default` con
@@ -256,7 +261,10 @@ política, transporte, auditoría, CLI y documentación generada.
   verify --all` (v1.13.0) ya detecta el borrado de un segmento rotado y el truncado
   del fichero activo cuando existen segmentos; queda el caso residual de truncar el
   ÚNICO fichero sin rotaciones (indistinguible de una instalación nueva sin un head
-  persistido fuera del log).
+  persistido fuera del log). El export WORM documentado (#139, OPERATIONS §
+  "Exporting the audit log to WORM / SIEM") lo **mitiga**: la copia inmutable
+  off-host conserva el head, así que el truncado del fichero local se detecta
+  comparando contra el archivo WORM.
 - [ ] **`allowed_sudo_commands` por host** como segunda capa.
 - [ ] **Rutas `/home/luislgf` en config.json/signer.json** mientras la máquina es
   macOS (`/Users/luislgf`) — revisar si son de la máquina Linux o están rotas.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -722,6 +722,45 @@ broker-ctl audit verify --log signer_audit.log --key pki/signer_audit.seed
 broker-ctl audit verify --log audit.log --all --key pki/audit.seed
 ```
 
+#### Exporting the audit log to WORM / SIEM
+
+The audit trail is a local append-only JSONL file — one Ed25519-signed,
+hash-chained entry per line — plus `/metrics`. To retain it off-host in immutable
+(WORM) storage and/or feed a SIEM, run a standard log shipper as a **sidecar**
+that tails the file. infrabroker deliberately does **not** push logs itself, so a
+slow or unreachable SIEM can never block an action: the local file stays the
+fail-closed source of truth, and the shipper only reads it.
+
+Two distinct goals, best served by two sinks:
+
+- **WORM archive (authoritative).** Ship to **S3 Object Lock** (or GCS retention)
+  so a host compromise cannot delete or rewrite already-exported records. Combined
+  with the per-entry signatures and hash chain, the archive is both
+  **tamper-proof** (Object Lock) and **tamper-evident** (the chain): pull a copy
+  back and run `broker-ctl audit verify --all --key <seed>` to prove it is intact
+  and complete.
+- **SIEM (search / alerting).** Ship to **syslog / Loki / a generic HTTP sink**
+  for dashboards and alerts on `outcome=denied`, `anomaly=…`, `approved_by=…`.
+  Best-effort operational visibility, not the authoritative copy.
+
+What to ship, and how:
+
+- **Include the rotated segments.** Rotation renames the file to
+  `<log>.<YYYYMMDDTHHMMSSZ>` (with a `.<n>` suffix on same-second collisions), so
+  glob `audit.log*` to follow the live file and every segment. Exclude the
+  audit-repair quarantine file `<log>.corrupt-*` — it is quarantined, not part of
+  the chain.
+- **Ship each line verbatim and in order.** Do not parse-and-re-encode the JSON or
+  reorder lines: each line carries its own signature and links to the previous via
+  `prev_hash`, so byte-exact lines in sequence are what `audit verify` checks.
+- **Secrets are already redacted** before an entry is signed, so no secret
+  material leaves the host (see the `redact` config).
+
+A ready-to-adapt **Vector** reference for the S3-Object-Lock + syslog/Loki pattern
+is in `deploy/vector.example.toml` — validate it with `vector validate` first. The
+same sidecar pattern works with any shipper (Fluent Bit, Filebeat, Promtail,
+rsyslog).
+
 #### Recovering a torn audit log (signer won't boot)
 
 The signer is **fail-closed** on audit-log corruption. If a crash or power loss


### PR DESCRIPTION
## Summary

The signed, hash-chained audit JSONL was local-only (plus `/metrics`); shipping it
to WORM/SIEM was left entirely to the operator with no guidance. Per the design
decision, this ships the **documented sidecar pattern** rather than a built-in
per-sink exporter (which would add buffering/retry/credential surface, a
maintenance tail, and risk entangling the fail-closed `Append` path — all of which
mature shippers already handle).

## What's delivered

- **OPERATIONS § "Exporting the audit log to WORM / SIEM"** — the guarantees and
  the operational rules.
- **`deploy/vector.example.toml`** — a ready-to-adapt Vector reference for the
  S3-Object-Lock + syslog/Loki pattern (validate with `vector validate` first).

Two goals, two sinks:
- **WORM archive (authoritative)** via **S3 Object Lock** — the exported copy stays
  chain-verifiable with `broker-ctl audit verify --all`, so it is both
  **tamper-proof** (Object Lock) and **tamper-evident** (the chain).
- **SIEM (search/alerting)** via syslog / Loki — best-effort, not authoritative.

Key rules documented: glob the rotated segments (`<log>.<ts>[.<n>]`), exclude the
`<log>.corrupt-*` quarantine file, and **ship each line verbatim and in order** so
the per-entry signatures and `prev_hash` links still verify. infrabroker does not
push logs itself, so a slow/unreachable SIEM never blocks an action; secrets are
already redacted before signing.

`HANDOFF.md`: the WORM-export roadmap item is marked done, and the residual
"external head anchoring" case is noted as mitigated by the off-host immutable copy.

Docs-only: `make verify` green (docs gate rebuilds mkdocs `--strict`, govulncheck clean).

Closes #139