### PR TITLE
docs(security): support latest release on main, not 1.x

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,11 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **SECURITY.md supported-versions table tracks the current major (#332)** —
+  the policy still said only the latest `1.x` on `main` received security fixes
+  after the project had already shipped `3.x`. It now states that only the latest
+  release on `main` (current major) is supported.
+
 - **Approve-and-learn no longer mints a durable waiver after freeze (#330)** —
   `#224` serialised admin grant create with freeze under `writeMu` and refused
   grants for frozen subjects; the learn path (`maybeLearnWaiver`) did not, so a

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -3,12 +3,13 @@
 ## Supported versions
 
 infrabroker follows `X.Y.Z` versioning (see [CONTRIBUTING.md](CONTRIBUTING.md)).
-Only the latest `1.x` release on `main` receives security fixes.
+Only the latest release on `main` (currently the `3.x` line) receives security
+fixes. Older major lines and older tags are unsupported — upgrade to latest.
 
 | Version | Supported |
 |---|---|
-| latest `1.x` (`main`) | ✅ |
-| older `1.x` tags | ❌ (upgrade to latest) |
+| latest on `main` (current major, `3.x`) | ✅ |
+| older majors / older tags | ❌ (upgrade to latest) |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Summary

Closes #332.

`docs/SECURITY.md` still claimed only the latest `1.x` on `main` received security fixes after the project had already shipped `3.x`. The supported-versions table now tracks the latest release on `main` (current major).

## Test plan

- [x] `make verify` (docs-check / strict mkdocs build)