### PR TITLE
fix(audit): seed the chain from the newest segment after a rotation-boundary crash (#279)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -124,6 +124,15 @@
   orders by `(timestamp, numeric n)`. Fail-safe (a false positive only; it could
   never mask tampering) and, like #257, only reachable with a small
   `max_file_size` or an extreme append rate.
+- **Audit chain survives a crash at the rotation boundary (#279)** — `maybeRotate`
+  renames the old segment and creates an empty active file, carrying the chain
+  forward only via the in-memory `prev_hash`. A hard crash (power loss) after the
+  rename but before the triggering record landed left an empty active file; on
+  restart `restoreChain` re-seeded at genesis (`prev_hash=""`) and ignored the
+  rotated segments, so the next entry broke cross-segment linkage and
+  `verify --all` falsely reported the chain corrupt. `restoreChain` now seeds
+  `prev_hash` from the newest rotated segment when the active file is empty or
+  absent. Fail-safe (a false positive only) and a narrow crash window.
 
 ### Security
 - **Command policy matches the decoded command, closing a deny/approval bypass

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -222,7 +222,11 @@ func Open(path string, signKey ed25519.PrivateKey) (*Log, error) {
 func (l *Log) restoreChain() error {
 	f, err := os.Open(l.path)
 	if os.IsNotExist(err) {
-		return nil // new file — chain starts from zero
+		// No active file. A crash right at a rotation boundary can leave this state
+		// with rotated segments present (maybeRotate renamed the old file and had
+		// not yet written the new one), so seed the chain head from the newest
+		// rotated segment instead of genesis (#279).
+		return l.seedFromRotatedSegments()
 	}
 	if err != nil {
 		return fmt.Errorf("reading existing log: %w", err)
@@ -242,7 +246,12 @@ func (l *Log) restoreChain() error {
 		return fmt.Errorf("scanning existing log: %w", err)
 	}
 	if len(lastLine) == 0 {
-		return nil // empty file — chain starts from zero
+		// Empty active file: maybeRotate creates the new segment empty and carries
+		// the chain forward only via the in-memory prevHash, so a crash after the
+		// rename but before the first record landed leaves an empty active file with
+		// the real chain head in the newest rotated segment. Seed from it, or the
+		// next Append would write prev_hash="" and break cross-segment linkage (#279).
+		return l.seedFromRotatedSegments()
 	}
 
 	// Detect a torn final write: if the file does not end with a newline, the
@@ -264,6 +273,37 @@ func (l *Log) restoreChain() error {
 	l.seq = e.Seq
 	sum := sha256.Sum256(lastLine)
 	l.prevHash = hex.EncodeToString(sum[:])
+	return nil
+}
+
+// seedFromRotatedSegments sets prevHash from the newest rotated segment's last
+// line, for the case where the active file is empty or absent but rotated
+// segments exist — the on-disk state a crash right at a rotation boundary leaves
+// behind. seq stays 0: it restarts per file, so the new active file's first entry
+// is seq 1 regardless; only the prevHash link across the boundary must be
+// recovered so VerifySegments does not see a broken chain (#279). No rotated
+// segment means a genuine fresh start (genesis).
+func (l *Log) seedFromRotatedSegments() error {
+	segments, err := discoverSegments(l.path)
+	if err != nil {
+		return fmt.Errorf("discovering rotated segments: %w", err)
+	}
+	// discoverSegments appends the active file (l.path) last when it exists; the
+	// rotated segments are everything else, ordered oldest→newest.
+	newest := ""
+	for _, s := range segments {
+		if s != l.path {
+			newest = s
+		}
+	}
+	if newest == "" {
+		return nil // no rotated segments — genuine genesis
+	}
+	_, lastHash, err := FileBounds(newest)
+	if err != nil {
+		return fmt.Errorf("seeding chain from rotated segment %s: %w", newest, err)
+	}
+	l.prevHash = lastHash
 	return nil
 }
 

--- a/internal/audit/log_test.go
+++ b/internal/audit/log_test.go
@@ -26,6 +26,53 @@ func (e expandRedactor) Redact(s string) string {
 	return strings.Repeat(s, e.factor)
 }
 
+// TestRestoreChainSeedsFromRotatedSegmentAfterCrash pins #279: a crash right at a
+// rotation boundary can leave an EMPTY active file with the real chain head in the
+// newest rotated segment. On restart the chain must seed its prev_hash from that
+// segment, not from genesis — otherwise the next Append writes prev_hash="" and
+// VerifySegments falsely reports the intact cross-segment chain as broken.
+func TestRestoreChainSeedsFromRotatedSegmentAfterCrash(t *testing.T) {
+	l, path := openTmp(t)
+	l.maxFileSize = 1 // every append after a non-empty file rotates the previous one
+
+	// E1 lands in the active file; E2 rotates E1 into a segment and lands in a new
+	// active file.
+	for _, cmd := range []string{"id", "uptime"} {
+		if err := l.Append(Entry{Caller: "c", Host: "h:22", Command: cmd, Outcome: "executed"}); err != nil {
+			t.Fatalf("Append %q: %v", cmd, err)
+		}
+	}
+	l.Close()
+
+	// Simulate the rotation-boundary crash: the active file is emptied (the record
+	// that triggered the rotation never durably landed), leaving the rotated
+	// segment(s) with the chain head. Truncate rather than delete to model an
+	// empty-but-present active file.
+	if err := os.Truncate(path, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen (restoreChain) — must seed prev_hash from the newest rotated segment.
+	l2, err := Open(path, testKey())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if err := l2.Append(Entry{Caller: "c", Host: "h:22", Command: "whoami", Outcome: "executed"}); err != nil {
+		t.Fatalf("Append after reopen: %v", err)
+	}
+	l2.Close()
+
+	// The cross-segment chain (rotated segment -> new active) must verify: the new
+	// active entry's prev_hash links to the rotated segment's last line.
+	total, errs := VerifySegments(path, pub(testKey()), discardReport)
+	if errs != 0 {
+		t.Fatalf("VerifySegments errs=%d, want 0 — chain head lost across a rotation-boundary crash (#279)", errs)
+	}
+	if total < 2 {
+		t.Fatalf("VerifySegments total=%d, want >=2 (rotated segment + new active)", total)
+	}
+}
+
 // TestAppendBoundsRedactionExpandedEntry is the #278 acceptance criterion: a
 // redactor that inflates a free-text field past the reader buffer must not
 // produce a line the readers cannot scan. Otherwise the next restart's


### PR DESCRIPTION
## Problem

`maybeRotate` renames the old segment and creates an **empty** active file, carrying the chain forward only via the in-memory `prevHash`. A hard crash (power loss) after the rename but before the triggering record durably landed leaves an **empty active file** whose real chain head lives in the newest rotated segment.

On restart, `restoreChain` saw the empty active file and returned genesis (`seq=0, prev_hash=""`), never consulting the rotated segments. The next `Append` then wrote `prev_hash=""`, and `VerifySegments` reported the active segment's `firstPrev ("")` does not link to the previous segment's `lastHash` — a false `segment dropped, truncated, replaced, or reordered` for a benign crash.

Fail-safe (it over-reports; it cannot mask tampering) and a narrow crash window, but it breaks the cross-segment integrity guarantee `maybeRotate` promises across restarts.

## Fix

`restoreChain` now seeds `prevHash` from the newest rotated segment's last line (`seedFromRotatedSegments`, via `FileBounds`) when the active file is empty or absent. `seq` stays 0 — it restarts per file, so the new active file's first entry is `seq 1` regardless; only the cross-boundary `prev_hash` link must be recovered.

## Verified

- `make verify` green (gofmt, vet, build, race, govulncheck, strict docs, no drift).
- New `TestRestoreChainSeedsFromRotatedSegmentAfterCrash`: rotates, empties the active file to model the crash, reopens, appends, and asserts `verify --all` is clean. Confirmed it reports `errs=1` without the fix.

Closes #279