### PR TITLE
feat(init): import ~/.ssh/config hosts and register the MCP (#136 phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ make install                 # → ~/bin/{infrabroker,signer,broker,broker-ctl,m
 
 # 2. Generate the local PKI + the two-service config (signer.json + config.json)
 infrabroker init             # writes pki/, signer.json, config.json; --force to redo
+# add --import-ssh-config to import hosts from ~/.ssh/config, --register-mcp to
+# run `claude mcp add` for you
 
 # 3. Start the signing service (must be running before the broker)
 ./signer.sh start

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,15 +32,16 @@
   `internal/brokermain`.
 
 ### Added
-- **`infrabroker init` — one-command local setup (#136, phase 1)** — generates the
-  local PKI (SSH CA, broker↔signer mTLS pair, audit seeds — pure Go, no
+- **`infrabroker init` — one-command local setup (#136)** — generates the local
+  PKI (SSH CA, broker↔signer mTLS pair, audit seeds — pure Go, no
   ssh-keygen/openssl) and writes a custody-separated two-service config
   (`signer.json` holding the SSH CA + a default-deny starter policy, and a
   remote-mode broker `config.json` holding no CA key), wired with the correct
-  default-deny `callers`/groups so the local broker is authorised. Refuses to
-  clobber an existing setup without `--force`, best-effort adds a `localhost`
-  starter host, and prints the per-host sshd enrolment snippet. The `~/.ssh/config`
-  bulk import and `claude mcp add` auto-registration are a follow-up (phase 2).
+  default-deny `callers`/groups so the local broker is authorised. `--import-ssh-config`
+  imports hosts from `~/.ssh/config` (`ssh -G` canonicalisation + host keys from
+  known_hosts with an ssh-keyscan TOFU fallback); `--register-mcp` registers the
+  stdio server with Claude Code (`claude mcp add`). Refuses to clobber an existing
+  setup without `--force`, and prints the per-host sshd enrolment snippet.
 - **Audit-log export to WORM / SIEM — documented sidecar pattern (#139)** — the
   signed, hash-chained audit JSONL can now be shipped off-host with a standard log
   shipper as a **sidecar**: a new OPERATIONS section ("Exporting the audit log to

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -28,6 +28,8 @@ cd /path/to/infrabroker
 #    config (signer.json holds the SSH CA + policy; config.json is the remote-mode
 #    broker). Pure-Go, no ssh-keygen/openssl. Re-run with --force to regenerate.
 #    (This is a local PEM CA — lab/dev custody; see §8 for separated/HSM custody.)
+#    Add --import-ssh-config to import hosts from ~/.ssh/config (ssh -G + known_hosts
+#    / keyscan), and --register-mcp to run `claude mcp add` for you.
 infrabroker init         # writes pki/, signer.json, config.json in the current dir
 
 # 1. Start the signer (must be running before the broker starts)

--- a/internal/initcmd/config.go
+++ b/internal/initcmd/config.go
@@ -75,8 +75,8 @@ type signerClientJSON struct {
 
 // buildSignerJSON assembles the signer config: CA custody + a default-deny
 // starter policy on the reserved _default group + the broker-local caller + the
-// optional starter host. All PKI paths are relative to the init dir.
-func buildSignerJSON(host *starterHost) signerJSON {
+// imported/starter hosts. All PKI paths are relative to the init dir.
+func buildSignerJSON(hosts []starterHost) signerJSON {
 	allow := "^uptime$"
 	s := signerJSON{
 		Listen:        ":9443",
@@ -105,7 +105,7 @@ func buildSignerJSON(host *starterHost) signerJSON {
 		},
 		Hosts: map[string]hostJSON{},
 	}
-	if host != nil {
+	for _, host := range hosts {
 		s.Hosts[host.name] = hostJSON{
 			Addr:      host.addr,
 			User:      host.user,

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -22,20 +22,31 @@ func Run(args []string) {
 	fs := flag.NewFlagSet("infrabroker init", flag.ExitOnError)
 	dir := fs.String("dir", ".", "directory to write the PKI and configs into")
 	force := fs.Bool("force", false, "overwrite an existing PKI/config in --dir")
+	importSSH := fs.Bool("import-ssh-config", false, "import hosts from ~/.ssh/config (ssh -G + known_hosts / keyscan)")
+	register := fs.Bool("register-mcp", false, "register the stdio MCP with Claude Code (runs `claude mcp add`)")
 	_ = fs.Parse(args)
 
-	host, err := generate(*dir, *force)
+	hosts, err := generate(*dir, *force, *importSSH)
 	if err != nil {
 		fatalf("%v", err)
 	}
-	printNextSteps(*dir, filepath.Join(*dir, "pki"), host)
+	printNextSteps(*dir, filepath.Join(*dir, "pki"), hosts)
+
+	if *register {
+		cfgAbs, _ := filepath.Abs(filepath.Join(*dir, "config.json"))
+		if err := registerMCP(selfPath(), cfgAbs); err != nil {
+			fmt.Fprintf(os.Stderr, "\ncould not auto-register the MCP (%v); run it manually:\n  claude mcp add infrabroker -- %s serve-mcp -config %s\n", err, selfPath(), cfgAbs)
+		} else {
+			fmt.Print("\nRegistered the stdio MCP with Claude Code (server name: infrabroker).\n")
+		}
+	}
 }
 
-// generate does the file-producing work of init and returns the starter host (or
-// nil). Split from Run — which handles flags and prints — so it is testable
-// without exiting the process. Returns an error (not fatalf) so idempotency and
-// failure paths can be asserted.
-func generate(root string, force bool) (*starterHost, error) {
+// generate does the file-producing work of init and returns the hosts written.
+// Split from Run — which handles flags, MCP registration and printing — so it is
+// testable without exiting the process. Returns an error (not fatalf) so
+// idempotency and failure paths can be asserted.
+func generate(root string, force, importSSH bool) ([]starterHost, error) {
 	pkiDir := filepath.Join(root, "pki")
 
 	// Idempotency: never silently clobber an existing setup.
@@ -53,14 +64,29 @@ func generate(root string, force bool) (*starterHost, error) {
 		return nil, fmt.Errorf("generating PKI: %w", err)
 	}
 
-	host := detectLocalhostHost()
-	if err := writeJSONConfig(filepath.Join(root, "signer.json"), buildSignerJSON(host)); err != nil {
+	hosts := collectHosts(importSSH)
+	if err := writeJSONConfig(filepath.Join(root, "signer.json"), buildSignerJSON(hosts)); err != nil {
 		return nil, fmt.Errorf("writing signer.json: %w", err)
 	}
 	if err := writeJSONConfig(filepath.Join(root, "config.json"), buildBrokerJSON()); err != nil {
 		return nil, fmt.Errorf("writing config.json: %w", err)
 	}
-	return host, nil
+	return hosts, nil
+}
+
+// collectHosts chooses the hosts to write: the imported ~/.ssh/config hosts when
+// --import-ssh-config is set (falling back to the localhost starter if the import
+// finds nothing), otherwise the best-effort localhost starter alone.
+func collectHosts(importSSH bool) []starterHost {
+	if importSSH {
+		if h := importSSHConfigHosts(); len(h) > 0 {
+			return h
+		}
+	}
+	if h := detectLocalhostHost(); h != nil {
+		return []starterHost{*h}
+	}
+	return nil
 }
 
 // detectLocalhostHost best-effort keyscans the local sshd for a functional
@@ -104,7 +130,7 @@ func currentUser() string {
 	return "deploy"
 }
 
-func printNextSteps(root, pkiDir string, host *starterHost) {
+func printNextSteps(root, pkiDir string, hosts []starterHost) {
 	abs := func(p string) string {
 		if a, err := filepath.Abs(p); err == nil {
 			return a
@@ -121,22 +147,27 @@ Start the two services (run from %s):
   signer      -config signer.json
   infrabroker serve-mcp -config config.json          # or serve-http / serve-mcp-http
 
-Register the stdio MCP with Claude Code:
+Register the stdio MCP with Claude Code (or re-run init with --register-mcp):
   claude mcp add infrabroker -- %s serve-mcp -config %s
 
 `, root, root, abs(selfPath()), abs(filepath.Join(root, "config.json")))
 
-	if host != nil {
+	if len(hosts) > 0 {
+		var names []string
+		for _, h := range hosts {
+			names = append(names, fmt.Sprintf("%s (%s@%s)", h.name, h.user, h.addr))
+		}
 		caPub, _ := os.ReadFile(filepath.Join(pkiDir, "ssh_ca.pub"))
-		fmt.Printf(`A starter host %q (%s@%s) was added. The default-deny policy allows only
-`+"`uptime`"+` until you widen it — e.g. broker-ctl policy grant --host %s --allow '^systemctl status '.
-
-Enrol its sshd so it trusts the CA:
-
-%s`, host.name, host.user, host.addr, host.name, enrollSnippet(caPub, host.user, "host:"+host.name))
+		fmt.Printf("%d host(s) added — review signer.json, then enrol each host's sshd. The\n"+
+			"default-deny policy allows only `uptime` until you widen it (broker-ctl policy grant).\n  %s\n\n",
+			len(hosts), strings.Join(names, "\n  "))
+		fmt.Print(enrollSnippet(caPub, hosts[0].user, "host:"+hosts[0].name))
+		if len(hosts) > 1 {
+			fmt.Print("\n(Same TrustedUserCAKeys on every host; for each, add its `host:<name>` principal\nto /etc/ssh/auth_principals/<its login user>.)\n")
+		}
 	} else {
-		fmt.Print(`No local sshd was reachable, so no starter host was added. Add your first host:
-  broker-ctl host add --name web01 --addr web01.example.com:22 --user deploy --scan --groups local
+		fmt.Print(`No hosts were added. Import from ~/.ssh/config (infrabroker init --force --import-ssh-config),
+or add one:  broker-ctl host add --name web01 --addr web01.example.com:22 --user deploy --scan --groups local
 then enrol its sshd (see docs/OPERATIONS.md § Remote host configuration).
 
 `)

--- a/internal/initcmd/initcmd_test.go
+++ b/internal/initcmd/initcmd_test.go
@@ -19,7 +19,7 @@ import (
 // serve-* -config …` boot against them.
 func TestGenerateProducesLoadableArtifacts(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := generate(dir, false); err != nil {
+	if _, err := generate(dir, false, false); err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 	pki := filepath.Join(dir, "pki")
@@ -105,13 +105,13 @@ func TestGenerateProducesLoadableArtifacts(t *testing.T) {
 // regenerates.
 func TestGenerateIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := generate(dir, false); err != nil {
+	if _, err := generate(dir, false, false); err != nil {
 		t.Fatalf("first generate: %v", err)
 	}
-	if _, err := generate(dir, false); err == nil {
+	if _, err := generate(dir, false, false); err == nil {
 		t.Fatal("second generate without --force must refuse to overwrite")
 	}
-	if _, err := generate(dir, true); err != nil {
+	if _, err := generate(dir, true, false); err != nil {
 		t.Fatalf("generate --force must overwrite: %v", err)
 	}
 }
@@ -119,7 +119,7 @@ func TestGenerateIsIdempotent(t *testing.T) {
 // TestBuildSignerJSONHostInvariant: when a starter host is present, its group
 // intersects the broker caller's allowed_groups (or default-deny hides it).
 func TestBuildSignerJSONHostInvariant(t *testing.T) {
-	s := buildSignerJSON(&starterHost{name: "localhost", addr: "127.0.0.1:22", user: "deploy", hostKey: "ssh-ed25519 AAAA"})
+	s := buildSignerJSON([]starterHost{{name: "localhost", addr: "127.0.0.1:22", user: "deploy", hostKey: "ssh-ed25519 AAAA"}})
 	h, ok := s.Hosts["localhost"]
 	if !ok {
 		t.Fatal("starter host not written")

--- a/internal/initcmd/mcp.go
+++ b/internal/initcmd/mcp.go
@@ -1,0 +1,26 @@
+package initcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// mcpAddArgs builds the `claude mcp add` argument vector that registers the stdio
+// MCP server (`infrabroker serve-mcp -config <config>`) with Claude Code. Split
+// out for testing.
+func mcpAddArgs(binary, config string) []string {
+	return []string{"mcp", "add", "infrabroker", "--", binary, "serve-mcp", "-config", config}
+}
+
+// registerMCP runs `claude mcp add …`, letting the Claude CLI own the ~/.claude.json
+// merge. Best-effort: it returns an error (e.g. the CLI is not installed) that the
+// caller turns into a printed fallback rather than failing init.
+func registerMCP(binary, config string) error {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return fmt.Errorf("the `claude` CLI is not on PATH")
+	}
+	cmd := exec.Command("claude", mcpAddArgs(binary, config)...)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd.Run()
+}

--- a/internal/initcmd/sshimport.go
+++ b/internal/initcmd/sshimport.go
@@ -1,0 +1,172 @@
+package initcmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// importSSHConfigHosts reads ~/.ssh/config, canonicalises each concrete Host alias
+// with `ssh -G`, and acquires each host key (from known_hosts, falling back to an
+// ssh-keyscan TOFU). Best-effort: an alias that cannot be resolved or whose key
+// cannot be found is skipped with a note on stderr. Returns the importable hosts.
+func importSSHConfigHosts() []starterHost {
+	cfg := sshConfigPath()
+	aliases, err := discoverSSHHosts(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "infrabroker init: reading %s: %v\n", cfg, err)
+		return nil
+	}
+	var hosts []starterHost
+	seen := map[string]bool{}
+	for _, alias := range aliases {
+		hostname, user, port, keyAlias := sshCanonicalize(alias)
+		if hostname == "" {
+			fmt.Fprintf(os.Stderr, "  skipped %q: ssh -G could not resolve it\n", alias)
+			continue
+		}
+		hk, err := hostKey(hostname, port, keyAlias)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  skipped %q (%s): no host key — %v\n", alias, hostname, err)
+			continue
+		}
+		name := sanitizeName(alias)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		hosts = append(hosts, starterHost{name: name, addr: hostname + ":" + port, user: user, hostKey: hk})
+	}
+	return hosts
+}
+
+func sshConfigPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".ssh", "config")
+}
+
+// discoverSSHHosts returns the concrete (non-pattern) Host aliases in an ssh
+// config file. Patterns (*, ?, !) and the catch-all `Host *` are skipped — they
+// are not connectable targets. A missing file yields no hosts (not an error).
+func discoverSSHHosts(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var hosts []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || !strings.EqualFold(fields[0], "Host") {
+			continue
+		}
+		for _, alias := range fields[1:] {
+			if strings.ContainsAny(alias, "*?!") {
+				continue
+			}
+			hosts = append(hosts, alias)
+		}
+	}
+	return hosts, sc.Err()
+}
+
+// sshCanonicalize runs `ssh -G alias` and extracts hostname, user, port and the
+// hostkeyalias (empty unless configured). Returns an empty hostname on failure.
+func sshCanonicalize(alias string) (hostname, user, port, keyAlias string) {
+	out, err := exec.Command("ssh", "-G", alias).Output()
+	if err != nil {
+		return "", "", "", ""
+	}
+	port = "22"
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	for sc.Scan() {
+		k, v, ok := strings.Cut(strings.TrimSpace(sc.Text()), " ")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(k) {
+		case "hostname":
+			hostname = v
+		case "user":
+			user = v
+		case "port":
+			port = v
+		case "hostkeyalias":
+			keyAlias = v
+		}
+	}
+	return hostname, user, port, keyAlias
+}
+
+// hostKey resolves a host key: known_hosts first (via ssh-keygen -F, which handles
+// hashed entries and [host]:port), then an ssh-keyscan TOFU fallback. Returns the
+// two-field "ssh-ed25519 AAAA..." form the host_key field stores.
+func hostKey(hostname, port, keyAlias string) (string, error) {
+	lookup := hostname
+	if keyAlias != "" {
+		lookup = keyAlias
+	}
+	if hk := knownHostsKey(lookup, port); hk != "" {
+		return hk, nil
+	}
+	return keyscan(hostname, port)
+}
+
+// knownHostsKey queries ~/.ssh/known_hosts for host's key via ssh-keygen -F,
+// preferring an ed25519 key. Returns "" if not found.
+func knownHostsKey(host, port string) string {
+	target := host
+	if port != "" && port != "22" {
+		target = "[" + host + "]:" + port
+	}
+	home, _ := os.UserHomeDir()
+	out, err := exec.Command("ssh-keygen", "-F", target, "-f", filepath.Join(home, ".ssh", "known_hosts")).Output()
+	if err != nil {
+		return ""
+	}
+	var first string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		key := strings.Join(parts[1:], " ")
+		if strings.HasPrefix(parts[1], "ssh-ed25519") {
+			return key
+		}
+		if first == "" {
+			first = key
+		}
+	}
+	return first
+}
+
+// sanitizeName maps an ssh alias to a signer host name (lowercase, [a-z0-9._-]).
+func sanitizeName(alias string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(alias) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/internal/initcmd/sshimport_test.go
+++ b/internal/initcmd/sshimport_test.go
@@ -1,0 +1,80 @@
+package initcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverSSHHosts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config")
+	content := `# a comment line
+Host web01 web02
+    HostName 10.0.0.1
+    User deploy
+Host *.example.com
+    User ops
+Host bastion
+    HostName bastion.example.com
+Host *
+    ForwardAgent no
+`
+	if err := os.WriteFile(cfg, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := discoverSSHHosts(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Patterns (*.example.com, *) are skipped; multi-alias lines are expanded.
+	want := []string{"web01", "web02", "bastion"}
+	if !equalStrings(got, want) {
+		t.Errorf("discoverSSHHosts = %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverSSHHostsMissingFileIsEmpty(t *testing.T) {
+	got, err := discoverSSHHosts(filepath.Join(t.TempDir(), "no-such-config"))
+	if err != nil {
+		t.Fatalf("missing ssh config must not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("missing ssh config yields %v, want none", got)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"web01":    "web01",
+		"Web-01":   "web-01",
+		"app.prod": "app.prod",
+		"a b/c":    "a-b-c",
+		"HOST_1":   "host_1",
+	}
+	for in, want := range cases {
+		if got := sanitizeName(in); got != want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMCPAddArgs(t *testing.T) {
+	got := mcpAddArgs("/usr/local/bin/infrabroker", "/etc/infrabroker/config.json")
+	want := []string{"mcp", "add", "infrabroker", "--", "/usr/local/bin/infrabroker", "serve-mcp", "-config", "/etc/infrabroker/config.json"}
+	if !equalStrings(got, want) {
+		t.Errorf("mcpAddArgs = %v, want %v", got, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Completes **`infrabroker init`** (#136): the two deferred parts of the "zero to a
policy-gated agent" flow, as opt-in flags.

- **`--import-ssh-config`** — discovers concrete `Host` aliases in `~/.ssh/config`,
  canonicalises each with **`ssh -G`** (hostname/user/port/hostkeyalias), and
  acquires each host key from **known_hosts** (`ssh-keygen -F`, preferring ed25519)
  with an **ssh-keyscan TOFU fallback**. Imported hosts are written into the
  generated `signer.json` in the `local` group. Patterns (`Host *`, `*.x`) are
  skipped; a host whose key can't be found is skipped with a note (review/prune
  `signer.json` after).
- **`--register-mcp`** — runs `claude mcp add infrabroker -- <bin> serve-mcp
  -config <config>`, letting the Claude CLI own the `~/.claude.json` merge.
  Best-effort: a missing CLI prints the manual command instead of failing.

`init` now writes **multiple hosts** (`buildSignerJSON` takes a slice) and prints
per-host enrolment guidance. Both flags are opt-in — blanket-importing every SSH
host or shelling out to a CLI by default would be surprising.

## Verification

- Unit tests: `~/.ssh/config` parsing (pattern skipping, multi-alias lines, missing
  file → empty), `sanitizeName`, and the `claude mcp add` argv. Phase-1 tests
  (PKI/config loadability, idempotency) still pass.
- **End-to-end**: `--register-mcp` registers (and I removed) the server cleanly via
  the real `claude` CLI; `--import-ssh-config` imported a real `known_hosts` entry
  (`ssh -G` → key lookup → `signer.json`).
- `make verify` green (gofmt, vet, build, race tests, govulncheck, mkdocs). Docs:
  README + OPERATIONS §1 mention the flags; CHANGELOG entry now describes the
  complete feature.

Closes #136