### PR TITLE
docs(release): stop hard-coding the installer tarball's binary count

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,14 @@ jobs:
         run: go test -race ./...
 
       # Build the SAME artifact as the documented install path (OPERATIONS §8):
-      # `make dist` produces dist/infrabroker-<version>.tar.gz with all six
-      # binaries (incl. control-plane, which the shipped systemd unit execs),
-      # version-injected, plus deploy/ and the example configs. goreleaser
-      # attaches it to the release via release.extra_files; its own archives
-      # live in dist-goreleaser/ so `release --clean` never wipes this one.
+      # `make dist` produces dist/infrabroker-<version>.tar.gz with every binary
+      # in the Makefile's CMDS list (incl. control-plane, which the shipped
+      # systemd unit execs), version-injected, plus deploy/ and the example
+      # configs. Deliberately not a hard-coded count here: CMDS is the single
+      # source of truth and has grown with approval-bridge (#120) and
+      # infrabroker-shim (#144). goreleaser attaches the tarball to the release
+      # via release.extra_files; its own archives live in dist-goreleaser/ so
+      # `release --clean` never wipes this one.
       - name: Build installer tarball
         run: make dist
 


### PR DESCRIPTION
The `Build installer tarball` step in `.github/workflows/release.yml` documented the release pipeline's contract with `deploy/install.sh` like this:

> `make dist` produces `dist/infrabroker-<version>.tar.gz` with all **six** binaries (incl. control-plane, which the shipped systemd unit execs)

`Makefile:21` has held **nine** since `approval-bridge` (#120, added to `CMDS` by #154) and `infrabroker-shim` (#144) landed:

```
CMDS := infrabroker signer broker broker-ctl mcp-broker mcp-broker-http control-plane approval-bridge infrabroker-shim
```

`make dist` runs `make build` over `CMDS`, so the tarball has shipped nine for several releases. Same stale-count class as the already-fixed #154 (Makefile `CMDS`), #156 (README archive claim) and #275 (Dockerfile `COPY` comment) — a wrong count here invites the reader to assume a binary is missing from the tarball when it is not.

The comment now points at `CMDS` as the single source of truth rather than restating a number that has to be maintained in lockstep. Comment only — no pipeline change, and no CHANGELOG entry (nothing user-visible changes).

## Verification

The workflow still parses as YAML with both jobs (`release`, `mcp-registry`) and all nine release steps intact. `make verify` green.

Closes #317