### PR TITLE
fix(broker): refuse file-transfer paths that forge audit tokens

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,12 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **File-transfer paths with whitespace/controls are refused before audit (#331)** —
+  `ssh_put_file` / `ssh_get_file` encoded `path=<path> bytes=… sha256=…` into the
+  space-separated audit `Command` stream while only rejecting NULs and newlines.
+  A path containing spaces could splice forged tokens. Paths now pass the same
+  `HasUnsafeTokenChar` gate used on identity fields.
+
 - **ARCHITECTURE Multi-CA section documents the `agent` CA backend (#333)** —
   the section still framed custody as PEM or AKV only and claimed Ed25519
   worked only in local PEM mode. It now lists `pem` / `akv` / `agent` and notes

--- a/internal/broker/filetransfer.go
+++ b/internal/broker/filetransfer.go
@@ -47,7 +47,10 @@ type FileTransferResult struct {
 var modeRe = regexp.MustCompile(`^[0-7]{3,4}$`)
 
 // validateTransferPath rejects paths the transfer commands cannot quote into a
-// single-line force-command safely.
+// single-line force-command safely, and paths that would splice forged tokens
+// into the put/get audit Command stream (path=<path> bytes=… sha256=…).
+// Spaces/tabs/controls match HasUnsafeTokenChar — the same gate used on
+// KeyID/audit identity fields (#331).
 func validateTransferPath(path string) error {
 	switch {
 	case path == "":
@@ -56,6 +59,10 @@ func validateTransferPath(path string) error {
 		return fmt.Errorf("%w: path contains null bytes", ErrBadRequest)
 	case strings.ContainsAny(path, "\n\r"):
 		return fmt.Errorf("%w: path contains newline characters", ErrBadRequest)
+	case signer.HasUnsafeTokenChar(path):
+		// Covers space/tab and other ASCII controls (NUL already rejected above).
+		// Without this, path="/tmp/x bytes=0 sha256=00" forges audit tokens.
+		return fmt.Errorf("%w: path contains whitespace or control characters", ErrBadRequest)
 	}
 	return nil
 }

--- a/internal/broker/filetransfer_test.go
+++ b/internal/broker/filetransfer_test.go
@@ -34,9 +34,12 @@ func TestPutFileValidation(t *testing.T) {
 		content    []byte
 		wantSubstr string
 	}{
-		"empty path":       {path: "", content: []byte("x"), wantSubstr: "path is required"},
-		"null byte":        {path: "/tmp/\x00f", content: []byte("x"), wantSubstr: "null bytes"},
-		"newline in path":  {path: "/tmp/a\nb", content: []byte("x"), wantSubstr: "newline"},
+		"empty path":      {path: "", content: []byte("x"), wantSubstr: "path is required"},
+		"null byte":       {path: "/tmp/\x00f", content: []byte("x"), wantSubstr: "null bytes"},
+		"newline in path": {path: "/tmp/a\nb", content: []byte("x"), wantSubstr: "newline"},
+		// #331: spaces would splice forged key=value tokens into the audit Command.
+		"space in path":    {path: "/tmp/x bytes=0 sha256=00", content: []byte("x"), wantSubstr: "whitespace or control"},
+		"tab in path":      {path: "/tmp/a\tb", content: []byte("x"), wantSubstr: "whitespace or control"},
 		"oversized":        {path: "/tmp/f", content: bytes.Repeat([]byte("a"), 9), wantSubstr: "transfer limit is 8"},
 		"bad mode":         {path: "/tmp/f", mode: "rwx", content: []byte("x"), wantSubstr: "invalid mode"},
 		"mode with prefix": {path: "/tmp/f", mode: "u+x", content: []byte("x"), wantSubstr: "invalid mode"},


### PR DESCRIPTION
## Summary

Closes #331.

`validateTransferPath` only rejected empty/NUL/newline paths while put/get audit entries encode `path=<path> bytes=… sha256=…` into the space-separated `Command` stream. A path containing spaces could splice forged tokens. Paths now pass `HasUnsafeTokenChar` (same gate as identity fields).

## Test plan

- [x] `go test -race ./internal/broker/ -run TestPutFileValidation`
- [x] `make verify`