### PR TITLE
fix(mcpserver): return the approval prompt as an input request (SEP-2322)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,21 @@
   quotes do not group arguments in a `Cmnd`, `\|` is a syntax error that
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
+### Fixed
+- **In-conversation approvals work again on the current MCP protocol (#318)** —
+  the `github.com/modelcontextprotocol/go-sdk` v1.7.0 bump brought protocol
+  version 2026-07-28, where SEP-2322 forbids a server from sending
+  `elicitation/create` while it is serving a `tools/call`. The #118 approval
+  prompt did exactly that, so against any client on the current protocol a
+  `require_approval` command returned a tool error instead of asking the human —
+  and the repository's test suite went red. The prompt is now returned as an
+  `inputRequests` entry on the tool result and the client re-calls the tool with
+  the answer, which is the SEP-2322 flow; clients still on an older protocol
+  version keep seeing an ordinary server-initiated elicitation (the SDK's server
+  middleware bridges them), so nothing changes for the human at either end. The
+  gate itself is unchanged: only an explicit accept with `approve=true` approves,
+  and the `approval_granted` record still commits before the command runs (#280).
+
 ### Internal
 - **Annotate the intentional SSH remote-exec sink** — `internal/ssh/run.go` carries
   a CodeQL suppression + rationale for `go/command-injection`: the command reaching

--- a/internal/mcpserver/approval_test.go
+++ b/internal/mcpserver/approval_test.go
@@ -25,6 +25,14 @@ import (
 // the server's elicitation on the client side.
 func approvalSession(t *testing.T, elicit bool, elicitHandler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) (*mcp.ClientSession, string) {
 	t.Helper()
+	return approvalSessionOpts(t, elicit, &mcp.ClientOptions{ElicitationHandler: elicitHandler})
+}
+
+// approvalSessionOpts is approvalSession with explicit client options, so a test
+// can opt out of the SDK's automatic multi round-trip handling and inspect the
+// raw input-required result the server returns.
+func approvalSessionOpts(t *testing.T, elicit bool, copts *mcp.ClientOptions) (*mcp.ClientSession, string) {
+	t.Helper()
 	dir := t.TempDir()
 	_, caPriv, _ := ed25519.GenerateKey(rand.Reader)
 	blk, err := ssh.MarshalPrivateKey(caPriv, "ca-test")
@@ -66,7 +74,7 @@ func approvalSession(t *testing.T, elicit bool, elicitHandler func(context.Conte
 	if _, err := srv.Connect(context.Background(), st, nil); err != nil {
 		t.Fatalf("server connect: %v", err)
 	}
-	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, &mcp.ClientOptions{ElicitationHandler: elicitHandler})
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, copts)
 	sess, err := client.Connect(context.Background(), ct, nil)
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
@@ -177,6 +185,45 @@ func TestApprovalDeclinedViaElicitation(t *testing.T) {
 	}
 	if _, executed := auditContains(t, auditLog, "executed"); executed {
 		t.Error("a declined command must not produce an executed audit entry")
+	}
+}
+
+// TestApprovalReturnsInputRequest pins the wire shape of the approval prompt:
+// since MCP protocol version 2026-07-28 (SEP-2322) a server may not send
+// elicitation/create while serving tools/call, so the question must ride back as
+// an InputRequests entry on the tool result. The client opts out of the SDK's
+// automatic multi round-trip middleware so the raw result is observable; the
+// other elicitation tests cover the fulfilled round trip.
+func TestApprovalReturnsInputRequest(t *testing.T) {
+	t.Parallel()
+	sess, auditLog := approvalSessionOpts(t, true, &mcp.ClientOptions{
+		MultiRoundTrip: &mcp.MultiRoundTripOptions{Disabled: true},
+		ElicitationHandler: func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+			t.Error("the server must not send elicitation/create while serving tools/call")
+			return nil, nil
+		},
+	})
+	res := callRestart(t, sess)
+	if !res.NeedsInput() {
+		t.Fatalf("want an input-required result; got NeedsInput=false IsError=%v text=%q", res.IsError, k8sToolText(t, res))
+	}
+	req, ok := res.InputRequests[approvalInputID]
+	if !ok {
+		t.Fatalf("input request %q missing; got %v", approvalInputID, res.InputRequests)
+	}
+	ep, ok := req.(*mcp.ElicitParams)
+	if !ok {
+		t.Fatalf("input request is %T, want *mcp.ElicitParams", req)
+	}
+	if !strings.Contains(ep.Message, "systemctl restart nginx") || !strings.Contains(ep.Message, "web01") {
+		t.Errorf("elicitation message must name the command and host; got %q", ep.Message)
+	}
+	// Nothing is decided or run until the human answers.
+	if _, ok := auditContains(t, auditLog, "approval_granted"); ok {
+		t.Error("an unanswered approval must not be recorded as granted")
+	}
+	if _, ok := auditContains(t, auditLog, "executed"); ok {
+		t.Error("an unanswered approval must not execute the command")
 	}
 }
 

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -231,9 +231,13 @@ func registerExecute(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc, e
 			// the human in the MCP client and retry with approval if accepted.
 			var appErr *broker.ApprovalRequiredError
 			if elicitApprovals && errors.As(err, &appErr) {
-				approved, elErr := elicitApproval(ctx, req.Session, in.Server, in.Command, appErr)
-				if elErr != nil {
-					return toolError(elErr), executeOutput{}, nil
+				approved, answered := elicitedApproval(req)
+				if !answered {
+					// First round: ask the human. The answer comes back as an input
+					// response on the client's retry of this same call, which re-enters
+					// this handler and re-derives appErr.Rule from the policy (never
+					// from client-echoed state, which must not reach the audit log).
+					return approvalElicitation(in.Server, in.Command, appErr), executeOutput{}, nil
 				}
 				caller := callerFn(ctx)
 				if !approved {
@@ -443,36 +447,64 @@ func toolError(err error) *mcp.CallToolResult {
 	return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}}
 }
 
-// elicitApproval asks the human in the MCP client to approve a require_approval
-// command (#118). The client renders the prompt to the human; the model cannot
-// answer it. Returns true only on an explicit approval (action "accept" with
-// approve=true); "decline"/"cancel" or approve=false return false.
-func elicitApproval(ctx context.Context, ss *mcp.ServerSession, server, command string, appErr *broker.ApprovalRequiredError) (bool, error) {
-	if ss == nil {
-		return false, fmt.Errorf("cannot request approval: no interactive client session")
-	}
-	res, err := ss.Elicit(ctx, &mcp.ElicitParams{
-		Mode:    "form",
-		Message: fmt.Sprintf("Approve running %q on %q? Host policy requires approval (%s).", command, server, appErr.Rule),
-		RequestedSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"approve": map[string]any{
-					"type":        "boolean",
-					"description": "Set true to approve and run the command, false to deny.",
+// approvalInputID keys the approval question inside a tool result's input-request
+// map. One question per ssh_execute call and the map is per-result, so a fixed
+// id is enough.
+const approvalInputID = "approval"
+
+// approvalElicitation returns the input-required tool result that asks the human
+// in the MCP client to approve a require_approval command (#118).
+//
+// It is an INPUT REQUEST, not a server-initiated elicitation: since MCP protocol
+// version 2026-07-28 (SEP-2322) a server may not send elicitation/create while it
+// is serving tools/call, so the question travels back with the result and the
+// client re-calls the tool with the answer in params.inputResponses. The SDK
+// installs both halves of that round trip by default and, for a client still on
+// an older protocol version, its server middleware fulfils the request with a
+// classic server-initiated elicitation and re-invokes this handler — so one code
+// path serves both client generations and the human sees the same prompt.
+//
+// The client renders the prompt to the human; the model cannot answer it, and it
+// cannot forge the answer either — inputResponses is a protocol field of the
+// retried call, not part of the tool arguments the model controls.
+func approvalElicitation(server, command string, appErr *broker.ApprovalRequiredError) *mcp.CallToolResult {
+	return &mcp.CallToolResult{InputRequests: mcp.InputRequestMap{
+		approvalInputID: &mcp.ElicitParams{
+			Mode:    "form",
+			Message: fmt.Sprintf("Approve running %q on %q? Host policy requires approval (%s).", command, server, appErr.Rule),
+			RequestedSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"approve": map[string]any{
+						"type":        "boolean",
+						"description": "Set true to approve and run the command, false to deny.",
+					},
 				},
+				"required": []string{"approve"},
 			},
-			"required": []string{"approve"},
 		},
-	})
-	if err != nil {
-		return false, fmt.Errorf("requesting approval from the client: %w", err)
+	}}
+}
+
+// elicitedApproval reads the human's answer out of a retried tool call. answered
+// is false while the client has not responded yet (the first invocation), which
+// is what makes the handler ask. Fail-closed: only an explicit "accept" carrying
+// approve=true approves — "decline"/"cancel", approve=false, and a response of an
+// unexpected type all deny.
+func elicitedApproval(req *mcp.CallToolRequest) (approved, answered bool) {
+	if req == nil || req.Params == nil {
+		return false, false
 	}
-	if res.Action != "accept" {
-		return false, nil
+	resp, ok := req.Params.InputResponses[approvalInputID]
+	if !ok {
+		return false, false
+	}
+	res, ok := resp.(*mcp.ElicitResult)
+	if !ok || res.Action != "accept" {
+		return false, true
 	}
 	approve, _ := res.Content["approve"].(bool)
-	return approve, nil
+	return approve, true
 }
 
 // renderDecision formats the result of a dry-run (policy simulation).


### PR DESCRIPTION
`main` has been red since de4bba1 (`chore(deps): bump github.com/modelcontextprotocol/go-sdk`, #314): the SDK moved to v1.7.0, which implements MCP protocol version **2026-07-28**. Under SEP-2322 a server may no longer send `elicitation/create` while it is serving a `tools/call` — `ServerSession.Elicit` now fails with

> `"elicitation/create" cannot be sent while serving a request on protocol version 2026-07-28: return an InputRequests map instead (multi round-trip requests, SEP-2322)`

The #118 in-conversation approval called exactly that from inside the `ssh_execute` handler, so two things broke:

- **CI**: `go test -race ./internal/mcpserver` fails, and `build` is a required check — every PR is blocked.
- **The feature**: against any client on the current protocol, a `require_approval` command returns a tool error instead of raising the in-chat prompt. It fails closed (no certificate, nothing runs), so this is a correctness/availability regression, not an authorization bypass.

## The fix

The approval question now rides back as an `inputRequests` entry on the tool result; the client re-calls the tool with the human's answer in `params.inputResponses`. The SDK installs both halves of that round trip by default, and its server middleware bridges clients still on an older protocol version by fulfilling the request with a classic server-initiated elicitation and re-invoking the handler — so **one code path serves both client generations** and the human sees the same prompt either way.

The gate is deliberately unchanged:

- only an explicit `accept` carrying `approve=true` approves; decline/cancel, `approve=false`, and an unexpected response type all deny;
- the matched rule is re-derived from the policy on the retry rather than read from client-echoed state, so nothing client-supplied reaches the audit log;
- the `approval_granted` record still commits before the command runs (#280);
- the model cannot forge the answer: `inputResponses` is a protocol field of the retried call, not part of the tool arguments it controls.

## Verification

`make verify` green (gofmt, vet, build, `go test -race`, govulncheck, docs gate).

The pre-existing `TestApprovalAcceptedViaElicitation` / `TestApprovalDeclinedViaElicitation` pass **unchanged** — they drive a real SDK client whose multi-round-trip middleware answers the input request via the `ElicitationHandler`, which exercises the whole round trip end to end. A new `TestApprovalReturnsInputRequest` disables that middleware to pin the wire shape directly and asserts that nothing is granted or executed while the question is unanswered.

Closes #318