### PR TITLE
chore: v3.0.1 security release (GHSA-937v-rmqp-j3hx)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [v3.0.1] - 2026-07-16
+
+Security patch. Closes a command-policy bypass (GHSA-937v-rmqp-j3hx, found via
+CodeQL + adversarial review) where a shell glob / brace / tilde metacharacter let
+an obfuscated command dodge a `deny` / `require_approval` rule the executed
+command would hit — the same class as #211/#277, left open for glob/brace/tilde.
+Upgrade recommended; no config changes required.
 
 ### Security
 - **Command policy: reject unresolved shell-expansion metacharacters (glob / brace

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **Command policy: reject unresolved shell-expansion metacharacters (glob / brace
+  / tilde) — GHSA-937v-rmqp-j3hx** — the AI-action firewall decided a host's `command_policy` against a
+  form of the command in which pathname globs (`* ? [ ]`), brace expansion
+  (`{a,b}`) and a leading tilde (`~`) were kept LITERAL, while the target host's
+  `$SHELL -c` (and the sealed-exec shim) expand them at run time. An obfuscated
+  command therefore dodged a `deny` / `require_approval` rule the executed command
+  would hit — e.g. `/bin/r[m] -rf /data` globs back to `/bin/rm -rf /data` past an
+  `rm` deny, and `cat /etc/{passwd,shadow}` brace-expands to read `/etc/shadow`
+  past a `/etc/shadow` deny. This is the same class as the quoting/`$IFS`/encoding
+  obfuscation closed in #211/#277, left open for glob/brace/tilde. With
+  `shell_parse` on (the default), a command word carrying such an UNQUOTED
+  metacharacter is now rejected fail-closed before matching; quoted metacharacters
+  (`'...'`, `"..."`, `$'...'`) do not expand and are unaffected, and literal
+  commands are unchanged. **Note:** a host that opted out with `"shell_parse":
+  false` keeps the legacy raw-string matching and remains exposed to this class —
+  do not use `shell_parse: false` on hosts with `deny`/`require_approval` rules.
+  Allowlist-mode hosts were never bypassable (a glob fails the allow match,
+  fail-closed).
+
 ## [v3.0.0] - 2026-07-16
 
 The major that closes both host-enforcement gaps in the threat model. Session

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,20 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-16 (v3.0.0, el major que cierra los dos gaps de host-enforcement del threat model: sealed exec #144 y re-validación OIDC en el signer #143).
+> actualización: 2026-07-16 (v3.0.1, patch de seguridad: cierra el bypass de command-policy por expansión glob/brace/tilde, GHSA-937v-rmqp-j3hx).
 >
 > Estado reciente:
+> - **v3.0.1** (patch de seguridad): CodeQL marcó `go/command-injection` crítico en
+>   `internal/ssh/run.go:315`; la revisión adversarial (workflow) demostró que NO era
+>   falso positivo — el firewall de comandos evaluaba la policy sobre la forma
+>   literal (`/bin/r[m]`, `/etc/{passwd,shadow}`, `~`) mientras el shell remoto la
+>   expande, esquivando reglas `deny`/`require_approval`. Fix en `cmdpolicy.go`
+>   (`literalArgs` rechaza fail-closed metacaracteres de glob/brace/tilde SIN
+>   comillas, respetando el quoting vía AST). Alcance: default `shell_parse` on;
+>   allowlist nunca fue vulnerable; `shell_parse:false` sigue en raw-match legacy.
+>   GHSA-937v-rmqp-j3hx (high). Lección: mantener `shell_parse` on en hosts con
+>   deny/approval; la revisión adversarial se ganó el sueldo (mi primera lectura fue
+>   "falso positivo" y era erróneo).
 > - **v3.0.0**: major que cierra **los dos gaps de host-enforcement** del
 >   THREAT_MODEL, ambos opt-in. **Sealed exec (#144, gap #1)**: con
 >   `"sealed_exec": true` en un host, su cert de sesión va pinneado a

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -243,6 +243,9 @@ func literalArgs(args []*syntax.Word) (string, error) {
 		if !isStaticWord(w) {
 			return "", errors.New("command word with a parameter/command/arithmetic expansion not allowed")
 		}
+		if err := rejectShellExpansion(w); err != nil {
+			return "", err
+		}
 		lit, err := expand.Literal(cfg, w)
 		if err != nil {
 			return "", fmt.Errorf("decoding command word: %w", err)
@@ -250,6 +253,36 @@ func literalArgs(args []*syntax.Word) (string, error) {
 		parts = append(parts, lit)
 	}
 	return strings.Join(parts, " "), nil
+}
+
+// rejectShellExpansion fails closed on a word carrying a shell expansion that the
+// signer cannot resolve at decision time but the target shell performs at exec
+// time: pathname globbing (* ? [ ]), brace expansion ({...}), or a leading tilde
+// (~). The value such a word expands to depends on the target's filesystem and
+// home directories, which the signer cannot see — so expand.Literal keeps the
+// metacharacter literal and the policy would match a DIFFERENT string than the
+// one the remote `$SHELL -c` runs. That is a deny/require_approval bypass:
+// "/bin/r[m] -rf x" dodges a `rm` deny (the shell globs r[m]->rm), and
+// "cat /etc/{a,shadow}" dodges a "/etc/shadow" deny (the shell brace-expands it).
+// Only UNQUOTED literal parts expand; quoted parts ('...', "...", $'...') are
+// left to expand.Literal, which decodes them verbatim (the shell won't expand a
+// quoted glob either). Rejecting here, before matching, closes the class the same
+// way #211/#277 closed quoting/$IFS/encoding obfuscation.
+func rejectShellExpansion(w *syntax.Word) error {
+	for i, part := range w.Parts {
+		lit, ok := part.(*syntax.Lit)
+		if !ok {
+			continue // '...', "...", $'...' don't glob/brace/tilde-expand
+		}
+		if strings.ContainsAny(lit.Value, "*?[{}") {
+			return fmt.Errorf("command word %q contains an unquoted shell glob or brace metacharacter that the target shell would expand; quote it or use an explicit value", lit.Value)
+		}
+		// Tilde expansion applies only at the very start of a word.
+		if i == 0 && strings.HasPrefix(lit.Value, "~") {
+			return fmt.Errorf("command word %q begins with an unquoted tilde that the target shell would expand to a home directory; use an explicit path", lit.Value)
+		}
+	}
+	return nil
 }
 
 // isStaticWord reports whether w's value is fully determined at policy-decision

--- a/internal/signer/cmdpolicy_glob_test.go
+++ b/internal/signer/cmdpolicy_glob_test.go
@@ -1,0 +1,64 @@
+package signer
+
+import "testing"
+
+// TestCommandPolicyRejectsShellExpansion is the regression for the command-policy
+// bypass (GHSA / CodeQL go/command-injection): the signer decided the policy on a
+// glob/brace/tilde-LITERAL form while the target shell (`$SHELL -c`) expands those
+// metacharacters at exec time, so an obfuscated command dodged a deny /
+// require_approval rule the executed command would hit — e.g. "/bin/r[m] -rf x"
+// globs back to "/bin/rm -rf x", "cat /etc/{a,shadow}" brace-expands to read
+// /etc/shadow. With shell_parse on (the default) such words are now rejected
+// fail-closed. Quoted metacharacters do NOT expand and must still be allowed.
+func TestCommandPolicyRejectsShellExpansion(t *testing.T) {
+	t.Parallel()
+
+	deny := PolicySet{{Mode: CmdPolicyDenylist, Deny: []string{`(^|/)rm(\s|$)`, `/etc/shadow`, `/root/`, `(^|/)reboot(\s|$)`}}}
+
+	denied := func(cmd, why string) {
+		if allowed, _, _, err := deny.Decide(cmd); allowed && err == nil {
+			t.Errorf("%s: %q must be blocked, was ALLOWED", why, cmd)
+		}
+	}
+	allowed := func(cmd string) {
+		if a, _, _, err := deny.Decide(cmd); !a || err != nil {
+			t.Errorf("legitimate command %q must be allowed, got allowed=%v err=%v", cmd, a, err)
+		}
+	}
+
+	// The literal forms are (and stay) denied by their rules.
+	denied("/bin/rm -rf /srv/data", "literal rm")
+	denied("cat /etc/shadow", "literal shadow")
+
+	// The obfuscated forms must no longer slip through: char-class and ? globbing,
+	// brace expansion, and tilde expansion all reach the same command at runtime.
+	denied("/bin/r[m] -rf /srv/data", "char-class glob dodges rm deny")
+	denied("/sbin/reboo?", "? glob dodges reboot approval/deny")
+	denied("/bin/rm* -rf /x", "* glob")
+	denied("cat /etc/{passwd,shadow}", "brace dodges shadow deny")
+	denied("cat /roo{t,}/secret", "brace dodges /root/ deny")
+	denied("cat ~/.ssh/id_rsa", "tilde expands to home")
+	denied("cat ~root/.ssh/id_rsa", "tilde-user")
+
+	// Legitimate literal commands are unaffected.
+	allowed("uptime")
+	allowed("systemctl status nginx")
+	allowed("cat /etc/hosts")
+
+	// A QUOTED metacharacter does not expand on the remote shell, so it must not
+	// be over-rejected: the quotes are decoded away and the literal is matched.
+	allowed("cat '/etc/[x]'")
+	allowed(`echo "a*b"`)
+	allowed("echo '~notahome'")
+
+	// Allowlist mode stays fail-closed: a glob that does not match an allow rule
+	// literally is denied (it never had a way in), and one that tries to sneak a
+	// metacharacter past a literal allow is rejected too.
+	allow := PolicySet{{Mode: CmdPolicyAllowlist, Allow: []string{`^cat /etc/hosts$`}}}
+	if a, _, _, err := allow.Decide("cat /et[c]/hosts"); a && err == nil {
+		t.Error("allowlist: a glob command must not be allowed")
+	}
+	if a, _, _, err := allow.Decide("cat /etc/hosts"); !a || err != nil {
+		t.Errorf("allowlist: the exact allowed command must pass, got allowed=%v err=%v", a, err)
+	}
+}

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:3.0.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:3.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Security patch — v3.0.1

Closes **[GHSA-937v-rmqp-j3hx](https://github.com/luisgf/infrabroker/security/advisories/GHSA-937v-rmqp-j3hx)** (High): a command-policy (AI-action firewall) bypass. Found via GitHub CodeQL (`go/command-injection`, `internal/ssh/run.go:315`) and confirmed by an adversarial review — it was **not** a false positive.

### The bug
The firewall evaluated `deny` / `require_approval` rules against a decoded-but-not-shell-**expanded** form of the command (`expand.Literal` with globbing off), while the managed host's `$SHELL -c` — and the sealed-exec shim's `/bin/sh -c` — expand globs / braces / tildes at run time. An obfuscated command dodged a rule the executed command hits:

- `/bin/r[m] -rf /data` → globs to `/bin/rm -rf /data` (past an `rm` deny)
- `/sbin/reboo?` → globs to `reboot` (past `require_approval`)
- `cat /etc/{passwd,shadow}` → brace-expands to read `/etc/shadow`
- `cat ~/.ssh/id_rsa` → tilde-expands to a home path

Same class as the quoting/`$IFS`/encoding obfuscation closed in #211/#277, left open for glob/brace/tilde.

### The fix
With `shell_parse` on (the default), `literalArgs` now rejects fail-closed any command word carrying an **unquoted** glob (`* ? [ ]`), brace (`{}`) or leading tilde (`~`) metacharacter, before matching. Quoting-aware via the shell AST: quoted metacharacters (`'...'`, `"..."`, `$'...'`) — which the remote shell does not expand — and literal commands are unaffected. Regression test: `internal/signer/cmdpolicy_glob_test.go`.

### Scope
- **Allowlist**-mode hosts were never bypassable (a glob fails the allow match; fail-closed). Affects `deny` / `require_approval`.
- `"shell_parse": false` (legacy raw matching) remains exposed to this class — documented; keep `shell_parse` on for deny/approval-sensitive hosts.
- Requires an already-authorized caller/agent (in-scope: constraining a prompt-injected AI).

### Release
Folds `[Unreleased]` into `## [v3.0.1]`; `server.json` bumped to 3.0.1 (version + OCI identifier), validated against the live registry. `make verify` green (build + vet + race tests + govulncheck + docs). The GHSA advisory is published alongside the tag.