### PR TITLE
docs(ops): state real blast radius of envelope-key compromise

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,13 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **OPERATIONS emergency envelope-key runbook states the real blast radius (#334)** —
+  the text claimed a leaked envelope private key could only mint envelopes for
+  commands the signer's policy would already have allowed. The shim does not
+  re-check policy; a leaked seed authorises any command on hosts that still pin
+  the compromised public key. The runbook now treats the seed as CA-adjacent:
+  no dual-key overlap, rotate immediately, kill open sealed sessions.
+
 - **SECURITY.md supported-versions table tracks the current major (#332)** —
   the policy still said only the latest `1.x` on `main` received security fixes
   after the project had already shipped `3.x`. It now states that only the latest

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -366,12 +366,19 @@ Sealed exec therefore fails closed against an old broker rather than silently
 downgrading; upgrade the broker before sealing hosts its users depend on.
 
 **Emergency rotation** (the envelope private key is believed leaked) is a
-different procedure: there is no overlap to preserve. Push a file containing
-**only** the new key to every sealed host and switch the signer; commands in
-flight under the old key are refused, which is the point. Until the new file
-lands, a holder of the leaked key can mint envelopes — but only for commands the
-signer's policy would already have allowed, on hosts whose certificates they can
-also obtain.
+different procedure: there is no overlap to preserve. Treat the envelope seed as
+**CA-adjacent** — the shim only checks signature, host binding, expiry, and
+nonce; it does **not** re-check `command_policy`. A holder of the leaked seed can
+therefore mint envelopes for **any** command on any sealed host that still pins
+the compromised public key. The residual gate is only possession of a live
+shim-pinned session (or the ability to obtain one via the CA / RBAC path).
+
+There is no dual-key overlap to preserve: push a file containing **only** the
+new key to every sealed host, switch the signer to the new seed, and **kill open
+sealed sessions** (freeze the affected callers/end-users, or close them
+operator-side). Commands still in flight under the old key are refused once the
+host collapses to the new pin, which is the point. Do not use `--add-pubkey`
+during an emergency — that would leave the compromised key trusted.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #334.

The OPERATIONS emergency envelope-key runbook claimed a leaked seed could only mint envelopes for commands the signer's policy would already have allowed. That is false: the shim verifies signature/host/expiry/nonce only. The runbook now treats the seed as CA-adjacent (no dual-key overlap, rotate immediately, kill open sealed sessions).

## Test plan

- [x] `make docs-check`