### PR TITLE
docs(deploy): fix install.sh callers default-deny checklist

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -254,7 +254,9 @@ Done. Before starting (see deploy/README.md for the full checklist):
       per-service keys   ${ETCDIR}/pki/<svc>/             (0640 root:infrabroker-<svc>)
       admin CLI material ${ETCDIR}/pki/admin/             (root-only)
     Each service can read ONLY its own subdirectory (privilege separation).
- 4. Production hardening: callers should contain "_default": {"allowed_groups": []}
-    (default-deny) and sign_rate_limit_per_min should be set.
+ 4. Production hardening: set a non-empty "callers" table that scopes real broker
+    CNs (a non-empty table is already default-deny for unlisted CNs — empty
+    "_default" is not required). Leaving "callers" unset is the fail-open.
+    Also set sign_rate_limit_per_min.
  5. systemctl enable --now infrabroker-signer   # signer first, then the rest
 EOF

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,10 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **install.sh post-install no longer teaches obsolete empty `_default` callers (#338)** —
+  since v2.0.0 a non-empty `callers` table is already default-deny without
+  `"_default": {"allowed_groups": []}`; the checklist now says so.
+
 - **OPERATIONS/CONTAINERS list `infrabroker-shim` in the release inventory (#335)** —
   `make dist` and the goreleaser archive already ship the sealed-exec host
   verifier; the install list and image/archive note omitted it (approval-bridge


### PR DESCRIPTION
## Summary

Closes #338.

`deploy/install.sh` post-install still recommended `"_default": {"allowed_groups": []}`. A non-empty `callers` table is already default-deny without that; the real fail-open is leaving `callers` unset.

## Test plan

- [x] `make docs-check`