### PR TITLE
docs(security): name sealed exec as gap #1 opt-in mitigation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,11 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **SECURITY.md gap #1 scope names sealed exec as the opt-in mitigation (#336)** —
+  the by-design list still claimed host-enforced session force-command was
+  absent entirely. It now notes default broker-preflighted sessions and that
+  `sealed_exec` closes the gap for opted-in hosts.
+
 - **File-transfer paths with whitespace/controls are refused before audit (#331)** —
   `ssh_put_file` / `ssh_get_file` encoded `path=<path> bytes=… sha256=…` into the
   space-separated audit `Command` stream while only rejecting NULs and newlines.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -39,13 +39,15 @@ infrabroker's security goals and **explicit non-goals** are documented in
 [THREAT_MODEL.md](THREAT_MODEL.md). Reports about the following are known/by
 design rather than vulnerabilities (but context is still welcome):
 
-- absence of host-enforced `force-command` containment for **sessions**; `mode=exec`
-  is broker-preflighted, but one-shot remains the strongest guarantee — gap #1;
+- **default** absence of host-enforced `force-command` for **sessions** (broker-
+  preflighted `mode=exec` only) — gap #1. Opt-in sealed exec (`sealed_exec` +
+  `infrabroker-shim`) closes that gap for hosts that enable it; one-shot remains
+  the strongest default without that opt-in;
 - behavior guardrails being detection rather than containment — gap #2;
 - absence of certificate revocation (KRL) — gap #3;
 - leaving `callers` unset (unrestricted) rather than a non-empty default-deny
   table — gap #6;
-- use of a PEM CA key in production (use AKV/HSM/KMS instead) — gap #7.
+- use of a PEM CA key in production (use AKV, ssh-agent/HSM, or KMS instead) — gap #7.
 
 In-scope and high-value: anything that lets a **compromised broker** or
 **compromised agent** exceed the operator's policy, mint or widen a certificate,


### PR DESCRIPTION
## Summary

Closes #336.

`docs/SECURITY.md` scope still listed absence of host-enforced session force-command as by-design without mentioning sealed exec. It now states the default and that `sealed_exec` closes gap #1 for opted-in hosts.

## Test plan

- [x] `make docs-check`