### PR TITLE
fix(broker-ctl): rebase a file-relative mTLS path onto the config file's dir

### DIFF
--- a/broker-ctl.example.json
+++ b/broker-ctl.example.json
@@ -10,6 +10,9 @@
   // searched — use --client-config for a local file, to avoid a planted
   // ./broker-ctl.json redirecting the mTLS endpoint/CA). Env vars:
   // BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and BROKER_CTL_CP_{URL,CERT,KEY,CA}.
+  // Prefer ABSOLUTE cert/key/ca paths, as below. A relative one is resolved
+  // against THIS FILE's directory (never the current working directory, so a
+  // planted ./pki cannot supply the admin CLI's identity or CA trust anchor).
 
   // Signer-facing commands (reload, policy *, host list --remote). The cert CN
   // must be in the signer's reload_callers for the policy/read APIs. If url is

--- a/cmd/broker-ctl/clientconfig.go
+++ b/cmd/broker-ctl/clientconfig.go
@@ -25,11 +25,13 @@
 // A file that exists but does not parse is always a hard error — never silently
 // ignored.
 //
-// When a config file is loaded but omits a cert/key/ca, the built-in default
-// (./pki/*) is resolved relative to that file's directory rather than the
-// current working directory, so a partial file cannot pull the mTLS trust
-// material from wherever the CLI happens to run. With no config file the default
-// stays CWD-relative (the lab fallback).
+// When a config file is loaded, a RELATIVE cert/key/ca — whether written in the
+// file or inherited from the built-in default (./pki/*) — is resolved relative to
+// that file's directory rather than the current working directory, so neither a
+// partial nor a relative-path config can pull the mTLS trust material from
+// wherever the CLI happens to run. With no config file the default stays
+// CWD-relative (the lab fallback). Absolute paths, environment variables and
+// explicit flags are used verbatim.
 //
 // Environment variables: BROKER_CTL_SIGNER_{URL,CERT,KEY,CA} and
 // BROKER_CTL_CP_{URL,CERT,KEY,CA}.
@@ -153,6 +155,15 @@ func loadClientConfig() (clientConfig, string) {
 func resolveTarget(fs *flag.FlagSet, env string, file clientTarget, fileDir string) {
 	set := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+	// rebase resolves a relative mTLS path against the config file's directory.
+	// It is a no-op for an absolute path, for a non-path parameter (url), and
+	// when no config file was loaded (the CWD-relative lab fallback).
+	rebase := func(v string, isPath bool) string {
+		if !isPath || fileDir == "" || v == "" || filepath.IsAbs(v) {
+			return v
+		}
+		return filepath.Join(fileDir, v)
+	}
 	apply := func(name, envSuffix, fileVal string, isPath bool) {
 		if set[name] {
 			return
@@ -166,16 +177,16 @@ func resolveTarget(fs *flag.FlagSet, env string, file clientTarget, fileDir stri
 			return
 		}
 		if fileVal != "" {
-			f.Value.Set(fileVal)
+			// A relative path IN the file is rebased too, not just the built-in
+			// default below: otherwise it would resolve against the CWD, which is
+			// the very exposure this file's search order avoids — a planted ./pki
+			// in whatever directory the admin runs from would supply this
+			// privileged CLI's client identity and CA trust anchor.
+			f.Value.Set(rebase(fileVal, isPath))
 			return
 		}
-		// Built-in default stands. If it came alongside a config file and is a
-		// relative path, rebase it onto the file's directory.
-		if isPath && fileDir != "" {
-			if cur := f.Value.String(); cur != "" && !filepath.IsAbs(cur) {
-				f.Value.Set(filepath.Join(fileDir, cur))
-			}
-		}
+		// Built-in default stands, rebased the same way.
+		f.Value.Set(rebase(f.Value.String(), isPath))
 	}
 	apply("url", "_URL", file.URL, false)
 	apply("cert", "_CERT", file.Cert, true)

--- a/cmd/broker-ctl/clientconfig_test.go
+++ b/cmd/broker-ctl/clientconfig_test.go
@@ -137,6 +137,55 @@ func TestResolveTargetRebasesDefaultToFileDir(t *testing.T) {
 	}
 }
 
+// TestResolveTargetRebasesFileRelativePaths: a RELATIVE cert/key/ca written in
+// the config file resolves against that file's directory, not the CWD. Resolving
+// it against the CWD would reopen the exposure the search order avoids — a
+// planted ./pki in whatever directory the admin runs from would supply this
+// privileged CLI's client identity and CA trust anchor. url is not a path and is
+// never rewritten.
+func TestResolveTargetRebasesFileRelativePaths(t *testing.T) {
+	for _, e := range []string{"URL", "CERT", "KEY", "CA"} {
+		t.Setenv("BROKER_CTL_SIGNER_"+e, "")
+	}
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	url, cert, key, ca := signerFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	resolveTarget(fs, "BROKER_CTL_SIGNER", clientTarget{
+		URL:  "s:9443",
+		Cert: "pki/admin.crt",
+		Key:  "./pki/admin.key",
+		CA:   "../shared/mtls_ca.crt",
+	}, "/etc/infrabroker")
+
+	for _, c := range []struct{ name, got, want string }{
+		{"cert", *cert, "/etc/infrabroker/pki/admin.crt"},
+		{"key", *key, "/etc/infrabroker/pki/admin.key"},
+		{"ca", *ca, "/etc/shared/mtls_ca.crt"},
+	} {
+		if c.got != c.want {
+			t.Errorf("file-relative %s must rebase onto the config file's dir: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+	if *url != "s:9443" {
+		t.Errorf("url is not a path and must be used verbatim, got %q", *url)
+	}
+
+	// With no config file there is nothing to rebase onto: a relative path from
+	// an explicitly-named file in the CWD keeps working as before.
+	fs2 := flag.NewFlagSet("t2", flag.ContinueOnError)
+	_, cert2, _, _ := signerFlags(fs2)
+	if err := fs2.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	resolveTarget(fs2, "BROKER_CTL_SIGNER", clientTarget{Cert: "pki/admin.crt"}, "")
+	if *cert2 != "pki/admin.crt" {
+		t.Errorf("with no config file dir the file value must be used verbatim, got %q", *cert2)
+	}
+}
+
 // TestClientConfigCandidatesOrder: --client-config and $BROKER_CTL_CONFIG are
 // explicit (required) and come first, in that order.
 func TestClientConfigCandidatesOrder(t *testing.T) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## [Unreleased]
 
 ### Security
+- **broker-ctl: a relative cert/key/ca in the client config resolves against that
+  file, not the CWD (#320)** — `cmd/broker-ctl/clientconfig.go` deliberately keeps
+  the current working directory out of the client-config search order so a planted
+  file cannot redirect this privileged CLI's mTLS endpoint and CA trust anchor, and
+  it already rebased the built-in `./pki/*` default onto the config file's
+  directory. A relative path written IN the file skipped that rebase and resolved
+  against the CWD, so running `broker-ctl` from a directory holding an unrelated
+  `pki/` took the admin client cert/key and the CA trust anchor from there —
+  letting a local file plant get the CLI to trust a spoofed signer / control plane
+  (answering `policy add`, `grant`, `approval allow`) or present an
+  attacker-chosen identity. Relative file values are now rebased the same way.
+  **Behaviour change**, narrow: only a RELATIVE cert/key/ca inside a loaded config
+  file moves — it now resolves next to that file instead of next to the CWD.
+  Absolute paths, `BROKER_CTL_*` env vars, explicit flags, and the no-config-file
+  lab fallback are unchanged. Prefer absolute paths, as `broker-ctl.example.json`
+  shows.
 - **Command policy: reject unquoted backslash escapes (#308)** — the last decode
   gap of the bypass class closed by #277 (quoting/encoding) and v3.0.1's
   GHSA-937v-rmqp-j3hx (glob/brace/tilde). The AI-action firewall decided a host's


### PR DESCRIPTION
`cmd/broker-ctl/clientconfig.go` hardens where the privileged admin CLI's mTLS material comes from. Its package comment states the intent: the CWD is deliberately **not** in the client-config search order, because *"an implicit ./broker-ctl.json would let a planted file redirect this privileged CLI's mTLS endpoint and CA trust anchor"*, and a loaded-but-partial file must not *"pull the mTLS trust material from wherever the CLI happens to run"*.

That rebase was implemented for the **built-in default only**. A value present in the config file took the early return and was passed to the flag verbatim — no absolute check, no rebase:

```go
if fileVal != "" {
    f.Value.Set(fileVal)
    return
}
// Built-in default stands. If it came alongside a config file and is a
// relative path, rebase it onto the file's directory.
```

So an operator whose `/etc/infrabroker/broker-ctl.json` writes `"ca": "pki/mtls_ca.crt"` instead of an absolute path got exactly the exposure the surrounding code was written to close: running `broker-ctl` from any directory containing a `pki/` resolved the CA trust anchor — and the client cert/key — out of *that* directory. An attacker able to drop files in a directory an admin runs from can then make the CLI trust an attacker CA (so `policy add`, `grant` and `approval allow` are answered by a spoofed signer / control plane) or present an attacker-chosen client identity.

Preconditions are an operator misconfiguration plus local file-plant ability, which is why this is low severity — but it was the one remaining hole in a control this file otherwise implements carefully, and nothing warned about it: the example happened to use absolute paths, and the installer's "use ABSOLUTE paths" note only covers `signer.json`.

## Behaviour change (narrow)

Only a **relative** `cert`/`key`/`ca` inside a loaded config file moves: it now resolves next to that file instead of next to the CWD. Absolute paths, `BROKER_CTL_*` env vars, explicit flags, and the no-config-file lab fallback are unchanged. `broker-ctl.example.json` now states the rule and recommends absolute paths.

## Verification

`make verify` green (gofmt, vet, build, `go test -race`, govulncheck, docs gate).

New `TestResolveTargetRebasesFileRelativePaths` covers relative, `./`-prefixed and `../` file values plus the no-config-file case, and asserts `url` (not a path) is never rewritten. It fails on the pre-fix code with `got "pki/admin.crt", want "/etc/infrabroker/pki/admin.crt"`.

Closes #320