### PR TITLE
docs(ha): decide and document how action budgets degrade under replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This README is a landing page. The detail lives in focused, single-source docs:
 | [THREAT_MODEL.md](docs/THREAT_MODEL.md) | Actors, trust boundaries, security controls, and explicit non-goals/gaps |
 | [OPERATIONS.md](docs/OPERATIONS.md) | Runbook: startup, adding hosts, hot-reload, `broker-ctl`, PKI rotation, configs |
 | [MESH.md](docs/MESH.md) | Running infrabroker over a NetBird / Tailscale mesh — the session layer on top of the overlay path |
+| [HA.md](docs/HA.md) | Why it is single-instance today: state inventory, the blockers, and what degrades under replication |
 | [API.md](docs/API.md) | HTTP endpoint reference for all services |
 | [USAGE.md](docs/USAGE.md) | Guide to the MCP tools (SSH + Kubernetes), dry-run, and audit review (for the model / operator) |
 | [SECURITY.md](docs/SECURITY.md) | Vulnerability disclosure policy |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -612,7 +612,7 @@ Cluster names must be **disjoint** from SSH host names (grants and the audit
 | `infrabroker serve-mcp-http` | no | sessions | network MCP frontend (OAuth2/OIDC) |
 | `infrabroker serve-http` | no | none | HTTP+mTLS one-shot frontend (no session endpoints) |
 | `cmd/control-plane` | **no** | approvals, behavior | optional PEP (approval + guardrails) |
-| `cmd/signer` | **yes** | none | sole CA custodian; policy + RBAC + signing |
+| `cmd/signer` | **yes** | grants, freezes, rate buckets | sole CA custodian; policy + RBAC + signing |
 | `cmd/broker-ctl` | no | none | operator CLI for `signer.json` + audit + approvals |
 
 See [OPERATIONS.md](OPERATIONS.md) for how to run and configure each, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+### Documentation
+- **Action budgets under replication: the degradation is now stated, and decided
+  (#295, #297)** — both budget layers (`sign_rate_limit_per_min` on the signer,
+  `rate_limit_per_min` + novelty baselines on the control plane) are per process,
+  so N replicas admit up to N× the configured cap and baselines split-brain. That
+  is now written where an operator reads it (`docs/OPERATIONS.md` § Action
+  budgets), with sizing guidance, instead of only in the HA design study — and
+  recorded as a **decision**: budgets are a detection layer, containment is the
+  signer's command policy and the approval gate, which are config-derived and
+  therefore identical on every replica. `docs/HA.md` gains the reasoning, the
+  facets that were not obvious (an approved-and-learned anomaly stays novel on the
+  other N−1 replicas; the blocked-attempt counting that makes a flood non-evasive
+  is also per process), the constraint that `agent` (ssh-agent) CA custody is
+  host-local and does not replicate the way `akv` does, and a quantified answer on
+  certificate serials (64-bit random, collision probability below 1e-6 up to ~6.1M
+  certificates; a collision would make `--serial` ambiguous rather than break
+  correlation, and replication does not change the math).
+
+  Three stale claims fixed along the way: `docs/ARCHITECTURE.md`'s component map
+  said the signer holds **no** state (it holds grants, freezes and rate buckets),
+  `docs/OPERATIONS.md` repeated "the signer stays stateless", and THREAT_MODEL
+  gap #5 enumerated only broker and control-plane replicas. `docs/HA.md` is now
+  linked from the README documentation table.
+
 ### Security
 - **broker-ctl: a relative cert/key/ca in the client config resolves against that
   file, not the CWD (#320)** — `cmd/broker-ctl/clientconfig.go` deliberately keeps

--- a/docs/HA.md
+++ b/docs/HA.md
@@ -112,14 +112,83 @@ In dependency order, each tracked as its own issue under the
 2. [**Broker session affinity**](https://github.com/luisgf/infrabroker/issues/294)
    — `session_id`-based routing, not shared state.
 3. [**Distributed behavior tracker**](https://github.com/luisgf/infrabroker/issues/295)
-   — shared counters + shared novelty sets, or an explicit degradation to
-   observe-only across replicas.
+   — **decided: explicit degradation**, documented rather than engineered. See
+   "Decided: budgets degrade, and that is the boundary" below.
 4. [**HA audit strategy**](https://github.com/luisgf/infrabroker/issues/296) —
    per-replica chains plus a central verifier, or an external sequencer.
 
 Optional and non-blocking, [tracked together](https://github.com/luisgf/infrabroker/issues/297):
 a globally shared rate limiter, and a decision on multi-signer CA custody + serial
-allocation.
+allocation — **decided** below.
+
+## Decided: budgets degrade, and that is the boundary
+
+Two of the items above are closed by a decision rather than by code
+([#295](https://github.com/luisgf/infrabroker/issues/295),
+[#297](https://github.com/luisgf/infrabroker/issues/297)). Both concern
+*budgets* — how much an agent may do — and in both cases the answer is to accept
+a looser bound under replication and say so, rather than put a shared datastore
+in the path of every signature.
+
+The reasoning is the same for both: **budgets are a detection and
+damage-limiting layer, not the containment boundary.** Containment is the
+signer's command policy and the approval gate; those are authoritative on every
+replica because they are derived from the same config, not from accumulated
+state. A rate limit that admits N× under N replicas is weaker than intended but
+still bounds a runaway agent; a behaviour baseline that split-brains produces
+*extra* escalations, not missed ones. Neither failure mode lets an agent run
+something policy forbids.
+
+**Behaviour tracker (#295).** Beyond the split-brain baselines and the N×
+sliding window already noted above, two facets worth stating because they are
+not obvious from the table:
+
+- `Learn` teaches only the replica that handled the approval, so an
+  approved-and-learned anomaly stays novel on the other N−1 replicas. The same
+  deviation can be escalated to a human once per replica before it is learned
+  everywhere — noisier, never more permissive.
+- The sliding window deliberately counts *blocked* attempts so a flood cannot
+  evade the cap by absorbing rejections. That property is per process too, so
+  under N replicas a flooder's budget is also N×.
+
+**Sign-rate limiter (#297).** `sign_rate_limit_per_min` (`signer.json`) is a
+per-CN token bucket in `internal/signer/ratelimit.go`, keyed on the
+authenticated mTLS peer CN and held in memory. N replicas therefore admit up to
+N× the configured cap. Size it as `desired_total / N`, or front the signers with
+a global limiter, and treat the config value as a per-replica cap. Backing the
+buckets with a shared counter is worth it only if a hard global cap is
+contractually required — it would put a network dependency in the path of every
+signature, which is the component that must not wobble.
+
+**Multi-signer CA custody (#297).** Every signer replica needs CA-key access, so
+custody choice constrains replication:
+
+- `akv` (Azure Key Vault) replicates cleanly — each replica authenticates
+  independently with its own managed identity, and the key never leaves the
+  vault. This is the recommended backend for a replicated signer.
+- `agent` (ssh-agent: YubiKey PIV / SoftHSM / TPM) is **host-local** — it is a
+  unix socket on one machine. It does not compose with N replicas without one
+  hardware token per replica (each a separate CA key, which multiplies the trust
+  surface) or a socket-forwarding arrangement that defeats the point. Excellent
+  for a single signer; not a replication story.
+- `pem` is lab-only regardless.
+
+**Certificate serials (#297).** `randomSerial` draws a full 64-bit value from
+`crypto/rand` per issuance (`internal/ca/sign.go`), and Kubernetes issuances mint
+audit serials from the same space. Replication does **not** change the collision
+math: the birthday bound depends on how many certificates exist, not on how many
+processes minted them, and no replica identity is mixed in. By that bound,
+collision probability stays below 1e-6 up to ~6.1 million certificates, reaches
+~0.03% at 10^8 and 50% only at ~5×10^9.
+
+A collision would not *break* audit correlation — every entry also carries time,
+caller, host, session id and outcome, so `--serial` degrades from a unique key to
+an ambiguous one. The materially affected control is the kill switch: freezing a
+`serial` matches by string, so two *simultaneously live* certificates sharing one
+would be closed together. That population is bounded by the 15-minute TTL cap,
+not by lifetime issuance — at 10,000 concurrently valid certificates the
+probability is ~3e-12. No action needed; partitioning serials per replica would
+buy nothing measurable.
 
 ## Why it stays demand-gated
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -56,9 +56,12 @@ just runs the matching `infrabroker serve-*`). `make install` injects the versio
 --tags`; a plain `go build ./cmd/...` still works but reports a `dev-<commit>`
 version. Run `make version` to see what would be embedded.
 
-**Order matters:** always start the signer before opening the MCP client. With
-multiple broker replicas, note that session/approval/behavior state is in-memory
-per process (single-instance only — see THREAT_MODEL.md).
+**Order matters:** always start the signer before opening the MCP client. All
+three services keep their state in process memory — sessions, approvals, grants,
+freezes, behaviour baselines and rate-limit buckets — so the supported deployment
+is **one instance per service**. [HA.md](HA.md) is the full inventory of what
+would break under replication and what is deliberately accepted; THREAT_MODEL.md
+gap #5 is the short version.
 
 **What survives a restart:** with `state_db` set (signer and control plane),
 runtime grants/waivers and pending or approved-but-uncollected approvals are
@@ -672,7 +675,8 @@ when that CN is a `trusted_forwarder`.
 - `observe` audits deviations (`anomaly`) but never blocks — run it first to
   learn a baseline, then switch to `enforce`.
 - `enforce` **denies** a subject over `rate_limit_per_min` with `429` (blocked
-  attempts are still counted, so a flood cannot evade the cap), and **escalates
+  attempts are still counted, so a flood cannot evade the cap **within one
+  control-plane process** — see the replication note below), and **escalates
   to human approval** on a deviation from the agent's pattern: the subject's
   first request sets the baseline, and a *subsequent* host it has not used or a
   *novel* command (first-token fingerprint) is flagged — so the human is asked on
@@ -680,6 +684,24 @@ when that CN is a `trusted_forwarder`.
   approval is granted, so a repeated unapproved anomaly stays anomalous. Novelty
   tracking is bounded: past `max_distinct_per_subject` it degrades to "seen"
   rather than emitting unbounded escalations.
+
+**Both layers are per process, and that is a deliberate decision, not an
+oversight** ([#295](https://github.com/luisgf/infrabroker/issues/295),
+[#297](https://github.com/luisgf/infrabroker/issues/297)). Behind N replicas:
+
+| | Degradation with N replicas |
+|---|---|
+| `sign_rate_limit_per_min` (signer) | Buckets are in-memory per signer process, so the fleet admits up to **N×** the configured cap. Size it as `desired_total / N`, or put a global limiter in front. |
+| `rate_limit_per_min` (control plane) | Same **N×** multiplication — including the blocked attempts that make a flood non-evasive within one process. |
+| Novelty baselines | Each replica sees only its slice of traffic, so a host that is "known" on A is "new-host" on B: **spurious escalations**, and a value learned on the replica that handled the approval stays novel on the other N−1 — the same anomaly can be re-escalated once per replica. |
+
+The decision is to accept this and state it, rather than take a shared datastore
+into the approval path: **behaviour guardrails are a detection layer, not the
+containment boundary.** Containment is the signer's command policy and the
+approval gate, both of which are authoritative regardless of replica count. If
+you need a hard global cap or a single baseline, that is the shared-backend work
+in [docs/HA.md](HA.md) — and today the supported deployment is one instance per
+service anyway.
 
 The contrast with network-layer tools is the point: a mesh/VPN budgets what an
 agent can *reach*, and an LLM gateway (e.g. NetBird's Agent Network) budgets what
@@ -691,8 +713,9 @@ possible at the layer that sees each action.
 > **Future — per-operation-class caps (build with demand).** A natural extension
 > is budgeting per *class* of operation (sudo executions, mutating Kubernetes
 > verbs, file transfers) rather than uniformly. Design, if it is built: it lives
-> in the control plane's `BehaviorConfig` (the signer stays stateless per the
-> threat model), in-memory like the current tracker (restart resets the
+> in the control plane's `BehaviorConfig` (keeping budget state off the signer,
+> which holds only grants, freezes and rate buckets), in-memory like the current
+> tracker (restart resets the
 > baseline), exhaustion **denies with `429`** and never auto-escalates (an
 > exhausted budget is not an anomaly, and flooding the approval queue would be an
 > amplification vector), and is audited edge-triggered. File-transfer

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -346,9 +346,20 @@ production. The control plane additionally applies its own per-subject
 behavioral rate limit on the forwarded path.
 
 ### 5. In-memory state → single instance
-Sessions, approvals, grants, and behavior baselines live in process memory.
-Running multiple broker or control-plane replicas would split this state.
+Sessions, approvals, grants, freezes, behavior baselines and rate-limit buckets
+live in process memory — in all three processes, the signer included. Running
+multiple broker, control-plane **or signer** replicas would split this state.
 Horizontal scaling requires externalizing it (e.g. Redis with TTL).
+- **Decided degradation for the budget layers (#295, #297):** the per-CN
+  `sign_rate_limit_per_min` and the control plane's per-subject
+  `rate_limit_per_min` are per process, so N replicas admit up to N× the
+  configured cap, and behaviour baselines split-brain (producing extra
+  escalations, never missed ones). This is accepted and documented rather than
+  engineered away: budgets are a **detection** layer, and containment remains the
+  signer's command policy and the approval gate, which are config-derived and so
+  identical on every replica. See [HA.md](HA.md) for the full reasoning, the
+  sizing guidance, and the custody constraint that `agent` (ssh-agent) custody is
+  host-local and does not replicate the way `akv` does.
 - **Mitigation (restart survival, not multi-instance):** the opt-in `state_db`
   (SQLite, write-through) persists the signer's runtime grants/waivers, the
   kill-switch freeze set, and the control plane's approval registry across
@@ -396,6 +407,11 @@ key in a running ssh-agent backed by a YubiKey PIV slot / SoftHSM / TPM
 (`ssh-add -s`), with no cgo in the signer and support for **Ed25519** CA keys
 (which AKV lacks). The private key never leaves the backend. Using PEM in
 production is an operator error the code warns about but cannot prevent.
+Note the two are not interchangeable if you ever replicate the signer: `akv` is a
+network service each replica authenticates to independently, while `agent` is a
+**host-local unix socket** — it does not compose with N replicas without one
+token per replica (separate CA keys, a wider trust surface) or socket forwarding
+that would defeat the custody boundary. See [HA.md](HA.md) (#297).
 
 ### 8. Secrets in commands: redaction is opt-in and best-effort
 A command is written to the broker and signer audit logs and, for `shell`/`pty`


### PR DESCRIPTION
Closes #295 and #297 **by decision rather than by code**, and writes the decision where an operator will actually read it.

Both issues asked for a choice, not an implementation — #295: *"shared counters + shared novelty sets, or an explicit degradation"*; #297: *"accept the looser bound and document it, or back the buckets with a shared counter"*. This takes the cheap option in both cases and records why.

## What was wrong

Both budget layers are per process — `sign_rate_limit_per_min` holds per-CN token buckets in signer memory, and the control plane's `rate_limit_per_min` plus its novelty baselines live in `BehaviorTracker`'s map. `docs/HA.md` already said so three times. `docs/OPERATIONS.md` — the page an operator *configures from* — did not, and actively claimed:

> `enforce` **denies** a subject over `rate_limit_per_min` with `429` (blocked attempts are still counted, so **a flood cannot evade the cap**)

True per process only. Under N control-plane replicas a flooder gets N× the budget.

## The decision

Accept the looser bound and state it, rather than put a shared datastore in the path of every signature. **Budgets are a detection layer.** Containment is the signer's command policy and the approval gate — both derived from config, therefore identical on every replica. A split baseline yields *extra* escalations, never missed ones; an N× cap still bounds a runaway agent. Neither failure mode lets an agent run something policy forbids.

`docs/OPERATIONS.md` § Action budgets now carries a per-layer degradation table with sizing guidance (`desired_total / N`), and `docs/HA.md` gains a "Decided" section with the reasoning.

## Facets that were not already documented

- **`Learn` teaches only the replica that handled the approval**, so an approved-and-learned anomaly stays novel on the other N−1 — the same deviation can be escalated once per replica before it is learned everywhere.
- The blocked-attempt counting that makes a flood non-evasive is itself per process.
- **`agent` (ssh-agent) CA custody is host-local** — a unix socket on one machine. It does not compose with N signer replicas the way `akv` does, without one token per replica (separate CA keys, wider trust surface) or socket forwarding that defeats the custody boundary. THREAT_MODEL §7 recommended it for production without that caveat.
- **Certificate serials are fine.** 64-bit from `crypto/rand` per issuance; collision probability below 1e-6 up to ~6.1M certificates, 50% only at ~5×10⁹. Replication does **not** change the math — the birthday bound depends on the certificate count, not the replica count, and no replica identity is mixed in. A collision would make `--serial` *ambiguous*, not break correlation (every entry also carries time, caller, host, session id). The materially affected control is `freeze --serial`, over the *concurrently live* population, bounded by the 15-minute TTL cap — ~3e-12 at 10,000 live certs. No action needed.

## Stale claims corrected

- `docs/ARCHITECTURE.md`'s component map said `cmd/signer` holds state "none" — it holds grants, freezes and rate buckets, exactly as `HA.md` already said.
- `docs/OPERATIONS.md` repeated "the signer stays stateless per the threat model".
- THREAT_MODEL gap #5 enumerated only "broker or control-plane replicas", omitting the signer.
- `docs/HA.md` was reachable only from the mkdocs nav; it is now in the README documentation table.

## Verification

`make verify` green, including the strict mkdocs build (so every new cross-link resolves).

Closes #295
Closes #297