### PR TITLE
fix(k8s): validate extra_resources charset at config load (#281)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -144,6 +144,14 @@
   durably audited fails closed (the command does not run).
 
 ### Security
+- **k8s `extra_resources` identifiers are charset-validated at config load
+  (#281)** — an operator's `extra_resources` entry could declare a `resource` or
+  `group` containing a space or `/`, which then flowed unvalidated into the
+  signer's canonical action string `<verb> <resource[.group]> <ns>/<name>` and
+  broke its "provably space/slash-free" anti-mismatch guarantee (fail-closed in
+  effect — a corrupted policy key, not a privilege gain). `k8s.Resources` now
+  rejects a `resource` that is not an RFC 1123 label or a `group` that is not an
+  RFC 1123 subdomain, so the canonical stays well-formed by construction.
 - **Command policy matches the decoded command, closing a deny/approval bypass
   via shell quoting (#277)** — the firewall parsed each command but matched the
   deny/`require_approval`/allow regexes against its *quote-preserving* printed

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -241,3 +241,28 @@ func TestResourcesTable(t *testing.T) {
 		t.Error("an incomplete extra resource must fail")
 	}
 }
+
+// TestResourcesTableRejectsInvalidCharset pins #281: a resource/group identifier
+// that is not a valid RFC 1123 label/subdomain (a space, a slash, uppercase)
+// must be rejected at config load, so it can never flow into the signer's
+// canonical action string "<verb> <resource[.group]> <ns>/<name>" and break the
+// space/slash-free anti-mismatch guarantee.
+func TestResourcesTableRejectsInvalidCharset(t *testing.T) {
+	t.Parallel()
+	bad := []ResourceDef{
+		{Resource: "my crd", Version: "v1", Kind: "X"},                    // space in resource
+		{Resource: "my/crd", Version: "v1", Kind: "X"},                    // slash in resource
+		{Resource: "Widgets", Version: "v1", Kind: "X"},                   // uppercase resource
+		{Resource: "widgets", Group: "foo/bar", Version: "v1", Kind: "X"}, // slash in group
+		{Resource: "widgets", Group: "foo bar", Version: "v1", Kind: "X"}, // space in group
+	}
+	for _, r := range bad {
+		if _, err := Resources([]ResourceDef{r}); err == nil {
+			t.Errorf("extra_resources %+v must be rejected (invalid RFC 1123 charset)", r)
+		}
+	}
+	// A valid subdomain group (dots) is still accepted.
+	if _, err := Resources([]ResourceDef{{Resource: "certificates", Group: "cert-manager.io", Version: "v1", Kind: "Certificate", Namespaced: true}}); err != nil {
+		t.Errorf("a valid extra_resources entry must be accepted: %v", err)
+	}
+}

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -11,7 +11,27 @@ package k8s
 
 import (
 	"fmt"
+	"regexp"
 )
+
+// reLabel (RFC 1123 label) and reSubdomain (RFC 1123 subdomain) are the charsets
+// for Kubernetes identifiers. Both exclude spaces and '/'. Validating a resource
+// table entry against them keeps the identifiers that later flow into the
+// signer's canonical action string "<verb> <resource[.group]> <ns>/<name>" free
+// of the separators that string is split on (mirrors the equivalent charset the
+// signer's action grammar enforces on client-supplied fields).
+var (
+	reLabel     = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+	reSubdomain = regexp.MustCompile(`^[a-z0-9]([-a-z0-9.]{0,251}[a-z0-9])?$`)
+)
+
+// validLabel reports whether s is a lowercase RFC 1123 label (resource plural
+// names) — no dots, spaces, or slashes.
+func validLabel(s string) bool { return reLabel.MatchString(s) }
+
+// validSubdomain reports whether s is a lowercase RFC 1123 subdomain (API
+// groups) — dots allowed, no spaces or slashes.
+func validSubdomain(s string) bool { return reSubdomain.MatchString(s) }
 
 // ResourceDef describes one addressable resource type: how it maps to a REST
 // path and to a manifest kind.
@@ -66,6 +86,16 @@ func Resources(extra []ResourceDef) (map[string]ResourceDef, error) {
 	for _, r := range extra {
 		if r.Resource == "" || r.Version == "" || r.Kind == "" {
 			return nil, fmt.Errorf("extra_resources: resource, version, and kind are required (got %+v)", r)
+		}
+		// Charset-validate the identifiers that flow into the signer's canonical
+		// action string. Without this an operator's extra_resources entry could
+		// inject a space or '/' into Resource/Group and break the canonical's
+		// "provably space/slash-free" anti-mismatch guarantee (#281).
+		if !validLabel(r.Resource) {
+			return nil, fmt.Errorf("extra_resources: resource %q is not a valid RFC 1123 label (lowercase alphanumeric and '-')", r.Resource)
+		}
+		if r.Group != "" && !validSubdomain(r.Group) {
+			return nil, fmt.Errorf("extra_resources: group %q is not a valid RFC 1123 subdomain", r.Group)
 		}
 		if prev, ok := table[r.Resource]; ok {
 			return nil, fmt.Errorf("extra_resources: %q collides with %s/%s", r.Resource, prev.Group, prev.Resource)


### PR DESCRIPTION
## Problem (low — hardening)

The signer's canonical k8s action string `<verb> <resource[.group]> <ns>/<name>` is injection-free only because every component is **provably free of spaces and slashes before the string is built** (it is constructed from validated fields, never parsed). `K8sAction.Validate` charset-checks the **client**-supplied fields, but after normalization `action.Resource`/`action.Group` are taken from the cluster's **resource table** — and `k8s.Resources` built that table from `extra_resources` checking only that `resource`/`version`/`kind` are non-empty, never the charset.

So an operator `extra_resources` entry like `{resource: "my crd"}` or `{group: "foo/bar"}` would put a space or `/` into the canonical (e.g. `get my crd -/x`), breaking the `<ns>/<name>` split and the anti-mismatch guarantee. Fail-closed in effect (a corrupted policy key / anti-mismatch denial, not a privilege gain) and the trigger is trusted operator config — hence low — but the by-construction invariant no longer held.

## Fix

`k8s.Resources` now rejects an `extra_resources` entry whose `resource` is not an RFC 1123 label or whose `group` is not an RFC 1123 subdomain (both charsets exclude spaces and `/`), so the identifiers that later flow into the canonical stay well-formed by construction.

Scope note: I did **not** also flip `ShellParse:false` on the compiled k8s policies (the finding's optional second suggestion). The grant-injection path is shared SSH/k8s and `PolicySet.shellParse()` is true if *any* member parses, so a k8s grant would re-enable it — a half-measure. With the charset validated, shell-parsing the canonical is harmless by construction (the validated charset has no shell metacharacters), so the coupling is now moot.

## Verified

- `make verify` green (gofmt, vet, build, race, govulncheck, strict docs, no drift).
- New `TestResourcesTableRejectsInvalidCharset`: space/slash/uppercase in `resource` and space/slash in `group` are rejected; a valid dotted-subdomain group (`cert-manager.io`) is still accepted.

Closes #281