### PR TITLE
fix(signer): reject unquoted backslash escapes in command policy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Security
+- **Command policy: reject unquoted backslash escapes (#308)** — the last decode
+  gap of the bypass class closed by #277 (quoting/encoding) and v3.0.1's
+  GHSA-937v-rmqp-j3hx (glob/brace/tilde). The AI-action firewall decided a host's
+  `command_policy` against a form of the command in which an UNQUOTED backslash
+  was kept LITERAL, while the target host's `$SHELL -c` (and the sealed-exec
+  shim) consume it as an escape. An obfuscated command therefore dodged a `deny`
+  / `require_approval` rule the executed command would hit — `r\m -rf /srv/data`
+  was matched as `r\m …` but runs as `rm -rf /srv/data`, and `cat /etc/sha\dow`
+  dodged an `/etc/shadow` deny. Such a word is now rejected fail-closed with an
+  actionable error ("quote it or use an explicit value"), the same treatment
+  glob/brace/tilde got in v3.0.1. Only hosts with an active `command_policy` are
+  affected, and only unquoted backslashes: `'a\b'`, `"a\b"`, `"a\$b"` and
+  `$'a\tb'` decode exactly as the shell decodes them and keep working — quote the
+  word to keep using one. The elevation path already refused these (#306).
+
 ### Changed
 - **Sudoers-friendly elevation: simple commands run as a direct sudo argv (#306)** —
   an elevated command with no shell semantics (one statement, statically-known

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -230,7 +230,9 @@ func extractCommands(command string) ([]string, error) {
 // runs instead of the caller's quoting (#277). It fails closed on any word whose
 // value is not statically knowable (a parameter/command/arithmetic expansion,
 // process substitution or extended glob): such a word is rejected rather than
-// matched against an incomplete string.
+// matched against an incomplete string. It equally fails closed on a word the
+// decode would resolve DIFFERENTLY from the target shell — an unquoted glob /
+// brace / tilde (GHSA-937v-rmqp-j3hx) or an unquoted backslash escape (#308).
 func literalArgs(args []*syntax.Word) (string, error) {
 	// A fresh config per call: expand.Literal mutates the *Config it is given
 	// (prepareConfig sets Env/ifs in place), so a shared instance would race
@@ -245,6 +247,9 @@ func literalArgs(args []*syntax.Word) (string, error) {
 		}
 		if err := rejectShellExpansion(w); err != nil {
 			return "", err
+		}
+		if bs, ok := unquotedBackslash(w); ok {
+			return "", fmt.Errorf("command word %q contains an unquoted backslash escape that the target shell would consume; quote it or use an explicit value", bs)
 		}
 		lit, err := expand.Literal(cfg, w)
 		if err != nil {
@@ -288,7 +293,10 @@ func directArgv(command string) ([]string, bool) {
 	cfg := &expand.Config{NoUnset: true}
 	argv := make([]string, 0, len(call.Args))
 	for _, w := range call.Args {
-		if !isStaticWord(w) || rejectShellExpansion(w) != nil || hasUnquotedBackslash(w) {
+		if !isStaticWord(w) || rejectShellExpansion(w) != nil {
+			return nil, false
+		}
+		if _, ok := unquotedBackslash(w); ok {
 			return nil, false
 		}
 		lit, err := expand.Literal(cfg, w)
@@ -315,20 +323,31 @@ func directArgv(command string) ([]string, bool) {
 	return argv, true
 }
 
-// hasUnquotedBackslash reports whether w carries a backslash in an UNQUOTED
-// literal part. `expand.Literal` keeps such a backslash verbatim while the
-// target shell would consume it as an escape, so the direct argv would differ
-// from what `sh -c` executes ("touch a\ b" is one argument to the shell, two
-// literal words here). Fail closed to the wrapper rather than run a different
-// command. (The same decode gap affects the policy layer for non-elevated
-// commands — tracked separately.)
-func hasUnquotedBackslash(w *syntax.Word) bool {
+// unquotedBackslash returns the first UNQUOTED literal part of w that carries a
+// backslash. `expand.Literal` keeps such a backslash verbatim while the target
+// shell consumes it as an escape, so the decoded value differs from what the
+// shell runs ("touch a\ b" is one argument to the shell, two literal words
+// here; "r\m" decodes to `r\m` but executes as `rm`). Both callers fail closed
+// on it, for the two consequences of that divergence:
+//
+//   - literalArgs (#308): the policy would decide against a string the shell
+//     never runs, so a deny / require_approval rule the executed command hits is
+//     dodged — the same bypass class as #277 (quoting/encoding) and
+//     GHSA-937v-rmqp-j3hx (glob/brace/tilde). The command is rejected.
+//   - directArgv (#306): the direct sudo argv would differ from what the
+//     historical `sh -c` wrapper executed, so the wrapper is kept.
+//
+// Only UNQUOTED parts diverge: expand.Literal decodes '...', "..." and $'...'
+// exactly as the shell does (`"a\b"`→`a\b`, `"a\$b"`→`a$b`, `$'a\tb'`→a<TAB>b),
+// so inspecting the top-level *syntax.Lit parts is the precise predicate and
+// quoted backslashes keep working.
+func unquotedBackslash(w *syntax.Word) (string, bool) {
 	for _, part := range w.Parts {
 		if lit, ok := part.(*syntax.Lit); ok && strings.Contains(lit.Value, `\`) {
-			return true
+			return lit.Value, true
 		}
 	}
-	return false
+	return "", false
 }
 
 // shellOnlyBuiltins are commands implemented by the shell with no external

--- a/internal/signer/cmdpolicy_backslash_test.go
+++ b/internal/signer/cmdpolicy_backslash_test.go
@@ -1,0 +1,99 @@
+package signer
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCommandPolicyRejectsUnquotedBackslash is the regression for the last
+// decode gap in the command-policy bypass class (#308, sibling of #277's
+// quoting/encoding and GHSA-937v-rmqp-j3hx's glob/brace/tilde): the signer
+// decided the policy on a form in which an UNQUOTED backslash was kept LITERAL,
+// while the target host's `$SHELL -c` (and the sealed-exec shim) consume it as
+// an escape. An obfuscated command therefore dodged a deny / require_approval
+// rule the executed command would hit — "r\m -rf /srv/data" decodes to the
+// policy string `r\m -rf /srv/data` but the shell runs `rm -rf /srv/data`.
+// With shell_parse on (the default) such words are now rejected fail-closed.
+// Quoted backslashes decode exactly as the shell decodes them and must keep
+// working.
+func TestCommandPolicyRejectsUnquotedBackslash(t *testing.T) {
+	t.Parallel()
+
+	deny := PolicySet{{Mode: CmdPolicyDenylist, Deny: []string{`(^|/)rm(\s|$)`, `/etc/shadow`, `(^|/)reboot(\s|$)`}}}
+
+	denied := func(cmd, why string) {
+		t.Helper()
+		if allowed, _, _, err := deny.Decide(cmd); allowed && err == nil {
+			t.Errorf("%s: %q must be blocked, was ALLOWED", why, cmd)
+		}
+	}
+	allowed := func(cmd string) {
+		t.Helper()
+		if a, _, _, err := deny.Decide(cmd); !a || err != nil {
+			t.Errorf("legitimate command %q must be allowed, got allowed=%v err=%v", cmd, a, err)
+		}
+	}
+
+	// The literal forms are (and stay) denied by their rules.
+	denied(`/bin/rm -rf /srv/data`, "literal rm")
+	denied(`cat /etc/shadow`, "literal shadow")
+
+	// The backslash-obfuscated forms must no longer slip through: every one of
+	// these reaches the denied command once the target shell strips the escape.
+	denied(`r\m -rf /srv/data`, `r\m dodges the rm deny`)
+	denied(`\rm -rf /srv/data`, `leading backslash dodges the rm deny`)
+	denied(`/bin/r\m -rf /srv/data`, `path-qualified r\m dodges the rm deny`)
+	denied(`cat /etc/sha\dow`, `sha\dow dodges the /etc/shadow deny`)
+	denied(`/sbin/rebo\ot`, `rebo\ot dodges the reboot deny`)
+
+	// Legitimate literal commands are unaffected.
+	allowed("uptime")
+	allowed("systemctl restart nginx.service")
+	allowed("cat /etc/hosts")
+
+	// A QUOTED backslash is decoded by expand.Literal exactly as the target shell
+	// decodes it, so it must not be over-rejected. Control cases, verified against
+	// the pinned mvdan.cc/sh: '...' and "..." keep `a\b`, "a\$b" becomes `a$b`,
+	// $'a\tb' becomes a real tab, and a"\\"b becomes `a\b`.
+	allowed(`echo 'a\b'`)
+	allowed(`echo "a\b"`)
+	allowed(`echo "a\$b"`)
+	allowed(`echo $'a\tb'`)
+	allowed(`echo a"\\"b`)
+
+	// require_approval is bypassable by exactly the same trick, so it must be
+	// closed too: the gate exists to put a human in front of the command.
+	appr := PolicySet{{Mode: CmdPolicyDenylist, RequireApproval: []string{`(^|/)systemctl\s+restart`}}}
+	if _, needs, _, err := appr.Decide("systemctl restart nginx"); !needs || err != nil {
+		t.Fatalf("literal command must require approval, got needs=%v err=%v", needs, err)
+	}
+	a, needs, _, err := appr.Decide(`systemctl\ restart nginx`)
+	if a && !needs && err == nil {
+		t.Error(`require_approval: "systemctl\ restart nginx" must not run unapproved`)
+	}
+
+	// Allowlist mode stays fail-closed: a backslash form never matched a literal
+	// allow rule, and it must not become an error-free allow either.
+	allow := PolicySet{{Mode: CmdPolicyAllowlist, Allow: []string{`^cat /etc/hosts$`}}}
+	if a, _, _, err := allow.Decide(`cat /etc/host\s`); a && err == nil {
+		t.Error("allowlist: a backslash-escaped command must not be allowed")
+	}
+	if a, _, _, err := allow.Decide("cat /etc/hosts"); !a || err != nil {
+		t.Errorf("allowlist: the exact allowed command must pass, got allowed=%v err=%v", a, err)
+	}
+}
+
+// TestUnquotedBackslashErrorIsActionable checks the rejection explains what to
+// do: an operator hitting it on a legitimate command needs to know that quoting
+// the word is the fix, not that "the command was denied".
+func TestUnquotedBackslashErrorIsActionable(t *testing.T) {
+	t.Parallel()
+
+	_, err := extractCommands(`touch a\ b`)
+	if err == nil {
+		t.Fatal("an unquoted backslash escape must be rejected")
+	}
+	if !strings.Contains(err.Error(), "unquoted backslash") || !strings.Contains(err.Error(), "quote it") {
+		t.Errorf("error must name the cause and the remedy, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #308

## The bypass

The command policy decides against the DECODED literal form of each simple
command, so it matches what the target shell will really run rather than the
caller's quoting. Two decode gaps in that class were already closed — #277
(quoting/encoding) and v3.0.1's GHSA-937v-rmqp-j3hx (glob/brace/tilde). This
was the one they left open.

`expand.Literal` keeps an **unquoted** backslash verbatim, while the target's
`$SHELL -c` (and the sealed-exec shim) consume it as an escape. The policy
therefore matched a different string from the one that executes:

| request | policy matched | host executed |
|---|---|---|
| `r\m -rf /srv/data` | `r\m -rf /srv/data` | `rm -rf /srv/data` |
| `cat /etc/sha\dow` | `cat /etc/sha\dow` | `cat /etc/shadow` |

A `deny` or `require_approval` rule the executed command hits was dodged. The
one-shot force-command baked into the certificate is the raw `in.Command`
(`internal/signer/signer.go:464`), which sshd runs via the account's login
shell.

The gap was already known to the code: `hasUnquotedBackslash` sat directly
below `literalArgs` and was applied only on the elevation path (#306), its
comment noting that the policy layer was "tracked separately" — but nothing
tracked it and `literalArgs` never called it.

## The fix

`literalArgs` now applies the same check, rejecting fail-closed with an
actionable error ("quote it or use an explicit value") — the treatment v3.0.1
gave glob/brace/tilde. The helper is renamed `unquotedBackslash` so it returns
the offending literal for that message; `directArgv` keeps its existing
fail-to-wrapper behaviour.

## Scope — no false rejections

Only unquoted backslashes diverge. Verified against the pinned
mvdan.cc/sh v3.13.1 that `expand.Literal` decodes quoted forms exactly as the
shell does, so they keep working and quoting is the remedy:

- `'a\b'` → `a\b`, `"a\b"` → `a\b`
- `"a\$b"` → `a$b`, ``"a\`b"`` → `` a`b ``
- `$'a\tb'` → a real tab, `a"\\"b` → `a\b`

Blast radius is limited to hosts with an active `command_policy`:
`PolicySet.Decide` returns early on an empty set.

## Verified

`make verify` green — gofmt, vet, build, race tests, govulncheck, and the docs
gate (docs-gen drift, example configs, strict site). New regression test covers
the bypass vectors for denylist, `require_approval` and allowlist, plus the
quoted control cases that must keep working. CHANGELOG entry added under
`[Unreleased]`.