### PR TITLE
fix(audit): record in-conversation approval grant/decline decisions (#280)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1117,6 +1117,7 @@ serial in the `Accepted certificate` log line.
 | `warning` | Advisory warning, e.g. command-policy audit mode would have denied or required approval. |
 | `approval_id` | Approval request id (control plane log; omitted if none). |
 | `approved_by` | CN of the approver (control plane log; omitted if none). |
+| `approved_via` | How a `require_approval` command was approved outside the control plane: `elicitation` for an in-conversation approval (#118). Set on the broker's `approval_granted` and resulting `executed` records; omitted otherwise. |
 | `anomaly` | Behavioral anomalies detected (control plane log): `rate-exceeded`, `new-host:<h>`, `new-command:<c>`. |
 | `err` | Error message on denial or failure (omitted on success). |
 | `prev_hash` | SHA-256 hex of the previous log line (chain integrity). |
@@ -1144,6 +1145,8 @@ serial in the `Accepted certificate` log line.
 | `approval-waiver-skipped` | Signer | Learn requested but the command is not `require_approval`; nothing waived. |
 | `approval-waiver-failed` | Signer | Approve-and-learn waiver creation failed (best-effort; the cert was still issued). |
 | `executed` | Broker | One-shot command completed. |
+| `approval_granted` | Broker | A `require_approval` command was approved in-conversation via elicitation (#118); recorded before execution. |
+| `approval_declined` | Broker | A `require_approval` command was presented via elicitation and the human declined; nothing executed. |
 | `dry_run_allowed` | Broker | Dry-run: command would be allowed (nothing executed). |
 | `dry_run_denied` | Broker | Dry-run: command would be denied (nothing executed). |
 | `denied` | Broker | Request rejected before execution. |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -124,6 +124,15 @@
   orders by `(timestamp, numeric n)`. Fail-safe (a false positive only; it could
   never mask tampering) and, like #257, only reachable with a small
   `max_file_size` or an extreme append rate.
+- **In-conversation approvals are now fully audited (#280)** — with
+  `approval_via_elicitation`, a human's **decline** was returned to the agent
+  with no audit record (indistinguishable from the agent giving up), and an
+  **approved** execution logged plain `executed` — identical to a non-gated one.
+  The broker now records an `approval_granted` entry (before execution, so the
+  decision is durable even if the command later fails) and an `approval_declined`
+  entry, both carrying `approved_via: "elicitation"`, and stamps the resulting
+  `executed` record with `approved_via` too. A granted approval that cannot be
+  durably audited fails closed (the command does not run).
 
 ### Security
 - **Command policy matches the decoded command, closing a deny/approval bypass

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -147,6 +147,12 @@ type Entry struct {
 	// Human approval (control plane).
 	ApprovalID string `json:"approval_id,omitempty"` // approval request id
 	ApprovedBy string `json:"approved_by,omitempty"` // CN of the approver
+	// ApprovedVia records HOW a require_approval command was approved when it did
+	// not go through the control plane: "elicitation" for an in-conversation
+	// approval (#118). It is set on the approval_granted decision record and on the
+	// resulting executed record, so an approved execution is distinguishable from a
+	// non-gated one; the control-plane path sets ApprovalID/ApprovedBy instead.
+	ApprovedVia string `json:"approved_via,omitempty"`
 
 	// Behaviour guardrails (control plane).
 	Anomaly string `json:"anomaly,omitempty"` // detected anomalies (rate-exceeded, new-host:..., new-command:...)

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -1079,17 +1079,22 @@ func (e *Engine) Execute(ctx context.Context, c Caller, host, command string, tt
 	// "executed" record cannot be persisted — the agent gets ErrAuditUnavailable
 	// instead of untraceable output (the remote side effect is the documented
 	// residual of any post-execution audit).
+	approvedVia := ""
+	if opts.Approved {
+		approvedVia = approvalViaElicitation
+	}
 	if err := e.auditE(audit.Entry{
-		Caller:     c.ID,
-		Host:       host,
-		Command:    command,
-		Serial:     serial,
-		Outcome:    "executed",
-		ExitCode:   res.ExitCode,
-		Elevation:  opts.elevationLabel(),
-		PTY:        opts.PTY,
-		PolicyRule: decisionRule(dec),
-		Warning:    strings.Join(warnings, "; "),
+		Caller:      c.ID,
+		Host:        host,
+		Command:     command,
+		Serial:      serial,
+		Outcome:     "executed",
+		ExitCode:    res.ExitCode,
+		Elevation:   opts.elevationLabel(),
+		PTY:         opts.PTY,
+		PolicyRule:  decisionRule(dec),
+		Warning:     strings.Join(warnings, "; "),
+		ApprovedVia: approvedVia,
 	}); err != nil {
 		return nil, err
 	}
@@ -1434,6 +1439,42 @@ func (e *Engine) appendAudit(ent audit.Entry) error {
 		log.Printf("warning: error writing audit log: %v", err)
 	}
 	return nil
+}
+
+// approvalViaElicitation labels an audit record whose require_approval decision
+// was made in-conversation via elicitation (#118), distinct from the control
+// plane (which sets ApprovalID/ApprovedBy).
+const approvalViaElicitation = "elicitation"
+
+// AuditApprovalGranted records that a require_approval command was approved by a
+// human via in-conversation elicitation (#118), BEFORE it is re-executed. It
+// returns the fail-closed error so the caller does not proceed to run the command
+// when the approval cannot be durably recorded — the approval decision must be in
+// the log before the action it authorises.
+func (e *Engine) AuditApprovalGranted(c Caller, host, command, rule string) error {
+	return e.auditE(audit.Entry{
+		Caller:      c.ID,
+		Host:        host,
+		Command:     command,
+		Outcome:     "approval_granted",
+		PolicyRule:  rule,
+		ApprovedVia: approvalViaElicitation,
+	})
+}
+
+// AuditApprovalDeclined records that a require_approval command was presented to a
+// human via in-conversation elicitation (#118) and DECLINED, so the log
+// distinguishes "asked and declined" from "the agent gave up" or "the channel
+// failed". Best-effort: nothing ran, so a failed audit here changes no outcome.
+func (e *Engine) AuditApprovalDeclined(c Caller, host, command, rule string) {
+	_ = e.auditE(audit.Entry{
+		Caller:      c.ID,
+		Host:        host,
+		Command:     command,
+		Outcome:     "approval_declined",
+		PolicyRule:  rule,
+		ApprovedVia: approvalViaElicitation,
+	})
 }
 
 // ParseHostKey converts an authorized_keys line into an ssh.PublicKey.

--- a/internal/mcpserver/approval_test.go
+++ b/internal/mcpserver/approval_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/json"
 	"encoding/pem"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/luisgf/infrabroker/internal/audit"
 	"github.com/luisgf/infrabroker/internal/broker"
 	"github.com/luisgf/infrabroker/internal/signer"
 )
@@ -21,7 +23,7 @@ import (
 // local-mode engine whose host web01 requires approval for `systemctl restart`.
 // elicit toggles in-conversation approval; elicitHandler (when non-nil) answers
 // the server's elicitation on the client side.
-func approvalSession(t *testing.T, elicit bool, elicitHandler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) *mcp.ClientSession {
+func approvalSession(t *testing.T, elicit bool, elicitHandler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) (*mcp.ClientSession, string) {
 	t.Helper()
 	dir := t.TempDir()
 	_, caPriv, _ := ed25519.GenerateKey(rand.Reader)
@@ -70,7 +72,32 @@ func approvalSession(t *testing.T, elicit bool, elicitHandler func(context.Conte
 		t.Fatalf("client connect: %v", err)
 	}
 	t.Cleanup(func() { sess.Close() })
-	return sess
+	return sess, filepath.Join(dir, "audit.log")
+}
+
+// auditContains reports whether the audit log at path has an entry with the given
+// outcome, and returns that entry (the last match) for further assertions.
+func auditContains(t *testing.T, path, outcome string) (audit.Entry, bool) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	var found audit.Entry
+	ok := false
+	for _, line := range strings.Split(strings.TrimRight(string(b), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var e audit.Entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal audit line: %v", err)
+		}
+		if e.Outcome == outcome {
+			found, ok = e, true
+		}
+	}
+	return found, ok
 }
 
 func callRestart(t *testing.T, sess *mcp.ClientSession) *mcp.CallToolResult {
@@ -89,7 +116,7 @@ func callRestart(t *testing.T, sess *mcp.ClientSession) *mcp.CallToolResult {
 // command is denied with an approval message (the existing behaviour).
 func TestApprovalRequiredWithoutElicitation(t *testing.T) {
 	t.Parallel()
-	sess := approvalSession(t, false, nil)
+	sess, _ := approvalSession(t, false, nil)
 	res := callRestart(t, sess)
 	if !res.IsError || !strings.Contains(k8sToolText(t, res), "requires human approval") {
 		t.Fatalf("want approval-required error; got IsError=%v text=%q", res.IsError, k8sToolText(t, res))
@@ -104,7 +131,7 @@ func TestApprovalAcceptedViaElicitation(t *testing.T) {
 	accept := func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
 		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"approve": true}}, nil
 	}
-	sess := approvalSession(t, true, accept)
+	sess, auditLog := approvalSession(t, true, accept)
 	res := callRestart(t, sess)
 	text := k8sToolText(t, res)
 	if strings.Contains(text, "requires human approval") {
@@ -114,6 +141,18 @@ func TestApprovalAcceptedViaElicitation(t *testing.T) {
 	if !res.IsError {
 		t.Logf("note: command returned success (unexpected without a real host), text=%q", text)
 	}
+	// #280: the approval decision is recorded before execution, with the channel,
+	// even though the exec later fails on the unreachable host.
+	e, ok := auditContains(t, auditLog, "approval_granted")
+	if !ok {
+		t.Fatal("expected an approval_granted audit entry after an elicited approval")
+	}
+	if e.ApprovedVia != "elicitation" {
+		t.Errorf("approval_granted approved_via=%q, want %q", e.ApprovedVia, "elicitation")
+	}
+	if e.Command != "systemctl restart nginx" || e.Host != "web01" {
+		t.Errorf("approval_granted entry = %+v, want the elicited command/host", e)
+	}
 }
 
 // TestApprovalDeclinedViaElicitation: the human declines, so the command does not run.
@@ -122,10 +161,22 @@ func TestApprovalDeclinedViaElicitation(t *testing.T) {
 	decline := func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
 		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"approve": false}}, nil
 	}
-	sess := approvalSession(t, true, decline)
+	sess, auditLog := approvalSession(t, true, decline)
 	res := callRestart(t, sess)
 	if !res.IsError || !strings.Contains(k8sToolText(t, res), "declined") {
 		t.Fatalf("want declined error; got IsError=%v text=%q", res.IsError, k8sToolText(t, res))
+	}
+	// #280: the decline must be audited (was silently dropped before), and no
+	// command must have executed.
+	e, ok := auditContains(t, auditLog, "approval_declined")
+	if !ok {
+		t.Fatal("expected an approval_declined audit entry after the human declined")
+	}
+	if e.Command != "systemctl restart nginx" || e.PolicyRule == "" {
+		t.Errorf("approval_declined entry = %+v, want the declined command and its rule", e)
+	}
+	if _, executed := auditContains(t, auditLog, "executed"); executed {
+		t.Error("a declined command must not produce an executed audit entry")
 	}
 }
 

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -235,11 +235,20 @@ func registerExecute(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, e
 				if elErr != nil {
 					return toolError(elErr), executeOutput{}, nil
 				}
+				caller := callerFn(ctx)
 				if !approved {
+					// Audit the human's decline so the log distinguishes it from the
+					// agent giving up; nothing ran, so this is best-effort (#280).
+					eng.AuditApprovalDeclined(caller, in.Server, in.Command, appErr.Rule)
 					return toolError(fmt.Errorf("approval declined: %q was not run on %q", in.Command, in.Server)), executeOutput{}, nil
 				}
+				// Record the approval BEFORE acting on it; if it cannot be durably
+				// audited, do not execute (fail-closed, #280).
+				if aErr := eng.AuditApprovalGranted(caller, in.Server, in.Command, appErr.Rule); aErr != nil {
+					return toolError(aErr), executeOutput{}, nil
+				}
 				opts.Approved = true
-				res, err = eng.Execute(ctx, callerFn(ctx), in.Server, in.Command, in.TTLSeconds, opts)
+				res, err = eng.Execute(ctx, caller, in.Server, in.Command, in.TTLSeconds, opts)
 			}
 			if err != nil {
 				return toolError(err), executeOutput{}, nil


### PR DESCRIPTION
## Problem

With `approval_via_elicitation` (#118), the broker audit log was incomplete:
- A human's **decline** (`tools.go`) returned an error to the agent with **no audit record** — the log could not distinguish "asked and declined" from "the agent gave up" or "the elicitation channel failed".
- An **approved** execution logged a plain `executed` entry, **identical to a non-gated one** — the approval left no trace on the broker side (contrast the control-plane path, which records `ApprovedBy`/`ApprovalID`).

Forensics / four-eyes completeness gap (not a bypass — the model cannot set `Approved`).

## Fix

The broker now records the approval **decision** as a first-class event at the decision point:
- `AuditApprovalGranted` → `approval_granted`, written **before** re-execution so the decision is durable even if the command later fails; returns the fail-closed error, so a grant that can't be audited means the command does **not** run.
- `AuditApprovalDeclined` → `approval_declined` (best-effort; nothing ran).

Both carry `approved_via: "elicitation"`, and the resulting `executed` record is stamped with `approved_via` too, so an approved execution is distinguishable from a non-gated one. Adds the `audit.Entry.ApprovedVia` field and documents the two outcomes + field in `API.md`.

## Verified

- `make verify` green (gofmt, vet, build, race, govulncheck, strict docs, no reference drift).
- `internal/mcpserver/approval_test.go` now asserts: an elicited **accept** writes `approval_granted` with `approved_via=elicitation` (present even though the test host is unreachable, proving it's recorded before execution); a **decline** writes `approval_declined` and produces **no** `executed` entry.

Closes #280