### PR TITLE
chore: v3.0.0 release (changelog + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## [Unreleased]
+## [v3.0.0] - 2026-07-16
+
+The major that closes both host-enforcement gaps in the threat model. Session
+`exec` filtering can now be enforced by the target host itself — "sealed exec",
+opt-in per host: the session certificate is pinned to a verifying shim that runs
+only signer-signed per-command envelopes — and the signer can re-validate the end
+user's OIDC identity instead of trusting the broker's assertion. A compromised
+broker can therefore neither skip the per-command preflight nor forge who an
+action is attributed to. Alongside that: the three frontends collapse into one
+`infrabroker` binary with transport subcommands, `infrabroker init` brings up a
+working local install in one command, and the audit chain gets a round of
+durability and ordering fixes. **Upgrade note (BREAKING):** an active
+`command_policy` now parses commands as POSIX sh before evaluating them
+(`shell_parse` defaults to on), so an allowlist finally covers chained commands
+such as `kubectl get pods; rm -rf /etc` — hosts whose policies were passing
+compound commands through unparsed will see new denials; set `"shell_parse":
+false` on a policy to restore the legacy raw-string matching.
 
 ### Changed
 - **Command policies parse commands by default (`shell_parse` on) (#211)** —
@@ -233,6 +249,16 @@
   buffer, so every line the writer emits is always readable.
 
 ### Internal
+- **Dependency bumps (#289)** — `github.com/coreos/go-oidc/v3` 3.19.0 → 3.20.0 and
+  `golang.org/x/crypto` 0.53.0 → 0.54.0 (plus the `x/net`, `x/sys` and `x/text`
+  indirects they pull). No behaviour change; both sit on the OIDC/SSH paths, so
+  they ride the release rather than a silent bump.
+- **Stale binary/feature docs corrected after the frontend unification (#273,
+  #274, #275)** — OPERATIONS §1 listed the compiled binaries without
+  `approval-bridge`, which `make install` builds and the same document tells
+  operators to run; the `initcmd` godoc still claimed `init` did no
+  `~/.ssh/config` import or MCP registration, both of which phase 2 added as
+  opt-in flags; and the Dockerfile header miscounted the prebuilt binaries.
 - **High-availability design study (#145)** — a new `docs/HA.md` maps what actually
   blocks running two replicas: a state inventory across the broker / control-plane
   / signer, the four true blockers (live SSH sessions, the kill-switch freeze set,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,31 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-10 (v2.1.0, hardening post-v2.0.0: kill-switch, audit fail-closed del control-plane, k8s/recording/freeze).
+> actualización: 2026-07-16 (v3.0.0, el major que cierra los dos gaps de host-enforcement del threat model: sealed exec #144 y re-validación OIDC en el signer #143).
 >
 > Estado reciente:
+> - **v3.0.0**: major que cierra **los dos gaps de host-enforcement** del
+>   THREAT_MODEL, ambos opt-in. **Sealed exec (#144, gap #1)**: con
+>   `"sealed_exec": true` en un host, su cert de sesión va pinneado a
+>   `force-command=infrabroker-shim <host>` y cada `ssh_session_exec` debe
+>   presentar un envelope `{nonce, host, command, expiry}` firmado por el signer en
+>   el preflight que ya existía; el nuevo binario `infrabroker-shim` no ejecuta
+>   nada que no verifique contra una pubkey pinneada. Dos sutilezas que costaron
+>   sangre, ambas cazadas antes de publicar: (1) **todo** cert de un host sellado
+>   va pinneado — un cert de rol `bastion` salía sin force-command, es decir shell
+>   libre saltándose el shim; (2) el host viaja **dentro del force-command
+>   firmado** y `sealed.Verify` lo exige como parámetro obligatorio, porque el shim
+>   verificaba la firma pero NO comparaba `Envelope.Host`: como toda la flota
+>   pinnea la misma clave, un envelope emitido para un host permisivo se replicaba
+>   tal cual en uno restrictivo (bearer token de flota; lo destapó la revisión
+>   adversarial multi-agente). Despliegue del shim aún manual → #291. **Re-validación OIDC (#143, gap #2)**: con
+>   `require_verified_end_user` por caller + bloque `end_user_oidc`, el signer
+>   re-valida el bearer contra JWKS y deriva `end_user`/grupos del JWT en vez de
+>   creerse al broker; fail-closed; el token nunca se loguea/audita/persiste (el
+>   control-plane lo stripea antes de `request_json`). **HA (#145)**: design-first
+>   — `docs/HA.md` + descomposición en #293–#297; sigue single-instance a propósito.
+>   Además: binario unificado `infrabroker` (#180), `infrabroker init` (#136), y
+>   **BREAKING**: `shell_parse` on por defecto (#211).
 > - **v2.1.0**: pasada de correctitud y hardening tras el major v2.0.0 — el kill
 >   switch corta un PTY ocupado (#202) y cubre el CN crudo de un forwarder frozen
 >   y `/v1/clusters` (#203); el audit four-eyes del control-plane es **fail-closed

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "3.0.0",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:2.1.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:3.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Version: v3.0.0 (MAJOR)

**Why major:** `6724f87 fix(signer)!: parse commands by default so allowlists cover chained commands (#211)` is a documented breaking change (`!` type + **BREAKING** in its changelog entry). An active `command_policy` now parses commands as POSIX sh before evaluating them (`shell_parse` defaults to on), so an allowlist finally covers chained commands like `kubectl get pods; rm -rf /etc` — but hosts whose policies were passing compound commands through unparsed **will see new denials**. Opt-out per policy: `"shell_parse": false`. Same criterion as the v2.0.0 secure-by-default flips.

27 commits since `v2.1.0`; 6 `feat:`; 1 breaking.

## Theme: host enforcement

Both THREAT_MODEL host-enforcement gaps are now closed, each opt-in:

- **Sealed exec (#144, gap #1)** — a sealed host's session cert is pinned to `infrabroker-shim <host>`; every `ssh_session_exec` must present a signer-signed `{nonce, host, command, expiry}` envelope, minted at the preflight that already existed. A compromised broker that skips the preflight has nothing the host will run. New `infrabroker-shim` binary; deployment to hosts is still manual (#291).
- **Signer-side OIDC re-validation (#143, gap #2)** — the signer re-validates the end user's bearer against JWKS and derives `end_user`/groups from the verified JWT instead of trusting the broker's assertion. Fail-closed; the token is never logged, audited or persisted.

Alongside: the three frontends collapse into one `infrabroker` binary (#180), `infrabroker init` (#136), audit-chain durability/ordering fixes (#209/#210/#257/#272/#278/#279/#280), and the HA design study (#145, docs only — still deliberately single-instance).

## Release prep in this PR

- `docs/CHANGELOG.md` — `[Unreleased]` folded into `## [v3.0.0] - 2026-07-16` with a theme paragraph and the **Upgrade note (BREAKING)** for #211.
- **Cross-checked against `git log v2.1.0..main`** and added the two entries that had landed without one: the dependency bumps (#289: `go-oidc` 3.19→3.20, `x/crypto` 0.53→0.54) and the stale-docs correction (#273/#274/#275).
- `server.json` — `version` **and** the OCI `identifier` → `3.0.0` (no `v` prefix). `mcp-publisher validate` → ✅ valid against the live registry schema; description 83 chars (≤100).
- `docs/HANDOFF.md` — header + a v3.0.0 entry.

`make verify` green locally (build + vet + race tests + govulncheck + docs drift + strict mkdocs).

## Merge gate

Release PRs are **not** auto-merged — this pins the version that gets tagged and published to ghcr and the MCP Registry. Please review and merge (or authorize it), and I'll push the annotated tag `v3.0.0` to trigger `release.yml`.