### PR TITLE
docs: correct stale binary/feature docs after the frontend unification (#273, #274, #275)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Built by goreleaser (see .goreleaser.yaml): the context already contains
-# the six prebuilt static binaries for the target platform — no compilation
-# happens here, so the image stays bit-identical to the release archives.
+# the seven prebuilt static binaries for the target platform — no compilation
+# happens here, so the image binaries are bit-identical to the release archives.
 #
 # distroless/static ships CA roots (outbound TLS to the signer / OIDC / Azure
 # Key Vault) and a nonroot user (uid 65532), and nothing else: no shell, no

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -50,9 +50,9 @@ make signer                  # or just one
 ```
 
 Compiled binaries: `~/bin/infrabroker` (the unified broker frontend) · `~/bin/signer`
-· `~/bin/broker-ctl` · `~/bin/control-plane`, plus the **deprecated** compat
-wrappers `~/bin/{broker, mcp-broker, mcp-broker-http}` (each just runs the matching
-`infrabroker serve-*`). `make install` injects the version from `git describe
+· `~/bin/broker-ctl` · `~/bin/control-plane` · `~/bin/approval-bridge`, plus the
+**deprecated** compat wrappers `~/bin/{broker, mcp-broker, mcp-broker-http}` (each
+just runs the matching `infrabroker serve-*`). `make install` injects the version from `git describe
 --tags`; a plain `go build ./cmd/...` still works but reports a `dev-<commit>`
 version. Run `make version` to see what would be embedded.
 

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -2,8 +2,10 @@
 // local PKI and writes a custody-separated two-service config (a signer that
 // holds the SSH CA + a broker in remote mode), installs a default-deny starter
 // policy, and prints the per-host sshd enrolment snippet — the fast path from
-// zero to a policy-gated agent. It does NOT do remote enrolment (that stays a
-// printed snippet), bulk ~/.ssh/config import, or MCP auto-registration.
+// zero to a policy-gated agent. Two opt-in flags extend it: --import-ssh-config
+// bulk-imports hosts from ~/.ssh/config, and --register-mcp registers the stdio
+// MCP with Claude Code. Remote host enrolment is NOT automated: it stays a
+// printed sshd snippet the operator runs on each managed host.
 package initcmd
 
 import (


### PR DESCRIPTION
Three concrete, checkable doc-drift fixes, all stale since the frontend unification / `init` phase-2:

- **#273** — `docs/OPERATIONS.md` §1 "Compiled binaries" enumerated 7 binaries but omitted `approval-bridge`, which `make install` builds (`Makefile` CMDS) and which the same document tells operators to run. Added it to the non-wrapper list.
- **#274** — the `internal/initcmd` package godoc stated init does **NOT** do `~/.ssh/config` import or MCP registration; phase-2 (#269/#270) added both as the `--import-ssh-config` / `--register-mcp` flags. Reworded: those are opt-in flags; only remote host enrolment stays a printed snippet.
- **#275** — `Dockerfile` header comment said "the **six** prebuilt static binaries" but the `COPY` brings **seven** (stale since the `infrabroker` binary was added). Fixed the count; tightened "bit-identical" to refer to the binaries (the archive is a superset).

Docs/comment-only — no code paths change. `make verify` green (strict mkdocs build, no reference drift).

Closes #273
Closes #274
Closes #275