### PR TITLE
fix(control-plane): forward allow_file_transfer on GET /v1/hosts

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -659,7 +659,13 @@ func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
 	for name, h := range hosts {
 		out[name] = signer.WireHostInfo{
 			Addr: h.Addr, User: h.User, HostKey: h.HostKey, Jump: h.Jump,
-			AllowSudo: h.AllowSudo, AllowPTY: h.AllowPTY,
+			// Every capability flag must be forwarded: the broker reports them in
+			// ssh_list_servers and the tool descriptions tell the model to trust
+			// them ("allow_file_transfer=false -> DO NOT attempt file transfers").
+			// A flag dropped here reads as "not allowed" to the model, so an
+			// operator-enabled capability becomes unusable behind the control plane
+			// while it works with a direct signer.
+			AllowSudo: h.AllowSudo, AllowPTY: h.AllowPTY, AllowFileTransfer: h.AllowFileTransfer,
 			// Groups must be forwarded so the broker can apply per-user group
 			// filtering in ssh_list_servers (otherwise an OIDC user with groups
 			// sees zero hosts behind the control plane).

--- a/cmd/control-plane/main_test.go
+++ b/cmd/control-plane/main_test.go
@@ -517,6 +517,59 @@ func TestControlPlaneForwardsHostGroups(t *testing.T) {
 	}
 }
 
+// TestControlPlaneForwardsHostCapabilities verifies GET /v1/hosts forwards every
+// per-host capability flag. The broker surfaces these in ssh_list_servers and the
+// MCP tool descriptions tell the model to obey them ("allow_file_transfer=false
+// -> DO NOT attempt file transfers"), so a flag dropped in the forward makes an
+// operator-enabled capability unusable behind the control plane while it works
+// against a direct signer (#315).
+func TestControlPlaneForwardsHostCapabilities(t *testing.T) {
+	sig := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/hosts" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]signer.WireHostInfo{
+			"web01": {
+				Addr: "10.0.0.1:22", User: "deploy", HostKey: "ssh-ed25519 AAAA", Jump: "bastion",
+				AllowSudo: true, AllowPTY: true, AllowFileTransfer: true,
+			},
+		})
+	}))
+	defer sig.Close()
+	s := testServer(t, sig.URL)
+
+	w := httptest.NewRecorder()
+	s.handleHosts(w, req(t, "GET", "/v1/hosts", "broker-1", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	var out map[string]signer.WireHostInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	h, ok := out["web01"]
+	if !ok {
+		t.Fatalf("web01 missing from the forwarded host list: %s", w.Body.String())
+	}
+	for _, c := range []struct {
+		field string
+		got   bool
+	}{
+		{"allow_sudo", h.AllowSudo},
+		{"allow_pty", h.AllowPTY},
+		{"allow_file_transfer", h.AllowFileTransfer},
+	} {
+		if !c.got {
+			t.Errorf("%s must be forwarded verbatim; got false", c.field)
+		}
+	}
+	// Connectivity fields ride along unchanged.
+	if h.Addr != "10.0.0.1:22" || h.User != "deploy" || h.HostKey != "ssh-ed25519 AAAA" || h.Jump != "bastion" {
+		t.Errorf("connectivity fields altered in the forward: %+v", h)
+	}
+}
+
 // TestControlPlaneSignCallerRoleSeparation covers the broker/approver role
 // separation on the signing path: by default an approver CN cannot sign, and an
 // explicit sign_callers list is an exact allowlist.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,16 @@
   middleware bridges them), so nothing changes for the human at either end. The
   gate itself is unchanged: only an explicit accept with `approve=true` approves,
   and the `approval_granted` record still commits before the command runs (#280).
+- **Control plane no longer hides `allow_file_transfer` (#315)** — when a broker
+  reached the signer THROUGH the control plane, `GET /v1/hosts` rebuilt each host
+  entry without the `allow_file_transfer` capability flag, so every host came back
+  as `file_transfer=false`. `ssh_list_servers` then reported the capability as
+  unavailable and the `ssh_put_file` / `ssh_get_file` tool descriptions tell the
+  model not to attempt a transfer on such a host — making an operator-enabled
+  capability unusable in the control-plane topology while it worked against a
+  direct signer. The flag is now forwarded like `allow_sudo` / `allow_pty`. No
+  authorization change: the signer always enforced `allow_file_transfer` at
+  `/v1/sign`, so the previous behaviour failed closed.
 
 ### Internal
 - **Annotate the intentional SSH remote-exec sink** — `internal/ssh/run.go` carries


### PR DESCRIPTION
The signer serves `allow_file_transfer` on `GET /v1/hosts` (`cmd/signer/main.go`), and `signer.Remote.FetchHosts` maps it into `HostInfo`. But when a broker reaches the signer **through the control plane**, `handleHosts` rebuilds each entry into a fresh `signer.WireHostInfo` and copied only `Addr`/`User`/`HostKey`/`Jump`/`AllowSudo`/`AllowPTY`/`Groups` — `allow_file_transfer` was dropped, so it decoded as `false` for every host.

Consequence: behind a control plane, `ssh_list_servers` reports `file_transfer=false` everywhere. The MCP tool descriptions instruct the model on exactly that field —

> `allow_file_transfer=false` → DO NOT attempt file transfers, the signer will reject them

and, on `ssh_put_file` / `ssh_get_file`, *"if false DO NOT retry"*. A correctly-behaving agent therefore never attempts a transfer on a host where the operator enabled it: the capability is silently unusable in the control-plane topology while it works against a direct signer.

**No authorization change.** The signer always enforced `allow_file_transfer` at `/v1/sign`, so the previous behaviour failed closed — this is a capability regression and a deployment-mode drift, not a bypass. The sibling `handleClusters` forwards every `WireClusterInfo` field, and `Groups` was added to this same map for the same class of bug (`TestControlPlaneForwardsHostGroups`), which is what makes the omission an oversight rather than a deliberate filter.

## Verification

`make verify` green (gofmt, vet, build, `go test -race`, govulncheck, docs gate).

New `TestControlPlaneForwardsHostCapabilities` asserts every capability flag and the connectivity fields survive the forward; it fails on the pre-fix code with *"allow_file_transfer must be forwarded verbatim; got false"*.

Closes #315