### PR TITLE
fix(signer): match the decoded command so quoting can't bypass deny/approval (#277)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -108,6 +108,21 @@
   segment discovery recognises it; plain timestamps stay backward-compatible.
 
 ### Security
+- **Command policy matches the decoded command, closing a deny/approval bypass
+  via shell quoting (#277)** — the firewall parsed each command but matched the
+  deny/`require_approval`/allow regexes against its *quote-preserving* printed
+  form. Since the target shell strips quoting at exec time, a caller could wrap
+  the command name to dodge a rule the executed command would hit: on a denylist
+  host `'rm' -rf …`, `r"m" -rf …`, `$'\x72\x6d' -rf …`, `rm$IFS-rf …` and
+  `LD_PRELOAD=… rm -rf …` all rode past a `^rm ` deny, and `'reboot'` ran with no
+  approval past a `^reboot` `require_approval`. Each simple command is now matched
+  against its **decoded literal** (quoting/encoding removed), and a command word
+  whose value the policy cannot know statically — a parameter/command/arithmetic
+  expansion (`$IFS`, `$(…)`) or an inline env assignment — is rejected
+  fail-closed. **Impact:** denylist/`require_approval`/allowlist hosts whose
+  policies relied on quoting or an unquoted `$VAR`/env-prefix in a command may see
+  new denials (the safe direction); allowlist hosts were already fail-closed. A
+  legitimately quoted command that decodes to an allowed form is still allowed.
 - **Freezes are durable against power loss, not just an app crash (#210)** — the
   state DB runs `synchronous=NORMAL`, which fsyncs only at a WAL checkpoint, so a
   committed freeze whose frames were not yet checkpointed was lost on power loss /

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -131,8 +132,11 @@ func (cp CommandPolicy) Validate() error {
 //   - file Redirect        — arbitrary write to the filesystem
 //
 // Allowed: pipes (|), sequences (&&, ||, ;) and fd→fd redirections (2>&1).
-// Each CallExpr in the AST is printed back to its canonical string and returned
-// as an independent element for separate evaluation.
+// Each CallExpr is returned as its DECODED literal command (quoting and
+// encoding removed), so the policy matches what the target shell will actually
+// run — not the caller's quoting. A command whose value the policy cannot know
+// statically (a parameter/command/arithmetic expansion, or an inline env
+// assignment) is rejected rather than matched against an incomplete string.
 func extractCommands(command string) ([]string, error) {
 	parser := shellParserPool.Get().(*syntax.Parser)
 	defer shellParserPool.Put(parser)
@@ -143,10 +147,6 @@ func extractCommands(command string) ([]string, error) {
 
 	var cmds []string
 	var walkErr error
-	// One printer per call, reused across every CallExpr instead of allocating a
-	// fresh one inside the walk.
-	printer := syntax.NewPrinter()
-	var buf strings.Builder
 
 	syntax.Walk(f, func(node syntax.Node) bool {
 		if walkErr != nil {
@@ -193,12 +193,24 @@ func extractCommands(command string) ([]string, error) {
 				}
 				break
 			}
-			buf.Reset()
-			if err2 := printer.Print(&buf, n); err2 != nil {
-				walkErr = fmt.Errorf("printer: %w", err2)
+			// An inline env prefix (FOO=bar cmd, LD_PRELOAD=… cmd) mutates how cmd
+			// runs but is invisible to the policy regexes — same danger as the
+			// standalone assignment and export/declare above (a deny like "^rm " is
+			// dodged by "FOO=bar rm -rf"). Reject it.
+			if len(n.Assigns) > 0 {
+				walkErr = errors.New("inline environment assignment before a command not allowed")
 				return false
 			}
-			cmds = append(cmds, buf.String())
+			// Match against the DECODED literal command, not its quoting-preserving
+			// source: the target shell removes quoting/encoding at exec time, so
+			// matching the printed form let 'rm', r"m", $'\x72\x6d' and rm$IFS-rf
+			// slip past a deny/allow rule that the executed command would hit (#277).
+			lit, err2 := literalArgs(n.Args)
+			if err2 != nil {
+				walkErr = err2
+				return false
+			}
+			cmds = append(cmds, lit)
 		}
 		return true
 	})
@@ -210,6 +222,63 @@ func extractCommands(command string) ([]string, error) {
 		return nil, errors.New("no commands found after shell parse")
 	}
 	return cmds, nil
+}
+
+// literalArgs returns a simple command's argument words decoded to their literal
+// values and joined by single spaces — the form the target shell will actually
+// execute, with all quoting/encoding removed so the command policy matches what
+// runs instead of the caller's quoting (#277). It fails closed on any word whose
+// value is not statically knowable (a parameter/command/arithmetic expansion,
+// process substitution or extended glob): such a word is rejected rather than
+// matched against an incomplete string.
+func literalArgs(args []*syntax.Word) (string, error) {
+	// A fresh config per call: expand.Literal mutates the *Config it is given
+	// (prepareConfig sets Env/ifs in place), so a shared instance would race
+	// under concurrent Decide calls. NoUnset makes any parameter reference that
+	// slips past isStaticWord an error rather than a silent "" expansion; a nil
+	// ReadDir disables globbing so a bare "*" stays literal.
+	cfg := &expand.Config{NoUnset: true}
+	parts := make([]string, 0, len(args))
+	for _, w := range args {
+		if !isStaticWord(w) {
+			return "", errors.New("command word with a parameter/command/arithmetic expansion not allowed")
+		}
+		lit, err := expand.Literal(cfg, w)
+		if err != nil {
+			return "", fmt.Errorf("decoding command word: %w", err)
+		}
+		parts = append(parts, lit)
+	}
+	return strings.Join(parts, " "), nil
+}
+
+// isStaticWord reports whether w's value is fully determined at policy-decision
+// time: it is built only from literals and quoted literals ('...', "...",
+// $'...'). Any expansion node — parameter ($x, ${x}, $IFS, $@), command
+// substitution, arithmetic, process substitution or extended glob — makes the
+// runtime value unknowable to the policy, so the word is treated as non-static
+// (the caller rejects it, fail-closed).
+func isStaticWord(w *syntax.Word) bool {
+	if w == nil {
+		return false
+	}
+	for _, part := range w.Parts {
+		switch p := part.(type) {
+		case *syntax.Lit, *syntax.SglQuoted:
+			// Bare literal, '...' , or $'...' (ANSI-C) — all statically known.
+		case *syntax.DblQuoted:
+			// A double-quoted string is static only if it contains no expansion
+			// (e.g. "$x", "$(...)" inside the quotes make it dynamic).
+			for _, inner := range p.Parts {
+				if _, ok := inner.(*syntax.Lit); !ok {
+					return false
+				}
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // isFdRef reports whether w is a bare file-descriptor reference — a decimal fd

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -348,6 +348,69 @@ func TestCommandPolicyShellParse(t *testing.T) {
 	}
 }
 
+// TestCommandPolicyQuotingBypassClosed is the #277 acceptance criterion: the
+// deny/require_approval firewall must match the DECODED command, not the
+// caller's quoting. The target shell strips quotes/encoding at exec time, so a
+// wrapped command name (or an $IFS/inline-env trick) must not slip past a rule
+// the executed command would hit. Decoding is symmetric: a legitimately quoted
+// command that decodes to an allowed/approval form is still allowed/gated.
+func TestCommandPolicyQuotingBypassClosed(t *testing.T) {
+	t.Parallel()
+
+	deny := CommandPolicy{Mode: CmdPolicyDenylist, Deny: []string{`^rm `, `^reboot`}}
+	allow := CommandPolicy{Mode: CmdPolicyAllowlist, Allow: []string{`^ps aux$`}}
+	approval := CommandPolicy{Mode: CmdPolicyDenylist, RequireApproval: []string{`^reboot`}}
+
+	tests := []struct {
+		name         string
+		cp           CommandPolicy
+		command      string
+		wantAllowed  bool
+		wantApproval bool
+		wantErrNil   bool
+	}{
+		// Denylist ^rm : every quoting/encoding of the command name must be denied.
+		{"plain rm denied", deny, "rm -rf /data", false, false, true},
+		{"single-quoted rm denied", deny, "'rm' -rf /data", false, false, true},
+		{"partial-quoted rm denied", deny, `r"m" -rf /data`, false, false, true},
+		{"double-quoted rm denied", deny, `"rm" -rf /data`, false, false, true},
+		{"ansi-c rm denied", deny, `$'\x72\x6d' -rf /data`, false, false, true},
+		// $IFS and inline env are unknowable/invisible to the policy → fail closed
+		// (rejected with an error, hence denied).
+		{"IFS-separated rm rejected", deny, "rm$IFS-rf /data", false, false, false},
+		{"inline env prefix rejected", deny, "LD_PRELOAD=/e.so rm -rf /data", false, false, false},
+		{"quoted reboot denied", deny, "'reboot'", false, false, true},
+		// Allowlist ^ps aux$: a legitimately quoted command that decodes to the
+		// allowed form is still allowed (decoding is symmetric, no false denial).
+		{"plain ps allowed", allow, "ps aux", true, false, true},
+		{"quoted ps allowed", allow, "'ps' aux", true, false, true},
+		{"quoted-arg ps allowed", allow, `ps "aux"`, true, false, true},
+		// require_approval ^reboot: quoting must not drop the approval gate.
+		{"plain reboot needs approval", approval, "reboot", true, true, true},
+		{"quoted reboot needs approval", approval, "'reboot'", true, true, true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			allowed, approval, _, err := PolicySet{tc.cp}.Decide(tc.command)
+			if tc.wantErrNil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.wantErrNil && err == nil {
+				t.Fatal("expected a fail-closed error but got nil")
+			}
+			if allowed != tc.wantAllowed {
+				t.Errorf("allowed=%v, want %v (err=%v)", allowed, tc.wantAllowed, err)
+			}
+			if approval != tc.wantApproval {
+				t.Errorf("approval=%v, want %v", approval, tc.wantApproval)
+			}
+		})
+	}
+}
+
 // TestCommandPolicyDefaultParsesChainedCommands is the #211 acceptance criterion:
 // with default config (no shell_parse set) an allowlist that matches only the
 // first word must not let a chained command ride past it.


### PR DESCRIPTION
## Problem (HIGH — firewall bypass)

The command policy — the signer-side \"AI-action firewall\", billed in THREAT_MODEL as the *hard guarantee* against a compromised broker — parsed each command but matched the deny / \`require_approval\` / allow regexes against the command's **quote-preserving** printed form (`printer.Print`). The target shell strips quoting at exec time, so a caller could wrap the command name to dodge a rule the executed command would hit.

Empirically confirmed against the real `PolicySet.Decide` (denylist `^rm `, `^reboot`; no allowlist → default-allow):

| command | before | after |
|---|---|---|
| `rm -rf /data` | denied ✓ | denied |
| `'rm' -rf /data` | **allowed** ✗ | denied |
| `r"m" -rf /data` | **allowed** ✗ | denied |
| `$'\x72\x6d' -rf /data` | **allowed** ✗ | denied |
| `rm$IFS-rf /data` | **allowed** ✗ | rejected (fail-closed) |
| `LD_PRELOAD=/e.so rm -rf /data` | **allowed** ✗ | rejected (fail-closed) |
| `'reboot'` (require_approval `^reboot`) | **ran, no approval** ✗ | gated |

Allowlist hosts were already fail-closed (the encoded form also misses the allow set → denied), which caps this at High, not Critical.

## Fix

`extractCommands` now returns each simple command's **decoded literal** (quoting/encoding removed via `expand.Literal`), so the policy matches what the target shell will actually run. A command word whose value the policy cannot know statically — a parameter/command/arithmetic expansion (`$IFS`, `$(…)`), or an inline env assignment (`FOO=bar cmd`) — is **rejected fail-closed** (same rationale as the existing standalone-assignment / `export` / file-redirect rejections). Decoding is symmetric: a legitimately quoted command that decodes to an allowed/approval form is still allowed/gated.

A fresh `expand.Config` is built per call — `expand` mutates the config in place (`prepareConfig` sets `Env`/`ifs`), so a shared instance races under concurrent `Decide` (caught by `-race`).

**Impact:** denylist / `require_approval` / allowlist hosts whose policies relied on quoting, or on an unquoted `$VAR`/env-prefix in a command, may see new denials — the safe direction, consistent with the #211 parse-by-default posture.

## Verified

- `make verify` green: gofmt, `go vet`, build, **race** tests, govulncheck (no vulns affecting our code), strict docs, no reference drift. Full `./...` suite passes.
- New `TestCommandPolicyQuotingBypassClosed` covers quoted / partial-quote / ANSI-C / `$IFS` / inline-env vectors across deny, `require_approval` and allowlist policies (and asserts legitimately-quoted commands still match).

Closes #277