### PR TITLE
feat(init): infrabroker init generates the local PKI + two-service config (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,13 @@ make install                 # → ~/bin/{infrabroker,signer,broker,broker-ctl,m
 # or a single binary:        make signer
 # (plain `go build ./cmd/...` also works; it reports a dev-<commit> version)
 
-# 2. Start the signing service (must be running before the broker)
+# 2. Generate the local PKI + the two-service config (signer.json + config.json)
+infrabroker init             # writes pki/, signer.json, config.json; --force to redo
+
+# 3. Start the signing service (must be running before the broker)
 ./signer.sh start
 
-# 3. Add a host and reload
+# 4. Add a host and reload
 broker-ctl host add --name web01 --addr web01.example.com:22 --user deploy --scan \
   --groups prod-web --sudo
 broker-ctl reload

--- a/cmd/infrabroker/main.go
+++ b/cmd/infrabroker/main.go
@@ -17,6 +17,7 @@ import (
 	"os"
 
 	"github.com/luisgf/infrabroker/internal/brokermain"
+	"github.com/luisgf/infrabroker/internal/initcmd"
 	"github.com/luisgf/infrabroker/internal/version"
 )
 
@@ -26,6 +27,8 @@ func main() {
 		os.Exit(2)
 	}
 	switch os.Args[1] {
+	case "init":
+		initcmd.Run(os.Args[2:])
 	case "serve-http":
 		brokermain.RunHTTP(os.Args[2:])
 	case "serve-mcp":
@@ -56,6 +59,7 @@ func usage() {
 	fmt.Fprint(os.Stderr, `infrabroker — unified broker frontend
 
 Usage:
+  infrabroker init            [--dir .] [--force]      generate a local PKI + two-service config
   infrabroker serve-http      [-config config.json]   HTTP + mTLS (POST /v1/ssh_run)
   infrabroker serve-mcp       [-config config.json]   MCP over stdio (local)
   infrabroker serve-mcp-http  [-config config.json]   MCP over HTTP + OAuth2/OIDC

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,15 @@
   `internal/brokermain`.
 
 ### Added
+- **`infrabroker init` — one-command local setup (#136, phase 1)** — generates the
+  local PKI (SSH CA, broker↔signer mTLS pair, audit seeds — pure Go, no
+  ssh-keygen/openssl) and writes a custody-separated two-service config
+  (`signer.json` holding the SSH CA + a default-deny starter policy, and a
+  remote-mode broker `config.json` holding no CA key), wired with the correct
+  default-deny `callers`/groups so the local broker is authorised. Refuses to
+  clobber an existing setup without `--force`, best-effort adds a `localhost`
+  starter host, and prints the per-host sshd enrolment snippet. The `~/.ssh/config`
+  bulk import and `claude mcp add` auto-registration are a follow-up (phase 2).
 - **Audit-log export to WORM / SIEM — documented sidecar pattern (#139)** — the
   signed, hash-chained audit JSONL can now be shipped off-host with a standard log
   shipper as a **sidecar**: a new OPERATIONS section ("Exporting the audit log to

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -24,6 +24,12 @@ for the security posture see [THREAT_MODEL.md](THREAT_MODEL.md).
 ```bash
 cd /path/to/infrabroker
 
+# 0. First-time setup: generate the local PKI + the custody-separated two-service
+#    config (signer.json holds the SSH CA + policy; config.json is the remote-mode
+#    broker). Pure-Go, no ssh-keygen/openssl. Re-run with --force to regenerate.
+#    (This is a local PEM CA — lab/dev custody; see §8 for separated/HSM custody.)
+infrabroker init         # writes pki/, signer.json, config.json in the current dir
+
 # 1. Start the signer (must be running before the broker starts)
 ./signer.sh start        # background, PID in signer.pid, log in signer.log
 ./signer.sh status

--- a/internal/initcmd/config.go
+++ b/internal/initcmd/config.go
@@ -1,0 +1,150 @@
+package initcmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// localGroup is the RBAC group tying the broker caller to the starter host: the
+// broker-local caller's allowed_groups and the host's groups must intersect or
+// the v2.0.0 default-deny callers table hides the host.
+const localGroup = "local"
+
+// signerURL is the localhost mTLS endpoint the broker dials.
+const signerURL = "https://127.0.0.1:9443"
+
+// starterHost is an optional first host written into signer.json.
+type starterHost struct {
+	name, addr, user, hostKey string
+}
+
+// signerJSON is the exact wire shape of the emitted signer.json. Sub-structures
+// reuse the real exported types (signer.CallerPolicy / signer.CommandPolicy) so
+// they cannot drift from the schema the signer loads.
+type signerJSON struct {
+	Listen               string                          `json:"listen"`
+	ServerCert           string                          `json:"server_cert"`
+	ServerKey            string                          `json:"server_key"`
+	ClientCA             string                          `json:"client_ca"`
+	CAKey                string                          `json:"ca_key"`
+	AuditLog             string                          `json:"audit_log"`
+	AuditKey             string                          `json:"audit_key"`
+	AuditFailMode        string                          `json:"audit_fail_mode"`
+	MaxTTLSeconds        int                             `json:"max_ttl_seconds"`
+	MonitorListen        string                          `json:"monitor_listen"`
+	ReloadCallers        []string                        `json:"reload_callers"`
+	Callers              map[string]signer.CallerPolicy  `json:"callers"`
+	CommandPolicies      map[string]signer.CommandPolicy `json:"command_policies"`
+	GroupCommandPolicies map[string][]string             `json:"group_command_policies"`
+	Hosts                map[string]hostJSON             `json:"hosts"`
+}
+
+// hostJSON is the subset of the host entry init emits (a functional connectable
+// host); it round-trips into signer.HostPolicy.
+type hostJSON struct {
+	Addr      string   `json:"addr"`
+	User      string   `json:"user"`
+	HostKey   string   `json:"host_key"`
+	Principal string   `json:"principal"`
+	Groups    []string `json:"groups"`
+}
+
+// brokerJSON is the lean remote/stdio broker config: it points at the signer and
+// holds NO CA key and NO host list (hosts are fetched via GET /v1/hosts).
+type brokerJSON struct {
+	Signer                signerClientJSON `json:"signer"`
+	AuditLog              string           `json:"audit_log"`
+	AuditKey              string           `json:"audit_key"`
+	AuditFailMode         string           `json:"audit_fail_mode"`
+	MaxTTLSeconds         int              `json:"max_ttl_seconds"`
+	HostsRefreshSeconds   int              `json:"hosts_refresh_seconds"`
+	RevocationPollSeconds int              `json:"revocation_poll_seconds"`
+	SessionIdleSeconds    int              `json:"session_idle_seconds"`
+	SessionMaxSeconds     int              `json:"session_max_seconds"`
+	MonitorListen         string           `json:"monitor_listen"`
+}
+
+type signerClientJSON struct {
+	URL        string `json:"url"`
+	ClientCert string `json:"client_cert"`
+	ClientKey  string `json:"client_key"`
+	CA         string `json:"ca"`
+}
+
+// buildSignerJSON assembles the signer config: CA custody + a default-deny
+// starter policy on the reserved _default group + the broker-local caller + the
+// optional starter host. All PKI paths are relative to the init dir.
+func buildSignerJSON(host *starterHost) signerJSON {
+	allow := "^uptime$"
+	s := signerJSON{
+		Listen:        ":9443",
+		ServerCert:    "pki/signer.crt",
+		ServerKey:     "pki/signer.key",
+		ClientCA:      "pki/mtls_ca.crt",
+		CAKey:         "pki/ssh_ca",
+		AuditLog:      "signer_audit.log",
+		AuditKey:      "pki/signer_audit.seed",
+		AuditFailMode: "closed",
+		MaxTTLSeconds: 300,
+		MonitorListen: "127.0.0.1:9160",
+		// broker-local doubles as the reload/admin CN (broker-ctl uses pki/broker.*).
+		ReloadCallers: []string{brokerCN},
+		Callers: map[string]signer.CallerPolicy{
+			brokerCN: {AllowedGroups: []string{localGroup}},
+		},
+		// Default-deny: an allowlist matching only `uptime`; everything else is
+		// denied. Attached to _default so it covers every host, now and future.
+		CommandPolicies: map[string]signer.CommandPolicy{
+			"starter-deny": {Mode: signer.CmdPolicyAllowlist, Allow: []string{allow}},
+		},
+		GroupCommandPolicies: map[string][]string{
+			// "_default" is the reserved group that applies to every host.
+			"_default": {"starter-deny"},
+		},
+		Hosts: map[string]hostJSON{},
+	}
+	if host != nil {
+		s.Hosts[host.name] = hostJSON{
+			Addr:      host.addr,
+			User:      host.user,
+			HostKey:   host.hostKey,
+			Principal: "host:" + host.name,
+			Groups:    []string{localGroup},
+		}
+	}
+	return s
+}
+
+// buildBrokerJSON assembles the remote-mode broker config (custody-separated: no
+// CA key). Its client cert CN (broker-local) is the caller in signer.json.
+func buildBrokerJSON() brokerJSON {
+	return brokerJSON{
+		Signer: signerClientJSON{
+			URL:        signerURL,
+			ClientCert: "pki/broker.crt",
+			ClientKey:  "pki/broker.key",
+			CA:         "pki/mtls_ca.crt",
+		},
+		AuditLog:              "audit.log",
+		AuditKey:              "pki/audit.seed",
+		AuditFailMode:         "closed",
+		MaxTTLSeconds:         300,
+		HostsRefreshSeconds:   30,
+		RevocationPollSeconds: 10,
+		SessionIdleSeconds:    300,
+		SessionMaxSeconds:     1800,
+		MonitorListen:         "127.0.0.1:9180",
+	}
+}
+
+// writeJSONConfig marshals v (indented) and writes it at 0640.
+func writeJSONConfig(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(path, b, 0o640)
+}

--- a/internal/initcmd/enroll.go
+++ b/internal/initcmd/enroll.go
@@ -1,0 +1,26 @@
+package initcmd
+
+import "fmt"
+
+// enrollSnippet returns copy-paste shell to enrol a managed host's sshd: trust
+// the generated SSH CA and map the certificate principal to a login account. Run
+// once per managed host. caPub is the contents of pki/ssh_ca.pub (it already ends
+// in a newline).
+func enrollSnippet(caPub []byte, user, principal string) string {
+	return fmt.Sprintf(`# On each managed host (as root): trust the infrabroker SSH CA and map the
+# certificate principal to the login account.
+
+sudo tee /etc/ssh/infrabroker_ca.pub >/dev/null <<'CAKEY'
+%sCAKEY
+
+sudo install -d -m 755 /etc/ssh/auth_principals
+echo %s | sudo tee /etc/ssh/auth_principals/%s >/dev/null
+
+# Add to /etc/ssh/sshd_config (or a drop-in under sshd_config.d/) and reload sshd:
+#   TrustedUserCAKeys /etc/ssh/infrabroker_ca.pub
+#   AuthorizedPrincipalsFile /etc/ssh/auth_principals/%%u
+#   LogLevel VERBOSE
+# The login account (%s) must exist on the host; for sudo access add a NOPASSWD
+# sudoers entry (e.g. "%s ALL=(root) NOPASSWD: ALL").
+`, caPub, principal, user, user, user)
+}

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -1,0 +1,160 @@
+// Package initcmd implements `infrabroker init`: one command that generates a
+// local PKI and writes a custody-separated two-service config (a signer that
+// holds the SSH CA + a broker in remote mode), installs a default-deny starter
+// policy, and prints the per-host sshd enrolment snippet — the fast path from
+// zero to a policy-gated agent. It does NOT do remote enrolment (that stays a
+// printed snippet), bulk ~/.ssh/config import, or MCP auto-registration.
+package initcmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// Run executes `infrabroker init` with args (everything after the subcommand).
+// It exits the process (fatalf) on any error.
+func Run(args []string) {
+	fs := flag.NewFlagSet("infrabroker init", flag.ExitOnError)
+	dir := fs.String("dir", ".", "directory to write the PKI and configs into")
+	force := fs.Bool("force", false, "overwrite an existing PKI/config in --dir")
+	_ = fs.Parse(args)
+
+	host, err := generate(*dir, *force)
+	if err != nil {
+		fatalf("%v", err)
+	}
+	printNextSteps(*dir, filepath.Join(*dir, "pki"), host)
+}
+
+// generate does the file-producing work of init and returns the starter host (or
+// nil). Split from Run — which handles flags and prints — so it is testable
+// without exiting the process. Returns an error (not fatalf) so idempotency and
+// failure paths can be asserted.
+func generate(root string, force bool) (*starterHost, error) {
+	pkiDir := filepath.Join(root, "pki")
+
+	// Idempotency: never silently clobber an existing setup.
+	if !force {
+		for _, p := range []string{filepath.Join(root, "signer.json"), filepath.Join(root, "config.json"), filepath.Join(pkiDir, "ssh_ca")} {
+			if _, err := os.Stat(p); err == nil {
+				return nil, fmt.Errorf("refusing to overwrite existing %s (pass --force to regenerate the PKI and configs)", p)
+			}
+		}
+	}
+	if err := os.MkdirAll(pkiDir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating %s: %w", pkiDir, err)
+	}
+	if err := generatePKI(pkiDir); err != nil {
+		return nil, fmt.Errorf("generating PKI: %w", err)
+	}
+
+	host := detectLocalhostHost()
+	if err := writeJSONConfig(filepath.Join(root, "signer.json"), buildSignerJSON(host)); err != nil {
+		return nil, fmt.Errorf("writing signer.json: %w", err)
+	}
+	if err := writeJSONConfig(filepath.Join(root, "config.json"), buildBrokerJSON()); err != nil {
+		return nil, fmt.Errorf("writing config.json: %w", err)
+	}
+	return host, nil
+}
+
+// detectLocalhostHost best-effort keyscans the local sshd for a functional
+// starter host. Returns nil (→ empty host list + guidance) if there is no local
+// sshd or ssh-keyscan is unavailable — init never fails on this.
+func detectLocalhostHost() *starterHost {
+	hk, err := keyscan("127.0.0.1", "22")
+	if err != nil {
+		return nil
+	}
+	return &starterHost{name: "localhost", addr: "127.0.0.1:22", user: currentUser(), hostKey: hk}
+}
+
+// keyscan mirrors broker-ctl's sshKeyscan (cmd/broker-ctl/main.go): fetch the
+// host's ed25519 key and strip the leading hostname, yielding the two-field
+// "ssh-ed25519 AAAA..." form the host_key field stores.
+func keyscan(host, port string) (string, error) {
+	out, err := exec.Command("ssh-keyscan", "-p", port, "-t", "ed25519", host).Output()
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if parts := strings.Fields(line); len(parts) >= 3 {
+			return strings.Join(parts[1:], " "), nil
+		}
+	}
+	return "", fmt.Errorf("ssh-keyscan returned no ed25519 key for %s", host)
+}
+
+func currentUser() string {
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		return u.Username
+	}
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	return "deploy"
+}
+
+func printNextSteps(root, pkiDir string, host *starterHost) {
+	abs := func(p string) string {
+		if a, err := filepath.Abs(p); err == nil {
+			return a
+		}
+		return p
+	}
+	fmt.Printf(`infrabroker init: wrote the local PKI and two-service config into %s
+
+  pki/          SSH CA, mTLS pair, audit seeds  (lab/dev custody — keys are 0600)
+  signer.json   the signer: holds the SSH CA key + policy
+  config.json   the broker: remote mode, holds NO CA key
+
+Start the two services (run from %s):
+  signer      -config signer.json
+  infrabroker serve-mcp -config config.json          # or serve-http / serve-mcp-http
+
+Register the stdio MCP with Claude Code:
+  claude mcp add infrabroker -- %s serve-mcp -config %s
+
+`, root, root, abs(selfPath()), abs(filepath.Join(root, "config.json")))
+
+	if host != nil {
+		caPub, _ := os.ReadFile(filepath.Join(pkiDir, "ssh_ca.pub"))
+		fmt.Printf(`A starter host %q (%s@%s) was added. The default-deny policy allows only
+`+"`uptime`"+` until you widen it — e.g. broker-ctl policy grant --host %s --allow '^systemctl status '.
+
+Enrol its sshd so it trusts the CA:
+
+%s`, host.name, host.user, host.addr, host.name, enrollSnippet(caPub, host.user, "host:"+host.name))
+	} else {
+		fmt.Print(`No local sshd was reachable, so no starter host was added. Add your first host:
+  broker-ctl host add --name web01 --addr web01.example.com:22 --user deploy --scan --groups local
+then enrol its sshd (see docs/OPERATIONS.md § Remote host configuration).
+
+`)
+	}
+
+	fmt.Print("Note: this is a local PEM CA (lab/dev custody); the signer logs a \"lab use only\"\nwarning. For separated/HSM custody see docs/OPERATIONS.md.\n")
+}
+
+// selfPath returns the path to the running infrabroker binary, for the printed
+// `claude mcp add` line; falls back to the plain name.
+func selfPath() string {
+	if p, err := os.Executable(); err == nil {
+		return p
+	}
+	return "infrabroker"
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "infrabroker init: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/internal/initcmd/initcmd_test.go
+++ b/internal/initcmd/initcmd_test.go
@@ -1,0 +1,145 @@
+package initcmd
+
+import (
+	"crypto/ed25519"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luisgf/infrabroker/internal/broker"
+	"github.com/luisgf/infrabroker/internal/ca"
+	"github.com/luisgf/infrabroker/internal/signer"
+)
+
+// TestGenerateProducesLoadableArtifacts is the core guarantee: `init` emits a PKI
+// and configs that the real loaders accept, so `signer -config …` + `infrabroker
+// serve-* -config …` boot against them.
+func TestGenerateProducesLoadableArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := generate(dir, false); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	pki := filepath.Join(dir, "pki")
+
+	// The broker config loads via the real exported loader (validates field names
+	// and confcheck strictness) and is remote-mode (no CA key).
+	bcfg, err := broker.LoadConfig(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("broker.LoadConfig: %v", err)
+	}
+	if bcfg.Signer == nil || bcfg.Signer.URL != signerURL {
+		t.Errorf("broker config signer block = %+v, want url %q", bcfg.Signer, signerURL)
+	}
+	if bcfg.CAKey != "" {
+		t.Errorf("remote broker must hold no CA key, got %q", bcfg.CAKey)
+	}
+
+	// The SSH CA loads in the exact OpenSSH-PEM form internal/ca expects.
+	caPEM, err := os.ReadFile(filepath.Join(pki, "ssh_ca"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ca.LoadCAFromPEM(caPEM); err != nil {
+		t.Fatalf("ca.LoadCAFromPEM(ssh_ca): %v", err)
+	}
+
+	// Both mTLS leaf pairs load, and the broker client cert verifies against the
+	// shared CA with the expected CN (which must equal the callers key).
+	if _, err := tls.LoadX509KeyPair(filepath.Join(pki, "signer.crt"), filepath.Join(pki, "signer.key")); err != nil {
+		t.Errorf("signer mTLS pair: %v", err)
+	}
+	brokerTLS, err := tls.LoadX509KeyPair(filepath.Join(pki, "broker.crt"), filepath.Join(pki, "broker.key"))
+	if err != nil {
+		t.Fatalf("broker mTLS pair: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(brokerTLS.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaf.Subject.CommonName != brokerCN {
+		t.Errorf("broker cert CN = %q, want %q", leaf.Subject.CommonName, brokerCN)
+	}
+	caPool := x509.NewCertPool()
+	caCrt, _ := os.ReadFile(filepath.Join(pki, "mtls_ca.crt"))
+	if !caPool.AppendCertsFromPEM(caCrt) {
+		t.Fatal("mtls_ca.crt not a valid CA PEM")
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: caPool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+		t.Errorf("broker cert does not verify against mtls_ca: %v", err)
+	}
+
+	// Audit seeds are raw >= 32 bytes (ed25519 seed size).
+	for _, s := range []string{"signer_audit.seed", "audit.seed"} {
+		b, err := os.ReadFile(filepath.Join(pki, s))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(b) < ed25519.SeedSize {
+			t.Errorf("%s is %d bytes, want >= %d", s, len(b), ed25519.SeedSize)
+		}
+	}
+
+	// The signer's hosts + default-deny policy compile through the real validator.
+	var sc struct {
+		Callers              map[string]signer.CallerPolicy  `json:"callers"`
+		CommandPolicies      map[string]signer.CommandPolicy `json:"command_policies"`
+		GroupCommandPolicies map[string][]string             `json:"group_command_policies"`
+		Hosts                signer.PolicyTable              `json:"hosts"`
+	}
+	sb, _ := os.ReadFile(filepath.Join(dir, "signer.json"))
+	if err := json.Unmarshal(sb, &sc); err != nil {
+		t.Fatalf("unmarshal signer.json: %v", err)
+	}
+	if _, err := signer.CompileHostPolicies(sc.Hosts, sc.CommandPolicies, sc.GroupCommandPolicies); err != nil {
+		t.Fatalf("signer.CompileHostPolicies on emitted signer.json: %v", err)
+	}
+	if g := sc.Callers[brokerCN].AllowedGroups; len(g) != 1 || g[0] != localGroup {
+		t.Errorf("callers[%q].allowed_groups = %v, want [%q]", brokerCN, g, localGroup)
+	}
+}
+
+// TestGenerateIsIdempotent: a second run without --force refuses; --force
+// regenerates.
+func TestGenerateIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := generate(dir, false); err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+	if _, err := generate(dir, false); err == nil {
+		t.Fatal("second generate without --force must refuse to overwrite")
+	}
+	if _, err := generate(dir, true); err != nil {
+		t.Fatalf("generate --force must overwrite: %v", err)
+	}
+}
+
+// TestBuildSignerJSONHostInvariant: when a starter host is present, its group
+// intersects the broker caller's allowed_groups (or default-deny hides it).
+func TestBuildSignerJSONHostInvariant(t *testing.T) {
+	s := buildSignerJSON(&starterHost{name: "localhost", addr: "127.0.0.1:22", user: "deploy", hostKey: "ssh-ed25519 AAAA"})
+	h, ok := s.Hosts["localhost"]
+	if !ok {
+		t.Fatal("starter host not written")
+	}
+	if h.Principal != "host:localhost" {
+		t.Errorf("principal = %q, want host:localhost", h.Principal)
+	}
+	callerGroups := s.Callers[brokerCN].AllowedGroups
+	if !intersects(h.Groups, callerGroups) {
+		t.Errorf("host groups %v do not intersect caller groups %v — default-deny would hide the host", h.Groups, callerGroups)
+	}
+}
+
+func intersects(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/initcmd/pki.go
+++ b/internal/initcmd/pki.go
@@ -1,0 +1,185 @@
+package initcmd
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// certValidity is the lifetime of every generated mTLS certificate. Long, because
+// this is a local dev/lab PKI a human regenerates with `infrabroker init --force`,
+// not a rotating production CA.
+const certValidity = 10 * 365 * 24 * time.Hour
+
+// brokerCN is the broker client-certificate CN. It MUST equal the key used for
+// the broker in the signer's `callers` table (config.go), or default-deny hides
+// every host from the broker.
+const brokerCN = "broker-local"
+
+// generatePKI writes the full local PKI into pkiDir: the SSH CA (that signs host
+// certificates), the shared mTLS CA and the signer/broker leaf certs for the
+// broker↔signer link, and the two per-service audit seeds. All pure Go — no
+// ssh-keygen/openssl.
+func generatePKI(pkiDir string) error {
+	if err := generateSSHCA(pkiDir); err != nil {
+		return fmt.Errorf("ssh ca: %w", err)
+	}
+	if err := generateMTLS(pkiDir); err != nil {
+		return fmt.Errorf("mtls: %w", err)
+	}
+	for _, seed := range []string{"signer_audit.seed", "audit.seed"} {
+		if err := generateAuditSeed(filepath.Join(pkiDir, seed)); err != nil {
+			return fmt.Errorf("audit seed %s: %w", seed, err)
+		}
+	}
+	return nil
+}
+
+// generateSSHCA writes the SSH certificate authority: ssh_ca (Ed25519 private key
+// in OpenSSH PEM, the format internal/ca's "pem" backend loads via
+// ssh.ParsePrivateKey) and ssh_ca.pub (the authorized_keys line for the managed
+// hosts' TrustedUserCAKeys).
+func generateSSHCA(pkiDir string) error {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "infrabroker-ssh-ca")
+	if err != nil {
+		return err
+	}
+	if err := writeSecret(filepath.Join(pkiDir, "ssh_ca"), pem.EncodeToMemory(block)); err != nil {
+		return err
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return err
+	}
+	return writePublic(filepath.Join(pkiDir, "ssh_ca.pub"), ssh.MarshalAuthorizedKey(sshPub))
+}
+
+// generateMTLS writes one shared mTLS CA and two leaf certs off it: the signer's
+// server cert (CN=localhost, SAN localhost/127.0.0.1) and the broker's client
+// cert (CN=broker-local). One CA signs both, so it is the signer's client_ca AND
+// the broker's signer.ca — matching the shipped pki/ layout.
+func generateMTLS(pkiDir string) error {
+	caCert, caKey, err := makeCA("infrabroker local mTLS CA")
+	if err != nil {
+		return err
+	}
+	if err := writeCert(filepath.Join(pkiDir, "mtls_ca.crt"), caCert.Raw); err != nil {
+		return err
+	}
+	if err := writeKey(filepath.Join(pkiDir, "mtls_ca.key"), caKey); err != nil {
+		return err
+	}
+
+	// Signer server cert: verified by the broker against mtls_ca; needs SANs.
+	if err := makeLeaf(pkiDir, "signer", "localhost", x509.ExtKeyUsageServerAuth,
+		[]string{"localhost"}, []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}, caCert, caKey); err != nil {
+		return err
+	}
+	// Broker client cert: its CN is the audit/RBAC identity (must be in callers).
+	return makeLeaf(pkiDir, "broker", brokerCN, x509.ExtKeyUsageClientAuth, nil, nil, caCert, caKey)
+}
+
+// makeCA creates a self-signed Ed25519 CA certificate and its private key.
+func makeCA(cn string) (*x509.Certificate, ed25519.PrivateKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial(),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(certValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, priv, nil
+}
+
+// makeLeaf creates a leaf cert (CN, EKU, optional SANs) signed by the CA, and
+// writes <name>.crt / <name>.key into pkiDir.
+func makeLeaf(pkiDir, name, cn string, eku x509.ExtKeyUsage, dns []string, ips []net.IP, ca *x509.Certificate, caKey ed25519.PrivateKey) error {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial(),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(certValidity),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+		DNSNames:     dns,
+		IPAddresses:  ips,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, pub, caKey)
+	if err != nil {
+		return err
+	}
+	if err := writeCert(filepath.Join(pkiDir, name+".crt"), der); err != nil {
+		return err
+	}
+	return writeKey(filepath.Join(pkiDir, name+".key"), priv)
+}
+
+// generateAuditSeed writes 32 random bytes (raw, not encoded): the audit log's
+// Ed25519 signing seed. engine.go requires >= ed25519.SeedSize (32).
+func generateAuditSeed(path string) error {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		return err
+	}
+	return writeSecret(path, seed)
+}
+
+func serial() *big.Int {
+	// 128-bit random serial (RFC 5280 §4.1.2.2: positive, <= 20 octets).
+	n, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		// crypto/rand should not fail; a fixed serial is acceptable for a local CA.
+		return big.NewInt(time.Now().UnixNano())
+	}
+	return n
+}
+
+// writeCert / writeKey / writeSecret / writePublic centralise the file modes:
+// certs and public keys are world-readable metadata, private keys and seeds are
+// 0600.
+func writeCert(path string, der []byte) error {
+	return writePublic(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func writeKey(path string, key ed25519.PrivateKey) error {
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return err
+	}
+	return writeSecret(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+func writeSecret(path string, data []byte) error { return os.WriteFile(path, data, 0o600) }
+func writePublic(path string, data []byte) error { return os.WriteFile(path, data, 0o644) }


### PR DESCRIPTION
## Summary

Standing up the custody-separated stack was a manual chore (generate a PKI,
hand-write `signer.json` + the broker `config.json`, wire the default-deny RBAC).
**`infrabroker init`** collapses that into one command. This is **phase 1 / the
deterministic core** (the scope chosen for this PR).

## What it does

New `internal/initcmd`, dispatched from the `init` subcommand:

- **Pure-Go PKI** (no `ssh-keygen`/`openssl`): SSH CA (Ed25519, OpenSSH-PEM — the
  form `internal/ca` loads) + `.pub`; one shared mTLS CA signing the signer server
  cert (CN=localhost, SAN) and the broker client cert (CN=`broker-local`); two raw
  32-byte audit seeds.
- **Custody-separated two-service config**: `signer.json` (holds the SSH CA + a
  default-deny starter policy — allowlist `^uptime$` on the `_default` group) and a
  **remote-mode** broker `config.json` (holds **no** CA key). Holds the two v2.0.0
  default-deny invariants: broker cert CN == the `callers` key, and the starter
  host's group ∩ the caller's `allowed_groups`.
- **Idempotent & safe**: refuses to overwrite without `--force`; keys `0600`.
- Best-effort keyscans a `localhost` starter host; prints the **per-host sshd
  enrolment snippet** and next-steps (incl. the `claude mcp add` line).

## Verification

- Unit tests: emitted `config.json` loads via **`broker.LoadConfig`**; SSH CA via
  `ca.LoadCAFromPEM`; mTLS pairs via `tls.LoadX509KeyPair` (broker cert **verifies
  against the CA**, CN=`broker-local`); `signer.json` hosts+policy compile via
  `signer.CompileHostPolicies`; idempotency/`--force` covered.
- **End-to-end**: the real `signer` boots against the generated `signer.json`, and
  `broker-ctl` reaches it over mTLS with the `broker-local` cert (`revocations` /
  `host list --remote` both succeed).
- `make verify` green (gofmt, vet, build, race tests, govulncheck, mkdocs). Docs:
  README + OPERATIONS §1 lead with `infrabroker init`; CHANGELOG.

## Scope

**`Part of #136`, not a close.** Phase 2 — `~/.ssh/config` bulk import (`ssh -G` +
known_hosts + keyscan) and `claude mcp add` auto-registration — stays tracked in
#136.

Part of #136