### PR TITLE
docs: name the ssh-agent CA backend everywhere custody is described

### DIFF
--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -54,8 +54,11 @@ type Config struct {
 	// CA key custody.
 	// ca_key: legacy path to a PEM CA key (backward compatible).
 	// ca_keys: per-group CA key overrides.  The reserved key "_default"
-	// overrides ca_key when present.  See CAKeyConfig for supported backends
-	// ("pem" for local files, "akv" for Azure Key Vault).
+	// overrides ca_key when present.  See CAKeyConfig for the three supported
+	// backends: "pem" (local key file — lab/dev, the signer logs a warning),
+	// "akv" (Azure Key Vault — the key never leaves the vault; RSA/EC only) and
+	// "agent" (ssh-agent — a YubiKey PIV slot / SoftHSM / TPM; the signer holds
+	// no key bytes and supports Ed25519).
 	CAKey  string                    `json:"ca_key"`
 	CAKeys map[string]ca.CAKeyConfig `json:"ca_keys,omitempty"`
 

--- a/config.example.json
+++ b/config.example.json
@@ -25,8 +25,8 @@
   // Multi-CA (local mode only): per-group CA key overrides. '_default' replaces
   // the legacy ca_key. A host's 'groups' field selects which CA signs its
   // certificates (first matching group wins). Ignored when the 'signer' block is
-  // set (remote mode). See signer.example.json for the full reference with AKV
-  // examples. Example:
+  // set (remote mode). See signer.example.json for the full reference on the
+  // three custody backends ('pem', 'akv', 'agent'). Example:
   //   "ca_keys": {
   //     "_default": { "type": "pem", "path": "pki/ssh_ca" },
   //     "prod-web":  { "type": "akv", "vault_url": "https://my-vault.vault.azure.net", "key_name": "ssh-ca-prod-web" },

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -138,7 +138,9 @@ broker-ctl doctor --security \
 
 - [ ] `signer.json` has a non-empty `callers` table scoping brokers to host groups — a non-empty table is default-deny for unlisted CNs (v2.0.0); no `_default` needed.
 - [ ] `sign_rate_limit_per_min` set (size to the busiest legitimate broker).
-- [ ] CA custody is `akv` (or another KMS); `pem` only in a lab.
+- [ ] CA custody is `akv` or `agent` (ssh-agent: YubiKey PIV / SoftHSM / TPM),
+  or another KMS; `pem` only in a lab. With `agent`, the agent socket is the
+  signing capability — its unix-socket permissions are the control.
 - [ ] mTLS PKI split per service: each key in `/etc/infrabroker/pki/<svc>/`
   (`0640 root:infrabroker-<svc>`), admin CLI material in `pki/admin/` (root-only),
   only the shared CA **cert** at the `pki/` root. No private key readable by

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -29,8 +29,8 @@
 #                [--start]        # implies --enable, also starts them
 #
 # The signer must be reachable before control-plane/mcp-http start, and the
-# choice of CA custody (pem vs akv) is made in signer.json — see
-# deploy/README.md before starting anything.
+# choice of CA custody (akv | agent | pem) is made in signer.json — see
+# "Choosing CA custody" in deploy/README.md before starting anything.
 
 set -euo pipefail
 

--- a/deploy/systemd/infrabroker-signer.service
+++ b/deploy/systemd/infrabroker-signer.service
@@ -1,7 +1,8 @@
 # infrabroker signing service (cmd/signer).
 #
-# Holds the CA key (or the AKV client when ca_keys uses type "akv") and the
-# issuance policy. In the reference layout:
+# Holds the issuance policy and the CA custody client — the key itself only with
+# type "pem"; with "akv" and "agent" the process holds no key bytes. In the
+# reference layout:
 #
 #   binary   /usr/local/bin/signer
 #   config   /var/lib/infrabroker/signer/signer.json (infrabroker-signer:infrabroker-signer 0640)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,15 @@
   `/v1/sign`, so the previous behaviour failed closed.
 
 ### Documentation
+- **The `agent` CA custody backend now appears everywhere custody is described
+  (#325)** — the sweep #160 and #316 should have had. `docs/reference/config.md`
+  (generated from the Go doc comments on `signer.json`'s and `config.json`'s
+  `ca_key`) still described custody as `pem` or `akv`, so the anti-drift
+  reference republished the omission on every build; `docs/OPERATIONS.md` §8 said
+  the same while §4 of the same document documented ssh-agent custody, and
+  `deploy/install.sh`'s header (printed by `--help`) and `deploy/README.md`'s
+  production checklist had not been updated either. All of them now name the
+  three backends and point at the comparison table.
 - **deploy/: the `agent` CA custody backend is offered where operators choose
   (#316)** — `deploy/README.md` has documented all three backends since #122, but
   the checklist `deploy/install.sh` PRINTS after an install, and the header of

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1101,12 +1101,17 @@ The installer also seeds `/etc/infrabroker/broker-ctl.json` (client parameters,
 see §4) so `broker-ctl host list --remote` works flag-less as the post-deploy
 end-to-end check.
 
-**CA custody is the operator's choice**, made in `signer.json` → `ca_keys`:
+**CA custody is the operator's choice**, made in `signer.json` → `ca_keys`
+(three backends, compared in `deploy/README.md`; see also §4):
 `"akv"` (Azure Key Vault — the private key never leaves the vault;
-recommended for production; RSA/EC only) or `"pem"` (local file — lab/dev,
-the signer logs a warning). Credentials for AKV come from
+recommended for production; RSA/EC only), `"agent"` (ssh-agent — the key lives
+in a YubiKey PIV slot, SoftHSM or TPM and never reaches the signer process;
+the only hardware option that supports Ed25519) or `"pem"` (local file —
+lab/dev, the signer logs a warning). Credentials for AKV come from
 `DefaultAzureCredential` (managed identity, or a service principal via the
-unit's optional `EnvironmentFile=/etc/infrabroker/signer.env`).
+unit's optional `EnvironmentFile=/etc/infrabroker/signer.env`); with `"agent"`
+the agent socket **is** the signing capability, so guard its permissions and
+keep it out of `/tmp` (the unit sets `PrivateTmp=yes`).
 
 The full checklist — custody trade-offs, default-deny `callers`, rate
 limits, upgrade caveats (in-memory approvals/sessions) — lives in

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,7 +14,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `server_cert` | `string` | TLS / mTLS for the HTTP frontend (not used by the MCP, which runs over stdio). |
 | `server_key` | `string` |  |
 | `client_ca` | `string` |  |
-| `ca_key` | `string` | CAKey — LOCAL mode ONLY (in-process signing). When the Signer block is present, this field is ignored and the broker holds no CA key. ca_keys: per-group CA key overrides. "_default" overrides ca_key when present. See ca.CAKeyConfig for supported backends ("pem" for local files, "akv" for Azure Key Vault). Local mode only; ignored when Signer is set. |
+| `ca_key` | `string` | CAKey — LOCAL mode ONLY (in-process signing). When the Signer block is present, this field is ignored and the broker holds no CA key. ca_keys: per-group CA key overrides. "_default" overrides ca_key when present. See ca.CAKeyConfig for the three supported backends: "pem" (local key file), "akv" (Azure Key Vault) and "agent" (ssh-agent — YubiKey PIV / SoftHSM / TPM). Local mode only; ignored when Signer is set. |
 | `ca_keys` | `map[string]ca.CAKeyConfig` |  |
 | `signer` | `*SignerClientConfig` | Signer, when present, externalises signing to a remote service (HTTP+mTLS). The broker no longer holds the CA key or the policy. |
 | `audit_log` | `string` | Audit. |
@@ -111,7 +111,7 @@ Every configuration field, extracted from the Go structs (field · JSON key · t
 | `server_cert` | `string` | mTLS: presents server_cert and requires clients signed by client_ca. |
 | `server_key` | `string` |  |
 | `client_ca` | `string` | CA that signs authorised brokers |
-| `ca_key` | `string` | CA key custody. ca_key: legacy path to a PEM CA key (backward compatible). ca_keys: per-group CA key overrides. The reserved key "_default" overrides ca_key when present. See CAKeyConfig for supported backends ("pem" for local files, "akv" for Azure Key Vault). |
+| `ca_key` | `string` | CA key custody. ca_key: legacy path to a PEM CA key (backward compatible). ca_keys: per-group CA key overrides. The reserved key "_default" overrides ca_key when present. See CAKeyConfig for the three supported backends: "pem" (local key file — lab/dev, the signer logs a warning), "akv" (Azure Key Vault — the key never leaves the vault; RSA/EC only) and "agent" (ssh-agent — a YubiKey PIV slot / SoftHSM / TPM; the signer holds no key bytes and supports Ed25519). |
 | `ca_keys` | `map[string]ca.CAKeyConfig` |  |
 | `audit_log` | `string` | Issuance audit log (independent of the broker). |
 | `audit_key` | `string` |  |

--- a/internal/broker/engine.go
+++ b/internal/broker/engine.go
@@ -63,8 +63,9 @@ type Config struct {
 	// CAKey — LOCAL mode ONLY (in-process signing). When the Signer block is
 	// present, this field is ignored and the broker holds no CA key.
 	// ca_keys: per-group CA key overrides. "_default" overrides ca_key when
-	// present. See ca.CAKeyConfig for supported backends ("pem" for local files,
-	// "akv" for Azure Key Vault). Local mode only; ignored when Signer is set.
+	// present. See ca.CAKeyConfig for the three supported backends: "pem" (local
+	// key file), "akv" (Azure Key Vault) and "agent" (ssh-agent — YubiKey PIV /
+	// SoftHSM / TPM). Local mode only; ignored when Signer is set.
 	CAKey  string                    `json:"ca_key,omitempty"`
 	CAKeys map[string]ca.CAKeyConfig `json:"ca_keys,omitempty"`
 

--- a/internal/ca/loader.go
+++ b/internal/ca/loader.go
@@ -59,7 +59,8 @@ type CAKeyConfig struct {
 // LoadCA loads a CA ssh.Signer from the given configuration.
 //
 // For "pem": the key is read from disk and parsed in memory. A runtime warning
-// is emitted (lab/dev use only). In production use "akv" or another HSM/KMS.
+// is emitted (lab/dev use only). In production use "akv", "agent", or another
+// HSM/KMS.
 //
 // For "akv": the AKV client is initialised and the public key is fetched
 // immediately (fail-fast on misconfiguration). The private key never leaves AKV.


### PR DESCRIPTION
#160 and #316 added the `agent` backend (#122) to `deploy/README.md`, the installer's printed checklist and the signer unit header. A grep-driven sweep (`grep -rn '"akv"' … | grep -vi agent`) shows the omission was wider than either of those PRs fixed — including one instance in a file #316 itself edited.

| Where | What it said | Why it matters |
|---|---|---|
| `docs/reference/config.md` ×2 | *"supported backends (\"pem\" for local files, \"akv\" for Azure Key Vault)"* | **Generated.** The anti-drift reference republished the omission on every build, so it could not be fixed in the markdown — the source is the Go doc comments on `cmd/signer/main.go` and `internal/broker/engine.go` `ca_key` |
| `docs/OPERATIONS.md` §8 | *"`\"akv\"` … or `\"pem\"`"* | §4 of the **same document** already documents ssh-agent custody — §8 contradicted it |
| `deploy/install.sh:32` | *"the choice of CA custody (pem vs akv)"* | The header comment, which `--help` prints. #316 fixed the checklist at the bottom of this same script and missed the header |
| `deploy/README.md:141` | *"CA custody is `akv` (or another KMS)"* | The production checklist never named `agent`, though the file's own custody table does |
| `internal/ca/loader.go:62` | *"In production use \"akv\" or another HSM/KMS"* | `LoadCA`'s own doc comment, right above the `case "agent"` it dispatches |
| `deploy/systemd/…-signer.service:3` | *"Holds the CA key (or the AKV client …)"* | True only for `pem` custody; with `akv` and `agent` the process holds no key bytes |

`config.example.json`'s pointer to the full reference now names all three backends too.

Comments and documentation only — no behaviour change. `docs/reference/` is regenerated and committed with the change (the gate only *detects* drift).

## Verification

`make verify` green. `bash -n deploy/install.sh` clean. Re-running the sweep afterwards leaves only code, tests, and JSON examples that legitimately use `"akv"` as a value, plus the historical CHANGELOG.

Closes #325