### PR TITLE
docs: document the unresolvable-expansion rejection class in shell_parse

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,7 +340,38 @@ falls back to matching the command as a **whole string**, where `&&`, `;`, `|`,
 `` ` `` and `$()` are transparent to the evaluator (allowlist `["^ps"]` then lets
 `ps aux && kill -9 1` through, and `^kubectl get ` lets
 `kubectl get pods; rm -rf /etc` through) — only safe when the target is not a
-POSIX shell. **Newlines (v1.11.2):** `\n`/`\r` in one-shot commands are rejected
+POSIX shell.
+
+**Words the signer cannot resolve statically are rejected (v3.0.1 / #308).** With
+`shell_parse` on, each command word is *decoded* to the literal value the target
+shell will execute, so the policy matches what runs rather than the caller's
+quoting (`'rm'`, `r"m"` and `$'\x72\x6d'` all decide as `rm` — #211/#277). A word
+whose runtime value the signer **cannot know** is therefore rejected fail-closed
+instead of being matched against a string the shell would not run:
+
+| Rejected (unquoted) | Why the signer cannot resolve it |
+|---|---|
+| `$x`, `${x}`, `$(…)`, `$((…))` | value comes from the target's environment |
+| `*`, `?`, `[…]` | pathname globbing depends on the target's filesystem |
+| `{a,b}` | brace expansion happens on the target |
+| leading `~` | expands to a home directory the signer cannot see |
+| `\` escapes | the shell consumes the escape; the decoded value differs |
+
+Each of these is a **bypass class**, not a style rule: the policy would otherwise
+decide on a literal form while the target's `$SHELL -c` (and the sealed-exec
+shim) expands it at run time — `/bin/r[m] -rf /data` globs back to `/bin/rm`,
+`cat /etc/{a,shadow}` brace-expands to `/etc/shadow`, and `r\m -rf /data` runs as
+`rm`, each dodging a `deny` / `require_approval` rule the executed command hits
+(GHSA-937v-rmqp-j3hx, #308).
+
+**The remedy is to quote the word** — `'/etc/[x]'`, `"a*b"`, `'~notahome'` — or to
+use an explicit value. Quoted metacharacters do not expand on the target either,
+so they are decoded and matched normally and keep working; the glob/brace, tilde
+and backslash rejections name the offending word and the remedy. Commands that
+genuinely need runtime expansion (`ls /var/log/*.gz`) belong in a script on the
+host, invoked by an allowed command.
+
+**Newlines (v1.11.2):** `\n`/`\r` in one-shot commands are rejected
 by `PolicyTable.Resolve` on every host regardless of `shell_parse` — a newline
 would smuggle extra command lines past the regexes (`^ps` also matches
 `"ps\nrm -rf /"`, and the remote shell runs both lines).


### PR DESCRIPTION
Closes #312

`docs/ARCHITECTURE.md` §"Anchoring, shell metacharacters & `shell_parse`" is
where an operator looks up what an active `command_policy` rejects. It listed the
unconditionally-rejected dangerous nodes (command/process substitution,
arithmetic, file redirects, environment mutations) and the newline rule — but
never the **other** rejection class the same code path enforces: a word whose
runtime value the signer cannot resolve statically is rejected fail-closed.

That class covers unquoted globs (`* ? [ ]`), brace expansion (`{a,b}`) and a
leading tilde — added in v3.0.1 for GHSA-937v-rmqp-j3hx — plus unquoted backslash
escapes, added in the fix for the sibling bypass tracked in #308.

Two consequences, both fixed here:

- **Operators hit it without warning.** A perfectly legitimate
  `ls /var/log/*.gz` or `cat ~/x` is denied on any host with a `command_policy`,
  and the section that should explain it did not mention it — nor the remedy.
- **The security rationale was invisible.** This class is what closes the bypass
  where the policy matched a literal form while the target shell expanded it at
  run time. The CHANGELOG records both fixes, but CHANGELOG is not where
  behaviour gets looked up.

## Changes

- A table of what is rejected and *why the signer cannot resolve it* (parameter/
  command/arithmetic expansion, glob, brace, leading tilde, backslash escape).
- Why each is a bypass class rather than a style rule, with the concrete dodges:
  `/bin/r[m] -rf /data` → `/bin/rm`, `cat /etc/{a,shadow}` → `/etc/shadow`,
  `r\m -rf /data` → `rm`.
- The remedy — quote the word, or move genuinely dynamic commands into a
  host-side script invoked by an allowed command — and the note that quoted
  metacharacters are decoded and matched normally, so they keep working.

Claims were checked against `internal/signer/cmdpolicy.go`: the "names the
offending word" statement is scoped to the glob/brace, tilde and backslash
errors, since the parameter-expansion rejection does not include the word.

## Verified

`make verify` green — gofmt, vet, build, race tests, govulncheck, and the docs
gate (docs-gen drift, example configs, strict mkdocs site). Docs-only, no
behaviour change.