### PR TITLE
fix(signer): refuse approve-and-learn waiver for frozen subjects

### DIFF
--- a/cmd/signer/grants.go
+++ b/cmd/signer/grants.go
@@ -181,6 +181,11 @@ func (s *server) handleGrantRevoke(w http.ResponseWriter, r *http.Request) {
 // issued, so a too-long TTL is clamped to max_grant_ttl_seconds and any Add error
 // is audited but never fails the sign. The waiver is scoped to the effective
 // broker caller and end-user that were approved, and matches the exact command.
+//
+// Serialised under writeMu with freeze mutations (sibling of #224 for the admin
+// grant path): without that, a concurrent freeze can RevokeForSubject and still
+// leave a learn-minted waiver that reactivates require_approval suppression the
+// moment the subject is unfrozen (#330).
 func (s *server) maybeLearnWaiver(caller string, req signer.WireRequest, issued *signer.Issued) {
 	// A credential was issued when either an SSH certificate or a k8s bound
 	// token came back; approve-and-learn applies to both targets.
@@ -197,6 +202,22 @@ func (s *server) maybeLearnWaiver(caller string, req signer.WireRequest, issued 
 		})
 		return
 	}
+
+	// Serialise with freeze (handleFreeze holds writeMu across freezes.Add +
+	// grants.RevokeForSubject) and refuse a learn-mint for a subject that is
+	// currently frozen. Same invariant as handleGrantCreate (#224/#330).
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if subj, frozen := s.freezes.Frozen(caller, req.EndUser); frozen {
+		_ = s.appendAudit(audit.Entry{
+			Caller: caller, Host: req.Host, Command: "approval-waiver",
+			Outcome: "approval-waiver-skipped", ApprovalID: req.LearnApprovalID,
+			ApprovedBy: req.LearnApprover,
+			Err:        fmt.Sprintf("subject is frozen: %s=%s; not learning a waiver that would re-widen on unfreeze", subj.Kind, subj.Value),
+		})
+		return
+	}
+
 	ttl := time.Duration(req.LearnTTLSeconds) * time.Second
 	if s.maxGrantTTL > 0 && ttl > s.maxGrantTTL {
 		ttl = s.maxGrantTTL // clamp, never reject: the cert is already issued

--- a/cmd/signer/learn_test.go
+++ b/cmd/signer/learn_test.go
@@ -83,3 +83,51 @@ func TestMaybeLearnWaiver(t *testing.T) {
 		t.Errorf("TTL should be clamped to ~1h, got %s", d)
 	}
 }
+
+// TestMaybeLearnWaiverRefusesFrozenSubject pins #330: a learn-mint scoped to a
+// frozen caller/end_user must not store a durable waiver that would survive the
+// freeze's RevokeForSubject and re-suppress require_approval the moment the
+// subject is unfrozen (sibling of #224 for the admin grant path).
+func TestMaybeLearnWaiverRefusesFrozenSubject(t *testing.T) {
+	t.Parallel()
+	issuedOK := &signer.Issued{Certificate: &ssh.Certificate{}, Decision: &signer.DecisionInfo{RequireApproval: true}}
+	req := signer.WireRequest{
+		Host: "web01", EndUser: "alice", Command: "systemctl restart nginx",
+		LearnTTLSeconds: 600, LearnApprover: "approver", LearnApprovalID: "ap1",
+	}
+
+	// Frozen caller: no waiver stored.
+	srv := grantTestServer(t, time.Hour)
+	srv.freezes = signer.NewFreezeStore()
+	if _, err := srv.freezes.Add(signer.FreezeSubject{Kind: signer.FreezeCaller, Value: "broker-1"}, "", "admin", time.Now()); err != nil {
+		t.Fatalf("freeze caller: %v", err)
+	}
+	srv.maybeLearnWaiver("broker-1", req, issuedOK)
+	if n := len(srv.grants.List(time.Now())); n != 0 {
+		t.Fatalf("learn for a frozen caller must store no waiver, found %d", n)
+	}
+	if srv.grants.WaiverMatches("web01", signer.Intent{
+		Host: "web01", Caller: "broker-1", EndUser: "alice", Command: "systemctl restart nginx",
+	}, time.Now()) {
+		t.Error("frozen-caller learn must not match a later WaiverMatches")
+	}
+
+	// Frozen end_user: same refuse.
+	srv2 := grantTestServer(t, time.Hour)
+	srv2.freezes = signer.NewFreezeStore()
+	if _, err := srv2.freezes.Add(signer.FreezeSubject{Kind: signer.FreezeEndUser, Value: "alice"}, "", "admin", time.Now()); err != nil {
+		t.Fatalf("freeze end_user: %v", err)
+	}
+	srv2.maybeLearnWaiver("broker-1", req, issuedOK)
+	if n := len(srv2.grants.List(time.Now())); n != 0 {
+		t.Fatalf("learn for a frozen end_user must store no waiver, found %d", n)
+	}
+
+	// Non-frozen subject still mints (control).
+	srv3 := grantTestServer(t, time.Hour)
+	srv3.freezes = signer.NewFreezeStore()
+	srv3.maybeLearnWaiver("broker-1", req, issuedOK)
+	if n := len(srv3.grants.List(time.Now())); n != 1 {
+		t.Fatalf("learn for a non-frozen subject: expected 1 waiver, got %d", n)
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,15 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **Approve-and-learn no longer mints a durable waiver after freeze (#330)** —
+  `#224` serialised admin grant create with freeze under `writeMu` and refused
+  grants for frozen subjects; the learn path (`maybeLearnWaiver`) did not, so a
+  concurrent freeze could revoke grants and still leave a learn-minted
+  `waive_approval` that re-suppressed `require_approval` the moment the subject
+  was unfrozen. Learn now takes the same lock, skips (and audits) when the
+  caller or end-user is frozen, and covers both the SSH and k8s issuance
+  branches.
+
 - **In-conversation approvals work again on the current MCP protocol (#318)** —
   the `github.com/modelcontextprotocol/go-sdk` v1.7.0 bump brought protocol
   version 2026-07-28, where SEP-2322 forbids a server from sending


### PR DESCRIPTION
## Summary

Closes #330.

Approve-and-learn (`maybeLearnWaiver`) could mint a durable `waive_approval` grant after a concurrent freeze had already run `RevokeForSubject`, so the waiver re-suppressed `require_approval` on unfreeze — the same class as #224 for the admin grant path.

- Hold `writeMu` for the freeze check + mint (same lock as `handleFreeze` / `handleGrantCreate`).
- Skip and audit when the caller or end-user is frozen.
- Regression test: `TestMaybeLearnWaiverRefusesFrozenSubject`.

## Test plan

- [x] `go test -race ./cmd/signer/ -run 'TestMaybeLearnWaiver|TestGrantCreateRefusesFrozen'`
- [x] `make verify` (gofmt/vet/build/race tests + docs gate)