### PR TITLE
docs: list infrabroker-shim in release binary inventory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,11 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **OPERATIONS/CONTAINERS list `infrabroker-shim` in the release inventory (#335)** —
+  `make dist` and the goreleaser archive already ship the sealed-exec host
+  verifier; the install list and image/archive note omitted it (approval-bridge
+  was the only archive-only extra named).
+
 - **THREAT_MODEL actors table no longer calls the signer "stateless" (#337)** —
   grants, freezes, rate buckets, and optional `state_db` contradict that claim.
   The row now describes minimal in-process state and points at gap #5 / HA.md.

--- a/docs/CONTAINERS.md
+++ b/docs/CONTAINERS.md
@@ -17,8 +17,10 @@ ghcr.io/luisgf/infrabroker:latest
   `mcp-broker-http` (each runs the matching `infrabroker serve-*`) under
   `/usr/local/bin/`, byte-for-byte identical to the ones in the release archives
   (the image copies the prebuilt binaries; nothing is compiled in the Dockerfile).
-  The release archive additionally ships `approval-bridge`, which the image
-  deliberately omits — it is a standalone daemon, not part of the broker runtime.
+  The release archive additionally ships `approval-bridge` and
+  `infrabroker-shim`, which the image deliberately omits — the bridge is a
+  standalone daemon and the shim runs on managed target hosts, not in the
+  broker/signer runtime image.
 - **Base:** `distroless/static` — CA roots for outbound TLS (signer, OIDC,
   Azure Key Vault), a `nonroot` user (uid 65532), and **no shell or package
   manager**. The SSH client is pure Go; no `openssh` inside.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -50,7 +50,9 @@ make signer                  # or just one
 ```
 
 Compiled binaries: `~/bin/infrabroker` (the unified broker frontend) · `~/bin/signer`
-· `~/bin/broker-ctl` · `~/bin/control-plane` · `~/bin/approval-bridge`, plus the
+· `~/bin/broker-ctl` · `~/bin/control-plane` · `~/bin/approval-bridge` ·
+`~/bin/infrabroker-shim` (host-side sealed-exec verifier — deploy with
+`deploy/install-shim.sh` on managed targets, not on the service hosts), plus the
 **deprecated** compat wrappers `~/bin/{broker, mcp-broker, mcp-broker-http}` (each
 just runs the matching `infrabroker serve-*`). `make install` injects the version from `git describe
 --tags`; a plain `go build ./cmd/...` still works but reports a `dev-<commit>`


### PR DESCRIPTION
## Summary

Closes #335.

OPERATIONS §1 and CONTAINERS.md archive note omitted `infrabroker-shim` while `Makefile` CMDS / goreleaser archives already ship it. Documented; image still intentionally excludes shim and approval-bridge.

## Test plan

- [x] `make docs-check`