### PR TITLE
fix(init): emit absolute config paths so a registered MCP server starts (#271)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,16 @@
   old file before closing it.
 
 ### Fixed
+- **`infrabroker init` now writes absolute config paths (#271)** — the generated
+  `signer.json`/`config.json` embedded PKI/audit paths relative to the init dir
+  (`pki/broker.crt`, `audit.log`, …). The broker resolves config paths against
+  the process working directory, so once `--register-mcp` (or a hand-written MCP
+  client entry) launched `infrabroker serve-mcp -config <abs>/config.json` from
+  the client's own CWD — not the init dir — the broker died at startup with
+  `open pki/broker.crt: no such file or directory`, leaving the registered server
+  dead on arrival. `init` now emits absolute paths (it knows the resolved
+  `--dir`), so the configs load regardless of launch CWD. Existing configs are
+  unaffected; re-run `infrabroker init --force` to regenerate.
 - **Cert expiry now force-closes a busy session (#225)** — the session reaper
   skipped any session with a command in flight *before* checking certificate
   expiry, so a continuously-busy session kept its already-authenticated SSH

--- a/internal/initcmd/config.go
+++ b/internal/initcmd/config.go
@@ -3,6 +3,7 @@ package initcmd
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/luisgf/infrabroker/internal/signer"
 )
@@ -75,17 +76,20 @@ type signerClientJSON struct {
 
 // buildSignerJSON assembles the signer config: CA custody + a default-deny
 // starter policy on the reserved _default group + the broker-local caller + the
-// imported/starter hosts. All PKI paths are relative to the init dir.
-func buildSignerJSON(hosts []starterHost) signerJSON {
+// imported/starter hosts. Every PKI/audit path is ABSOLUTE (rooted at absRoot):
+// the broker's config.json is launched by the MCP client from an arbitrary CWD
+// (`--register-mcp`), and the broker/signer resolve config paths against the
+// process CWD, so relative paths would break a registered server (#271).
+func buildSignerJSON(hosts []starterHost, absRoot string) signerJSON {
 	allow := "^uptime$"
 	s := signerJSON{
 		Listen:        ":9443",
-		ServerCert:    "pki/signer.crt",
-		ServerKey:     "pki/signer.key",
-		ClientCA:      "pki/mtls_ca.crt",
-		CAKey:         "pki/ssh_ca",
-		AuditLog:      "signer_audit.log",
-		AuditKey:      "pki/signer_audit.seed",
+		ServerCert:    filepath.Join(absRoot, "pki", "signer.crt"),
+		ServerKey:     filepath.Join(absRoot, "pki", "signer.key"),
+		ClientCA:      filepath.Join(absRoot, "pki", "mtls_ca.crt"),
+		CAKey:         filepath.Join(absRoot, "pki", "ssh_ca"),
+		AuditLog:      filepath.Join(absRoot, "signer_audit.log"),
+		AuditKey:      filepath.Join(absRoot, "pki", "signer_audit.seed"),
 		AuditFailMode: "closed",
 		MaxTTLSeconds: 300,
 		MonitorListen: "127.0.0.1:9160",
@@ -118,17 +122,19 @@ func buildSignerJSON(hosts []starterHost) signerJSON {
 }
 
 // buildBrokerJSON assembles the remote-mode broker config (custody-separated: no
-// CA key). Its client cert CN (broker-local) is the caller in signer.json.
-func buildBrokerJSON() brokerJSON {
+// CA key). Its client cert CN (broker-local) is the caller in signer.json. Every
+// path is ABSOLUTE (rooted at absRoot) so the config works when the MCP client
+// launches `infrabroker serve-mcp` from its own CWD, not the init dir (#271).
+func buildBrokerJSON(absRoot string) brokerJSON {
 	return brokerJSON{
 		Signer: signerClientJSON{
 			URL:        signerURL,
-			ClientCert: "pki/broker.crt",
-			ClientKey:  "pki/broker.key",
-			CA:         "pki/mtls_ca.crt",
+			ClientCert: filepath.Join(absRoot, "pki", "broker.crt"),
+			ClientKey:  filepath.Join(absRoot, "pki", "broker.key"),
+			CA:         filepath.Join(absRoot, "pki", "mtls_ca.crt"),
 		},
-		AuditLog:              "audit.log",
-		AuditKey:              "pki/audit.seed",
+		AuditLog:              filepath.Join(absRoot, "audit.log"),
+		AuditKey:              filepath.Join(absRoot, "pki", "audit.seed"),
 		AuditFailMode:         "closed",
 		MaxTTLSeconds:         300,
 		HostsRefreshSeconds:   30,

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -47,11 +47,18 @@ func Run(args []string) {
 // testable without exiting the process. Returns an error (not fatalf) so
 // idempotency and failure paths can be asserted.
 func generate(root string, force, importSSH bool) ([]starterHost, error) {
-	pkiDir := filepath.Join(root, "pki")
+	// Resolve to an absolute root: the generated configs embed absolute PKI/audit
+	// paths so they load regardless of the process CWD (the broker config is
+	// launched by the MCP client from its own dir — see buildBrokerJSON, #271).
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolving --dir %q: %w", root, err)
+	}
+	pkiDir := filepath.Join(absRoot, "pki")
 
 	// Idempotency: never silently clobber an existing setup.
 	if !force {
-		for _, p := range []string{filepath.Join(root, "signer.json"), filepath.Join(root, "config.json"), filepath.Join(pkiDir, "ssh_ca")} {
+		for _, p := range []string{filepath.Join(absRoot, "signer.json"), filepath.Join(absRoot, "config.json"), filepath.Join(pkiDir, "ssh_ca")} {
 			if _, err := os.Stat(p); err == nil {
 				return nil, fmt.Errorf("refusing to overwrite existing %s (pass --force to regenerate the PKI and configs)", p)
 			}
@@ -65,10 +72,10 @@ func generate(root string, force, importSSH bool) ([]starterHost, error) {
 	}
 
 	hosts := collectHosts(importSSH)
-	if err := writeJSONConfig(filepath.Join(root, "signer.json"), buildSignerJSON(hosts)); err != nil {
+	if err := writeJSONConfig(filepath.Join(absRoot, "signer.json"), buildSignerJSON(hosts, absRoot)); err != nil {
 		return nil, fmt.Errorf("writing signer.json: %w", err)
 	}
-	if err := writeJSONConfig(filepath.Join(root, "config.json"), buildBrokerJSON()); err != nil {
+	if err := writeJSONConfig(filepath.Join(absRoot, "config.json"), buildBrokerJSON(absRoot)); err != nil {
 		return nil, fmt.Errorf("writing config.json: %w", err)
 	}
 	return hosts, nil

--- a/internal/initcmd/initcmd_test.go
+++ b/internal/initcmd/initcmd_test.go
@@ -101,6 +101,80 @@ func TestGenerateProducesLoadableArtifacts(t *testing.T) {
 	}
 }
 
+// TestGeneratedConfigPathsAreAbsolute locks in #271: the emitted signer.json and
+// config.json must carry ABSOLUTE PKI/audit paths and every one must point at a
+// file init actually created. The broker resolves config paths against the
+// process CWD, and the MCP client launches `infrabroker serve-mcp` from its own
+// dir (--register-mcp) — a relative path would make the registered server fail to
+// start. Asserting absolute + existing is CWD-independent, which is the guarantee.
+func TestGeneratedConfigPathsAreAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := generate(dir, false, false); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	var signerPaths struct {
+		ServerCert string `json:"server_cert"`
+		ServerKey  string `json:"server_key"`
+		ClientCA   string `json:"client_ca"`
+		CAKey      string `json:"ca_key"`
+		AuditLog   string `json:"audit_log"`
+		AuditKey   string `json:"audit_key"`
+	}
+	readJSON(t, filepath.Join(dir, "signer.json"), &signerPaths)
+
+	var brokerPaths struct {
+		Signer struct {
+			ClientCert string `json:"client_cert"`
+			ClientKey  string `json:"client_key"`
+			CA         string `json:"ca"`
+		} `json:"signer"`
+		AuditLog string `json:"audit_log"`
+		AuditKey string `json:"audit_key"`
+	}
+	readJSON(t, filepath.Join(dir, "config.json"), &brokerPaths)
+
+	// These are files init actually creates now (PKI + audit seeds): assert both
+	// absolute and present.
+	paths := map[string]string{
+		"signer.server_cert": signerPaths.ServerCert,
+		"signer.server_key":  signerPaths.ServerKey,
+		"signer.client_ca":   signerPaths.ClientCA,
+		"signer.ca_key":      signerPaths.CAKey,
+		"signer.audit_key":   signerPaths.AuditKey,
+		"broker.client_cert": brokerPaths.Signer.ClientCert,
+		"broker.client_key":  brokerPaths.Signer.ClientKey,
+		"broker.ca":          brokerPaths.Signer.CA,
+		"broker.audit_key":   brokerPaths.AuditKey,
+	}
+	for field, p := range paths {
+		if !filepath.IsAbs(p) {
+			t.Errorf("%s = %q, want an absolute path (a registered MCP server launches from a foreign CWD)", field, p)
+		}
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("%s = %q does not exist: %v", field, p, err)
+		}
+	}
+	// The audit logs are created on first write, not by init, so only assert they
+	// are absolute (and land inside the init dir).
+	for field, p := range map[string]string{"broker.audit_log": brokerPaths.AuditLog, "signer.audit_log": signerPaths.AuditLog} {
+		if !filepath.IsAbs(p) {
+			t.Errorf("%s = %q, want an absolute path", field, p)
+		}
+	}
+}
+
+func readJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}
+
 // TestGenerateIsIdempotent: a second run without --force refuses; --force
 // regenerates.
 func TestGenerateIsIdempotent(t *testing.T) {
@@ -119,7 +193,7 @@ func TestGenerateIsIdempotent(t *testing.T) {
 // TestBuildSignerJSONHostInvariant: when a starter host is present, its group
 // intersects the broker caller's allowed_groups (or default-deny hides it).
 func TestBuildSignerJSONHostInvariant(t *testing.T) {
-	s := buildSignerJSON([]starterHost{{name: "localhost", addr: "127.0.0.1:22", user: "deploy", hostKey: "ssh-ed25519 AAAA"}})
+	s := buildSignerJSON([]starterHost{{name: "localhost", addr: "127.0.0.1:22", user: "deploy", hostKey: "ssh-ed25519 AAAA"}}, "/abs/root")
 	h, ok := s.Hosts["localhost"]
 	if !ok {
 		t.Fatal("starter host not written")


### PR DESCRIPTION
## Problem

`infrabroker init` wrote `signer.json`/`config.json` with PKI and audit paths **relative to the init directory** (`pki/broker.crt`, `pki/audit.seed`, `audit.log`). The broker resolves config paths against the **process working directory** (`broker.LoadConfig` → `NewEngine`/`openAuditLog` open the paths verbatim; there is no resolution against the config file's dir).

`infrabroker init --register-mcp` runs `claude mcp add infrabroker -- <binary> serve-mcp -config <ABSOLUTE>/config.json`, and the MCP client (Claude Code / OpenCode) later launches that server **from its own CWD**, not the init dir. The broker then can't find `pki/broker.crt` and dies at startup:

```
initialising broker: signing client TLS: loading client cert: open pki/broker.crt: no such file or directory
```

So the registered server is dead on arrival — defeating the #136/#270 zero-to-agent fast path. The same breakage hits the hand-written MCP registration documented in the README.

## Fix

`init` resolves `--dir` to an absolute path and emits **absolute** PKI/audit paths in both generated configs, so they load regardless of the launch CWD.

Deliberately **not** changed: the broker/signer config loader. Making it resolve relative-to-config-dir would break the production systemd model, where `WorkingDirectory=/var/lib/infrabroker/<svc>` makes a relative `audit_log` land in the writable state dir while the config lives in the read-only `/etc/infrabroker`.

## Verified

- `make verify` green: gofmt, `go vet`, build, race tests, govulncheck (no vulns affecting our code), strict docs, no reference drift.
- New `TestGeneratedConfigPathsAreAbsolute` locks in the invariant (every emitted PKI/audit path is absolute and, for files init creates, present).
- End-to-end repro: signer started from the init dir + `infrabroker serve-mcp -config <abs>/config.json` launched **from `/tmp`** now reaches `ready` and loads hosts over mTLS; before the fix it failed with the error above.

Closes #271