### PR TITLE
fix(audit): bound entry size so a redaction-expanded record can't brick startup (#278)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,6 +116,18 @@
   full WAL checkpoint (fsync of the WAL and the DB) before returning success, so a
   freeze that the API acknowledged survives power loss. Grants and approve-and-learn
   waivers stay `NORMAL` — a lost widening fails safe.
+- **Audit entries are bounded so a redaction-expanded record can't brick startup
+  (#278)** — redaction runs on every entry and *expands* free-text (`AUTH=a` →
+  `AUTH=[REDACTED:env-assignment]`), while the command was bounded only by the
+  64 KiB request body. A crafted ~63 KiB command of `AUTH=…` tokens inflated the
+  serialized entry past the 256 KiB `bufio.Scanner` the readers use; the running
+  process kept appending (its chain is in memory), but the **next restart**
+  failed — `restoreChain` returned `bufio.ErrTooLong`, and with audit required
+  and fail-closed the service refused to boot (a latent, caller-triggered DoS
+  that `audit repair` could not fix, since the line is valid JSON). `Append` now
+  trims the free-text fields (longest first, with a `...[TRUNCATED]` marker,
+  still under the entry signature) to a single-sourced size below the reader
+  buffer, so every line the writer emits is always readable.
 
 ### Internal
 - **Sealed exec named as a designed future control (#144, Part A)** — THREAT_MODEL

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/luisgf/infrabroker/internal/monitor"
 )
@@ -48,6 +49,23 @@ const (
 // with a timestamp suffix. 0 disables rotation. The default (100 MiB) prevents
 // the disk from filling up and writes from failing silently.
 const AuditLogMaxSize int64 = 100 * 1024 * 1024 // 100 MiB
+
+// readerBufferSize is the bufio.Scanner token cap the audit readers allocate
+// (restoreChain, Verify, FileBounds). A written line MUST fit it, or the reader
+// returns bufio.ErrTooLong and — since audit is required and fail-closed — the
+// service refuses to start. maxEntryBytes bounds the writer strictly below it.
+const readerBufferSize = 256 * 1024
+
+// maxEntryBytes bounds a serialized audit line so every line the writer emits is
+// readable. Redaction can EXPAND a free-text field ("AUTH=a" ->
+// "AUTH=[REDACTED:env-assignment]") and the command is otherwise bounded only by
+// the request-body cap, so without this a crafted command could inflate an entry
+// past readerBufferSize and brick fail-closed startup on the next restart (#278).
+const maxEntryBytes = readerBufferSize
+
+// truncatedMarker is appended to a free-text field trimmed to fit maxEntryBytes,
+// so the truncation is visible (and still covered by the entry signature).
+const truncatedMarker = "...[TRUNCATED]"
 
 // rotationTimeFormat is the timestamp suffix a rotated segment carries
 // (<log>.<rotationTimeFormat>). Single-sourced with rotatedSegmentPath (writer)
@@ -212,7 +230,7 @@ func (l *Log) restoreChain() error {
 	defer f.Close()
 
 	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 256*1024), 256*1024) // entries up to 256 KiB
+	sc.Buffer(make([]byte, readerBufferSize), readerBufferSize)
 	var lastLine []byte
 	for sc.Scan() {
 		if b := sc.Bytes(); len(b) > 0 {
@@ -400,6 +418,11 @@ func (l *Log) doAppend(e Entry) error {
 		e.Anomaly = l.redactor.Redact(e.Anomaly)
 	}
 
+	// Bound the serialized entry so the line stays readable by the fixed-size
+	// reader buffer: redaction can expand a free-text field past readerBufferSize,
+	// which would otherwise wedge fail-closed startup on the next restart (#278).
+	fitEntry(&e)
+
 	// L2: rotate if the file has reached the size limit.
 	l.maybeRotate()
 	// A reopen failure during rotation (or a prior write) can leave l.f nil;
@@ -457,6 +480,59 @@ func (l *Log) doAppend(e Entry) error {
 	myCount := l.writeCount
 
 	return l.syncTo(myCount)
+}
+
+// fitEntry trims e's free-text fields (Command/Err/Warning/Anomaly, longest
+// first) so the serialized, signed line fits within maxEntryBytes and stays
+// readable by the reader buffer. Only these four fields carry unbounded /
+// redaction-expanded text; every other field is short metadata and is never
+// trimmed. The loop terminates because each source byte contributes at least one
+// JSON byte, so removing the overage from the longest field always makes
+// progress; once all four are empty the entry is pure metadata and fits.
+func fitEntry(e *Entry) {
+	// Reserve headroom for the fields set (or grown) AFTER this measurement:
+	// seq, prev_hash (64 hex), the base64 signature (88), time, and the newline.
+	const reserve = 1024
+	budget := maxEntryBytes - reserve
+	fields := []*string{&e.Command, &e.Err, &e.Warning, &e.Anomaly}
+	// At most a couple of passes are needed (each trim removes the full overage);
+	// the bound is a generous backstop covering marker re-add and rune rounding.
+	for i := 0; i < 8; i++ {
+		b, err := json.Marshal(e)
+		if err != nil || len(b) <= budget {
+			return
+		}
+		longest := longestField(fields)
+		if longest == nil || *longest == "" {
+			return // only metadata remains; nothing left to trim
+		}
+		*longest = truncateField(*longest, len(b)-budget)
+	}
+}
+
+// longestField returns the field pointer with the longest current value.
+func longestField(fields []*string) *string {
+	var longest *string
+	for _, f := range fields {
+		if longest == nil || len(*f) > len(*longest) {
+			longest = f
+		}
+	}
+	return longest
+}
+
+// truncateField shortens s by at least `over` bytes and appends truncatedMarker
+// so the trim is visible in the (still-signed) record. It cuts on a UTF-8 rune
+// boundary so the field stays valid text.
+func truncateField(s string, over int) string {
+	keep := len(s) - over - len(truncatedMarker)
+	if keep < 0 {
+		keep = 0
+	}
+	for keep > 0 && !utf8.RuneStart(s[keep]) {
+		keep--
+	}
+	return s[:keep] + truncatedMarker
 }
 
 // syncTo blocks until every write up to and including count is durably fsynced,

--- a/internal/audit/log_test.go
+++ b/internal/audit/log_test.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
@@ -10,8 +11,77 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// expandRedactor models a redaction rule that EXPANDS its input, like the
+// env-assignment default ("AUTH=a" -> "AUTH=[REDACTED:env-assignment]").
+type expandRedactor struct{ factor int }
+
+func (e expandRedactor) Redact(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.Repeat(s, e.factor)
+}
+
+// TestAppendBoundsRedactionExpandedEntry is the #278 acceptance criterion: a
+// redactor that inflates a free-text field past the reader buffer must not
+// produce a line the readers cannot scan. Otherwise the next restart's
+// restoreChain (and `audit verify`) fail with bufio.ErrTooLong and, since audit
+// is required and fail-closed, the service refuses to start.
+func TestAppendBoundsRedactionExpandedEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	key := testKey()
+
+	l, err := Open(path, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.SetRedactor(expandRedactor{factor: 6})
+
+	// A command well under the 64 KiB request-body cap that redaction inflates
+	// far past the 256 KiB reader buffer (~63 KiB -> ~378 KiB).
+	cmd := strings.Repeat("AUTH=a ", 9000)
+	if err := l.Append(Entry{Caller: "agent", Host: "web01", Command: cmd, Outcome: "denied"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n")) {
+		if len(line) > readerBufferSize {
+			t.Fatalf("audit line is %d bytes, exceeds reader buffer %d", len(line), readerBufferSize)
+		}
+	}
+	if !bytes.Contains(data, []byte(truncatedMarker)) {
+		t.Errorf("expected the oversized field to carry %q", truncatedMarker)
+	}
+
+	// Reopen (restoreChain) — the exact restart path #278 bricked — and verify.
+	l2, err := Open(path, key)
+	if err != nil {
+		t.Fatalf("reopen after an oversized (redaction-expanded) entry must succeed: %v", err)
+	}
+	if err := l2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	total, errs := Verify(f, key.Public().(ed25519.PublicKey), func(string, ...any) {})
+	if total != 1 || errs != 0 {
+		t.Errorf("Verify: total=%d errs=%d, want 1 and 0", total, errs)
+	}
+}
 
 // faultySink wraps a logFile and can inject a Sync failure after a successful
 // Write, modelling a transient fsync I/O error. Used to prove that such a fault

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -33,7 +33,7 @@ import (
 // reported through reportf; returns (entries read, errors).
 func Verify(r io.Reader, pub ed25519.PublicKey, reportf func(format string, args ...any)) (total, errs int) {
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 256*1024), 256*1024)
+	sc.Buffer(make([]byte, readerBufferSize), readerBufferSize)
 
 	var prevHash string
 	var prevSeq uint64
@@ -199,7 +199,7 @@ func FileBounds(path string) (firstPrevHash, lastHash string, err error) {
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 256*1024), 256*1024)
+	sc.Buffer(make([]byte, readerBufferSize), readerBufferSize)
 	first := true
 	for sc.Scan() {
 		b := sc.Bytes()


### PR DESCRIPTION
## Problem (HIGH — latent, caller-triggered DoS + audit wedge)

Redaction runs on **every** audit entry and *expands* free-text — the `env-assignment` default turns `AUTH=a` (6 B) into `AUTH=[REDACTED:env-assignment]` (30 B). The command is otherwise bounded only by the 64 KiB request body, and the serialized entry had **no size cap**. Every reader uses a 256 KiB `bufio.Scanner` (`restoreChain`, `Verify`, `FileBounds`).

A caller submits a ~63 KiB command of repeated `AUTH=a ` (audited whether executed or, on a host with no command policy, allowed). Redaction inflates it to ~378 KiB. The running process keeps appending (its chain is in memory), so the damage is **latent until the next restart**: `restoreChain`'s scanner returns `bufio.ErrTooLong` → `Open` fails → with audit required and fail-closed **the service refuses to boot**. `broker-ctl audit verify` also errors on the line, and `audit repair` can't fix it (the line is valid JSON, just too long). Affects the signer, control-plane and broker audit logs (shared code, precondition: redaction enabled — a recommended control for gap #8).

## Fix

`Append` now trims the free-text fields (`Command`/`Err`/`Warning`/`Anomaly`, longest first, with a `...[TRUNCATED]` marker, **before** signing so the trim is covered by the signature) to a single-sourced `maxEntryBytes` that sits below the reader buffer. The three reader sites now use the same `readerBufferSize` constant, so the writer/reader relationship is explicit and can't drift. Only those four fields are unbounded/redaction-expanded; all other fields are short metadata.

## Verified

- `make verify` green: gofmt, `go vet`, build, **race** tests, govulncheck, strict docs, no reference drift. Full `./...` suite passes.
- New `TestAppendBoundsRedactionExpandedEntry`: appends a redaction-expanded ~378 KiB entry, then asserts every physical line fits `readerBufferSize`, the record carries the truncation marker, and — the exact path #278 bricked — **reopen (`restoreChain`) and `Verify` both succeed**.

Closes #278