### PR TITLE
chore(codeql): annotate the intentional SSH remote-exec sink

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Internal
+- **Annotate the intentional SSH remote-exec sink** — `internal/ssh/run.go` carries
+  a CodeQL suppression + rationale for `go/command-injection`: the command reaching
+  `session.Run` is signer-authorised (one-shot force-command / session
+  `command_policy`), the glob/brace/tilde bypass class was closed in v3.0.1
+  (GHSA-937v-rmqp-j3hx), and that cross-package mitigation is invisible to the
+  dataflow query. No behaviour change.
+
 ## [v3.0.1] - 2026-07-16
 
 Security patch. Closes a command-policy bypass (GHSA-937v-rmqp-j3hx, found via

--- a/internal/ssh/run.go
+++ b/internal/ssh/run.go
@@ -312,7 +312,15 @@ func ExecOnce(ctx context.Context, client *ssh.Client, command string, opts ...E
 // and runErr is ctx.Err() or the timeout error.
 func runWithTimeout(ctx context.Context, session *ssh.Session, command string, execTimeout time.Duration) (error, bool) {
 	done := make(chan error, 1)
-	go func() { done <- session.Run(command) }()
+	// CodeQL go/command-injection flags `command` reaching this remote-exec sink.
+	// It is by design and mitigated cross-package, which the query cannot see:
+	// running an operator-scoped command on a remote host IS the product, and the
+	// command is signer-authorised — one-shot is pinned by the certificate
+	// force-command, and every session exec is vetted by the command_policy
+	// firewall (internal/signer), which rejects unresolved shell glob/brace/tilde
+	// metacharacters (GHSA-937v-rmqp-j3hx / v3.0.1). session.Run is the SSH exec
+	// request, not a local shell.
+	go func() { done <- session.Run(command) }() // lgtm[go/command-injection]
 	return waitResult(ctx, done, execTimeout, func() { _ = session.Signal(ssh.SIGTERM) })
 }
 


### PR DESCRIPTION
Adds an inline CodeQL suppression (`// lgtm[go/command-injection]`) + rationale on `internal/ssh/run.go`'s `session.Run(command)` — the remote-exec sink CodeQL flags.

Why it's safe: running an operator-scoped command on a remote host **is** the product; the command is signer-authorised (one-shot pinned by the certificate `force-command`, every session exec vetted by the `command_policy` firewall), and the glob/brace/tilde bypass class was closed in **v3.0.1** (GHSA-937v-rmqp-j3hx). `session.Run` is the SSH exec request, not a local shell. The cross-package mitigation is invisible to the dataflow query, so the alert would otherwise recur on each scan.

Comment-only; no behaviour change. `### Internal` changelog line added.