### PR TITLE
fix(audit): order same-second segments numerically in verify --all (#272)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,6 +116,14 @@
   100 MiB rotates far apart), but a latent audit-integrity hole. Rotation now
   appends a `.<n>` disambiguator when the timestamped name already exists, and
   segment discovery recognises it; plain timestamps stay backward-compatible.
+- **`audit verify --all` orders same-second segments numerically (#272)** —
+  completing #257: discovery sorted segments with `sort.Strings`, which orders the
+  `.<n>` disambiguator lexicographically (`.10` before `.2`). Once ten or more
+  segments landed in one second, `VerifySegments` checked cross-segment linkage in
+  the wrong order and falsely reported the intact chain as broken. Discovery now
+  orders by `(timestamp, numeric n)`. Fail-safe (a false positive only; it could
+  never mask tampering) and, like #257, only reachable with a small
+  `max_file_size` or an extreme append rate.
 
 ### Security
 - **Command policy matches the decoded command, closing a deny/approval bypass

--- a/internal/audit/rotation_collision_test.go
+++ b/internal/audit/rotation_collision_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 )
@@ -80,5 +81,63 @@ func TestRotationSameSecondNoRecordLoss(t *testing.T) {
 	total, errs := VerifySegments(path, pub(testKey()), discardReport)
 	if total != n || errs != 0 {
 		t.Fatalf("VerifySegments = (%d,%d); want (%d,0) — same-second rotations lost records (#257)", total, errs, n)
+	}
+}
+
+// TestVerifySegmentsOrdersDoubleDigitSameSecond pins #272: with ten or more
+// same-second segments, discovery must order them numerically (…​.9, .10, .11),
+// not lexicographically (.10, .11, .2). Before the fix VerifySegments compared
+// cross-segment linkage in the wrong order and falsely reported the intact chain
+// broken. n=12 crosses the .10 boundary where sort.Strings diverges.
+func TestVerifySegmentsOrdersDoubleDigitSameSecond(t *testing.T) {
+	l, path := openTmp(t)
+	l.maxFileSize = 1 // every append rotates the previous (non-empty) file
+
+	const n = 12
+	for i := 0; i < n; i++ {
+		if err := l.Append(Entry{Caller: "c", Host: "h:22", Command: "id", Outcome: "executed"}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	l.Close()
+
+	total, errs := VerifySegments(path, pub(testKey()), discardReport)
+	if total != n || errs != 0 {
+		t.Fatalf("VerifySegments = (%d,%d); want (%d,0) — >=10 same-second segments misordered (#272)", total, errs, n)
+	}
+}
+
+// TestSegmentOrderNumericSuffix directly pins the numeric ordering that #272
+// requires: .10/.11 sort AFTER .2/.9, unlike sort.Strings.
+func TestSegmentOrderNumericSuffix(t *testing.T) {
+	prefix := "/var/log/audit.log."
+	files := []string{
+		prefix + "20260711T102224Z.10",
+		prefix + "20260711T102224Z.2",
+		prefix + "20260711T102224Z",
+		prefix + "20260711T102224Z.11",
+		prefix + "20260711T102224Z.9",
+		prefix + "20260712T000000Z.1",
+	}
+	sort.Slice(files, func(i, j int) bool {
+		ti, ni := segmentOrder(prefix, files[i])
+		tj, nj := segmentOrder(prefix, files[j])
+		if ti != tj {
+			return ti < tj
+		}
+		return ni < nj
+	})
+	want := []string{
+		prefix + "20260711T102224Z",
+		prefix + "20260711T102224Z.2",
+		prefix + "20260711T102224Z.9",
+		prefix + "20260711T102224Z.10",
+		prefix + "20260711T102224Z.11",
+		prefix + "20260712T000000Z.1",
+	}
+	for i := range want {
+		if files[i] != want[i] {
+			t.Errorf("position %d = %q, want %q", i, files[i], want[i])
+		}
 	}
 }

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -163,14 +164,18 @@ func VerifySegments(logPath string, pub ed25519.PublicKey, reportf func(string, 
 }
 
 // discoverSegments returns the rotated segments of logPath followed by the
-// active file, sorted oldest→newest (the timestamp suffix — and its ".<n>"
-// same-second disambiguator — sorts chronologically). Only true rotation
-// segments are included, recognised by isRotatedSegment (single-sourced with what
-// maybeRotate/rotatedSegmentPath write). This deliberately excludes sibling files
-// that share the "<logPath>." glob prefix but are NOT segments, notably the
-// `audit repair` quarantine file (<logPath>.corrupt-<ts>), whose quarantined bytes
-// are malformed by definition and would otherwise make `verify --all` falsely
-// report a repaired chain broken.
+// active file, sorted oldest→newest. Ordering is by (timestamp, numeric .<n>):
+// the timestamp suffix is fixed-width so it sorts chronologically as a string,
+// but the ".<n>" same-second disambiguator must be compared NUMERICALLY —
+// sort.Strings would put ".10" before ".2" and make VerifySegments compare
+// cross-segment linkage in the wrong order, falsely reporting an intact chain
+// as broken once ten or more segments land in one second (#272). Only true
+// rotation segments are included, recognised by isRotatedSegment (single-sourced
+// with what maybeRotate/rotatedSegmentPath write). This deliberately excludes
+// sibling files that share the "<logPath>." glob prefix but are NOT segments,
+// notably the `audit repair` quarantine file (<logPath>.corrupt-<ts>), whose
+// quarantined bytes are malformed by definition and would otherwise make
+// `verify --all` falsely report a repaired chain broken.
 func discoverSegments(logPath string) ([]string, error) {
 	matches, err := filepath.Glob(logPath + ".*")
 	if err != nil {
@@ -183,11 +188,32 @@ func discoverSegments(logPath string) ([]string, error) {
 			files = append(files, m)
 		}
 	}
-	sort.Strings(files)
+	sort.Slice(files, func(i, j int) bool {
+		ti, ni := segmentOrder(prefix, files[i])
+		tj, nj := segmentOrder(prefix, files[j])
+		if ti != tj {
+			return ti < tj
+		}
+		return ni < nj
+	})
 	if _, err := os.Stat(logPath); err == nil {
 		files = append(files, logPath)
 	}
 	return files, nil
+}
+
+// segmentOrder returns the sort key for a rotated segment path: its fixed-width
+// timestamp suffix (lexicographic == chronological) and the numeric same-second
+// disambiguator (.<n>, 0 when absent). isRotatedSegment has already guaranteed
+// the shape, so the digits parse; a defensive parse failure sorts as 0.
+func segmentOrder(prefix, path string) (ts string, n int) {
+	suffix := strings.TrimPrefix(path, prefix)
+	ts = suffix
+	if i := strings.IndexByte(suffix, '.'); i >= 0 {
+		ts = suffix[:i]
+		n, _ = strconv.Atoi(suffix[i+1:])
+	}
+	return ts, n
 }
 
 // FileBounds returns the prev_hash of the first entry and the SHA-256 of the


### PR DESCRIPTION
## Problem (completes #257)

`discoverSegments` sorted rotated segments with `sort.Strings` (byte-lexicographic). The same-second disambiguator `.<n>` added in #257 is unpadded, so lexicographically `.10` and `.11` sort **before** `.2`. Once ten or more segments landed in one wall-clock second, `VerifySegments` walked them out of creation order and its cross-segment linkage check (`segment[i].firstPrevHash == segment[i-1].lastHash`) failed — falsely reporting an **intact** chain as `dropped, truncated, replaced, or reordered`, so `broker-ctl audit verify --all` printed FAIL.

Fail-safe (a false positive only — SHA-256 linkage can never accidentally re-link a genuinely reordered/tampered chain, so it cannot mask tampering) and, like #257, only reachable with a small `max_file_size` or an extreme append rate. It is the reader-half of #257, which fixed only the writer's naming.

## Fix

Discovery now orders by `(timestamp, numeric n)`: the fixed-width timestamp stays chronological as a string, and the `.<n>` suffix is parsed and compared as an integer (`segmentOrder`).

## Verified

- `make verify` green (gofmt, vet, build, race, govulncheck, strict docs, no drift).
- New `TestVerifySegmentsOrdersDoubleDigitSameSecond`: rotates 12× in one second and asserts `verify --all` = `(12,0)`. Confirmed it reports `(12,3)` with the old `sort.Strings` (regression test proven to catch the bug). `TestSegmentOrderNumericSuffix` pins the comparator directly.

Closes #272