### PR TITLE
docs: USAGE covers thirteen MCP tools, not seven

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,7 +1,14 @@
 # Usage Guide — infrabroker MCP Tools
 
-This document covers practical usage of the seven MCP tools exposed by
-`cmd/mcp-broker` (stdio) and `cmd/mcp-broker-http` (HTTP+OAuth2/OIDC).
+This document covers practical usage of the thirteen MCP tools exposed by
+`cmd/mcp-broker` (stdio) and `cmd/mcp-broker-http` (HTTP+OAuth2/OIDC): the seven
+`ssh_*` tools (`ssh_list_servers` in [§1](#1-before-you-start), `ssh_execute` in
+[§2](#2-ssh_execute--one-shot-command), the three session tools in
+[§3](#3-ssh_session_open--exec--close--persistent-session), and the two transfer
+tools in [§9](#9-ssh_put_file--ssh_get_file--file-transfer)), plus the six
+`k8s_*` tools in [§10](#10-kubernetes-tools-k8s_) — the latter registered only
+when a Kubernetes cluster is visible to the caller, so an SSH-only deployment
+exposes no k8s tools at all.
 
 Keep this file up to date whenever a tool is added, removed, renamed, or its
 parameters or behaviour change.
@@ -19,6 +26,7 @@ parameters or behaviour change.
 7. [Reviewing audit logs](#7-reviewing-audit-logs)
 8. [Session recording](#8-session-recording)
 9. [ssh\_put\_file / ssh\_get\_file — file transfer](#9-ssh_put_file--ssh_get_file--file-transfer)
+10. [Kubernetes tools (k8s\_\*)](#10-kubernetes-tools-k8s_)
 
 ---
 


### PR DESCRIPTION
Closes #309

`docs/USAGE.md` opened with "practical usage of the **seven** MCP tools" — a
leftover from the SSH-only era. Thirteen ship, and the file already documents
all of them: the seven `ssh_*` tools plus the six `k8s_*` tools
(`k8s_list_clusters`, `k8s_get`, `k8s_list`, `k8s_logs`, `k8s_apply`,
`k8s_delete`) added with the Kubernetes target in v1.34.0, which have their own
section 10.

The stale count was the first thing a reader saw and undercounted the surface by
six — in a file that carries the instruction "Keep this file up to date whenever
a tool is added, removed, renamed", and which README links as the guide to "MCP
tools (SSH + Kubernetes)".

## Changes

- The intro now states the real surface and points at where each group is
  documented (`ssh_list_servers` §1, `ssh_execute` §2, sessions §3, transfers §9,
  k8s §10), and keeps the conditional-registration boundary explicit: the k8s
  tools are registered only when a cluster is visible, so an SSH-only deployment
  exposes none. That is the boundary `docs/ARCHITECTURE.md` already states.
- The table of contents stopped at 9 and omitted section 10 entirely — added.

## Verified

`make verify` green — docs-gen drift, example configs, and the strict mkdocs
site build. Cross-checked the tool count against the registrations in
`internal/mcpserver/tools.go` + `tools_k8s.go` and the generated
`docs/reference/mcp-tools.md` (13 in both). Docs-only, no behaviour change and
no CHANGELOG entry, matching how the previous stale-docs correction was shipped.