### PR TITLE
chore: v3.1.0 release (changelog + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [v3.1.0] - 2026-08-03
+
+Sealed-exec ops: host installer, no-downtime envelope-key rotation, and sudoers-
+friendly elevation — plus security fixes for approve-and-learn/freeze, audit
+token forgery on file transfer, command-policy backslash escapes, and
+broker-ctl path resolution.
 
 ### Added
 - **Sealed-exec host deployment: `deploy/install-shim.sh` (#291)** — sealing a
@@ -248,6 +253,12 @@
   `command_policy`), the glob/brace/tilde bypass class was closed in v3.0.1
   (GHSA-937v-rmqp-j3hx), and that cross-package mitigation is invisible to the
   dataflow query. No behaviour change.
+- **Dependency bumps** — `actions/setup-go` and `actions/setup-python` to v7;
+  `modernc.org/sqlite` patch; `github.com/modelcontextprotocol/go-sdk` (the latter
+  required the SEP-2322 in-conversation approval fix above).
+- **Docs hygiene** — USAGE documents thirteen MCP tools (not seven); ARCHITECTURE
+  documents the unresolvable-expansion rejection class in `shell_parse`;
+  `release.yml` no longer hard-codes the installer tarball's binary count.
 
 ## [v3.0.1] - 2026-07-16
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,9 +1,21 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-07-16 (v3.0.1, patch de seguridad: cierra el bypass de command-policy por expansión glob/brace/tilde, GHSA-937v-rmqp-j3hx).
+> actualización: 2026-08-03 (v3.1.0: sealed-exec host installer + rotación sin
+> downtime, sudo argv directo, fixes freeze/learn y audit path forgery).
 >
 > Estado reciente:
+> - **v3.1.0** (minor): **ops de sealed-exec** — `deploy/install-shim.sh` (#291)
+>   instala el shim, pinnea `envelope.pub` (multi-key para rotación sin outage) y
+>   el nonce store; `broker-ctl envelope pubkey` imprime la clave entrante offline.
+>   **Elevación**: comandos simples salen como `sudo -n -- argv…` (#306) en lugar
+>   de `sh -c`, para que sudoers por binario coincida con `command_policies`.
+>   Security: learn no emite waiver tras freeze (#330); paths de file-transfer sin
+>   espacios en el stream de audit (#331); backslash unquoted en policy (#308);
+>   broker-ctl rebasa cert/key/ca relativos al dir del config (#320); ForceCommand
+>   de sshd_config no debe pisar el del cert sellado. MCP: approvals in-chat de
+>   nuevo con SEP-2322 (`inputRequests`, #318). Control-plane reenvía
+>   `allow_file_transfer` (#315). Docs: agent CA, budgets HA, SECURITY 3.x.
 > - **v3.0.1** (patch de seguridad): CodeQL marcó `go/command-injection` crítico en
 >   `internal/ssh/run.go:315`; la revisión adversarial (workflow) demostró que NO era
 >   falso positivo — el firewall de comandos evaluaba la policy sobre la forma

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "3.0.1",
+  "version": "3.1.0",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:3.0.1",
+      "identifier": "ghcr.io/luisgf/infrabroker:3.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Prepare **v3.1.0** (minor) for publish.

**Why minor:** user-facing features since `v3.0.1`:
- Sealed-exec host deployment (`deploy/install-shim.sh`, multi-key rotation, `broker-ctl envelope pubkey`) — #291 / #328
- Direct sudo argv for simple elevated commands — #306 / #307

Also folds the security and docs fixes from the recent audit pass (#330–#339) and intervening fixes (#308, #315, #318, #320, etc.).

### Files
- `docs/CHANGELOG.md` — fold `[Unreleased]` → `[v3.1.0] - 2026-08-03`
- `server.json` — `version` + OCI identifier `3.1.0`
- `docs/HANDOFF.md` — estado reciente

### Verify
- [x] `make verify` (incl. govulncheck, docs-check)
- [x] `mcp-publisher validate server.json` ✅

## After merge (human gates)

1. Review + merge this PR (no auto-merge for releases).
2. Authorize the annotated tag: `v3.1.0` on the merge commit → `git push origin v3.1.0`.
3. CI `release.yml` publishes GitHub release, multi-arch ghcr image, MCP Registry.