### PR TITLE
docs(deploy): offer the ssh-agent CA backend where operators choose custody

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -240,10 +240,15 @@ Done. Before starting (see deploy/README.md for the full checklist):
     SIGNER config lives in ${STATEDIR}/signer/signer.json (service-owned, so
     the durable policy-mutation API can rewrite it); control-plane / mcp-http
     configs are in ${ETCDIR}.
- 2. Choose CA custody in signer.json (ca_keys._default.type):
-      "akv"  Azure Key Vault (production; credentials via managed identity or
-             ${ETCDIR}/signer.env with AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET)
-      "pem"  local key file (lab/dev only)
+ 2. Choose CA custody in signer.json (ca_keys._default.type) — see
+    "Choosing CA custody" in deploy/README.md for the full comparison:
+      "akv"    Azure Key Vault (production; credentials via managed identity or
+               ${ETCDIR}/signer.env with AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET)
+      "agent"  ssh-agent, hardware-backed (production; YubiKey PIV / SoftHSM /
+               TPM. Needs public_key_path to pin which agent key is the CA, and
+               an agent socket the signer can reach — NOT under /tmp, which the
+               unit's PrivateTmp hides; e.g. /run/infrabroker/ssh-agent.sock)
+      "pem"    local key file (lab/dev only)
  3. Place the mTLS PKI:
       shared CA cert     ${ETCDIR}/pki/mtls_ca.crt        (0640 root:infrabroker)
       per-service keys   ${ETCDIR}/pki/<svc>/             (0640 root:infrabroker-<svc>)

--- a/deploy/systemd/infrabroker-signer.service
+++ b/deploy/systemd/infrabroker-signer.service
@@ -23,12 +23,20 @@
 # Relative paths (e.g. the default audit_log "signer_audit.log") resolve under
 # WorkingDirectory, i.e. /var/lib/infrabroker/signer — that is intentional.
 #
-# CA custody is chosen in signer.json (ca_keys._default.type):
-#   "pem"  local key file — lab/dev only, the signer logs a warning.
-#   "akv"  Azure Key Vault — private key never leaves the vault. Credentials
-#          come from DefaultAzureCredential: managed identity needs nothing
-#          extra; a service principal takes AZURE_TENANT_ID / AZURE_CLIENT_ID /
-#          AZURE_CLIENT_SECRET from the optional environment file below.
+# CA custody is chosen in signer.json (ca_keys._default.type) — see "Choosing CA
+# custody" in deploy/README.md:
+#   "pem"    local key file — lab/dev only, the signer logs a warning.
+#   "akv"    Azure Key Vault — private key never leaves the vault. Credentials
+#            come from DefaultAzureCredential: managed identity needs nothing
+#            extra; a service principal takes AZURE_TENANT_ID / AZURE_CLIENT_ID /
+#            AZURE_CLIENT_SECRET from the optional environment file below.
+#   "agent"  ssh-agent — the key lives in a YubiKey PIV slot, SoftHSM or TPM and
+#            never reaches this process; every signature is an agent round trip.
+#            public_key_path pins which agent key is the CA. The agent SOCKET is
+#            then the signing capability: guard its unix-socket permissions, and
+#            put it somewhere this unit can reach — NOT under /tmp or /var/tmp,
+#            which PrivateTmp below replaces with a private empty tree (e.g.
+#            /run/infrabroker/ssh-agent.sock works).
 
 [Unit]
 Description=infrabroker signing service (CA custody and issuance policy)
@@ -56,8 +64,10 @@ RestartSec=2
 # Sandboxing. The service needs: read /etc/infrabroker (PKI), read+write its own
 # state dir (config + audit log; the durable policy-mutation API rewrites the
 # config there via temp-file+rename, which the service-owned StateDirectory
-# permits), listen on its mTLS port, and (akv only) outbound HTTPS to the vault
-# / IMDS. /etc stays fully read-only for the service — no ReadWritePaths needed.
+# permits), listen on its mTLS port, (akv only) outbound HTTPS to the vault /
+# IMDS, and (agent only) connect to the ssh-agent unix socket — which is why
+# RestrictAddressFamilies keeps AF_UNIX. /etc stays fully read-only for the
+# service — no ReadWritePaths needed.
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,19 @@
   authorization change: the signer always enforced `allow_file_transfer` at
   `/v1/sign`, so the previous behaviour failed closed.
 
+### Documentation
+- **deploy/: the `agent` CA custody backend is offered where operators choose
+  (#316)** — `deploy/README.md` has documented all three backends since #122, but
+  the checklist `deploy/install.sh` PRINTS after an install, and the header of
+  `deploy/systemd/infrabroker-signer.service`, still presented the choice as
+  `akv` or `pem`. An operator following the printed checklist concluded the
+  hardware-backed production option (YubiKey PIV / SoftHSM / TPM via ssh-agent)
+  did not exist. Both now list `agent` and point at the README's comparison
+  table, and the unit records what that backend needs from the sandbox: the
+  agent socket is the signing capability, so guard its permissions and keep it
+  out of `/tmp` (`PrivateTmp=yes` replaces that with a private empty tree) —
+  e.g. `/run/infrabroker/ssh-agent.sock`.
+
 ### Internal
 - **Annotate the intentional SSH remote-exec sink** — `internal/ssh/run.go` carries
   a CodeQL suppression + rationale for `go/command-injection`: the command reaching


### PR DESCRIPTION
`internal/ca` has supported three CA-custody backends since #122: `pem`, `akv`, and `agent` (the private key lives in a running ssh-agent — YubiKey PIV / SoftHSM / TPM — and the signer process never holds key bytes). `deploy/README.md` documents all three in its "Choosing CA custody" table, and so does `docs/reference/config.md`.

Two operator-facing spots in `deploy/` were never updated and still presented the choice as binary:

- **`deploy/install.sh`** — the checklist the installer *prints as its final output*, i.e. the first thing an operator reads before editing `signer.json`.
- **`deploy/systemd/infrabroker-signer.service`** — the unit header comment.

An operator following the printed checklist concludes the hardware-backed production option does not exist. That is the same gap #160 closed for the README.

Both now list `agent` and point at the README's comparison table. The unit additionally records what that backend needs from its sandbox, which nothing stated before:

- the agent **socket is the signing capability** — anything that can reach it can sign — so its unix-socket permissions are the control;
- `public_key_path` pins which agent key is the CA;
- the socket must not live under `/tmp` or `/var/tmp`, which `PrivateTmp=yes` replaces with a private empty tree (`/run/infrabroker/ssh-agent.sock` works — it is what the README's example uses);
- the sandbox rationale comment now says the `AF_UNIX` in `RestrictAddressFamilies` is load-bearing for this backend.

No behaviour change — comments and printed text only.

## Verification

`bash -n deploy/install.sh` clean and the rendered checklist inspected (the block is inside an unquoted heredoc; the added text introduces no new expansions beyond the existing `${ETCDIR}`). `make verify` green.

Closes #316