### PR TITLE
docs(threat): stop calling the signer stateless

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,10 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **THREAT_MODEL actors table no longer calls the signer "stateless" (#337)** —
+  grants, freezes, rate buckets, and optional `state_db` contradict that claim.
+  The row now describes minimal in-process state and points at gap #5 / HA.md.
+
 - **SECURITY.md gap #1 scope names sealed exec as the opt-in mitigation (#336)** —
   the by-design list still claimed host-enforced session force-command was
   absent entirely. It now notes default broker-preflighted sessions and that

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -46,7 +46,7 @@ partially for sessions — see the gaps below.
 | **AI model** | Untrusted | Assumed subject to prompt injection. Sees only output; never holds credentials. |
 | **Broker** (`infrabroker serve-mcp` / `serve-mcp-http` / `serve-http`) | Semi-trusted — *may be compromised* | Holds ephemeral private keys transiently. Never holds the CA key. Authenticates to the signer with its own mTLS CN. |
 | **Control plane** (`control-plane`) | Semi-trusted (PEP) | Orchestrates approval and behavior guardrails. **No CA key.** Trusted by the signer only for `on_behalf_of`/`approved` if its CN is in `trusted_forwarders`. |
-| **Signer** (`signer`) | Trusted | **Sole custodian of the CA key.** Authoritative for policy, RBAC, and the approval gate. Kept deliberately minimal and stateless. |
+| **Signer** (`signer`) | Trusted | **Sole custodian of the CA key.** Authoritative for policy, RBAC, and the approval gate. Kept deliberately minimal; holds in-process policy plus grants/freezes/rate-limit state (optional `state_db` for durability) — **not multi-replica-safe** (see gap #5 / [HA.md](HA.md)). |
 | **Operator** | Trusted | Edits `signer.json`, approves out-of-band, holds approver/reload certs. |
 | **Remote host `sshd`** | Trusted endpoint | Enforces `force-command`, `source-address`, principals, and sudoers — the last line of defense. |
 


### PR DESCRIPTION
## Summary

Closes #337.

THREAT_MODEL actors table still called the signer "stateless" while it holds grants/freezes/rate state and optional `state_db`. Updated to match gap #5 / HA.md.

## Test plan

- [x] `make docs-check`