### PR TITLE
docs(ops): sealed sessions never unlock require_approval via approve

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,11 @@
   invalidates the file, and an unescaped `#` truncates a rule silently.
 
 ### Fixed
+- **OPERATIONS sealed-session docs: require_approval never unlocks session exec (#339)** —
+  the constraints list implied approval would eventually yield an envelope on a
+  sealed session. Sealed sessions permanently refuse `require_approval`; use
+  oneshot `ssh_execute` (waivers still work by clearing the gate first).
+
 - **install.sh post-install no longer teaches obsolete empty `_default` callers (#338)** —
   since v2.0.0 a non-empty `callers` table is already default-deny without
   `"_default": {"allowed_groups": []}`; the checklist now says so.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -314,8 +314,12 @@ probe for you.
   OpenSSH validates a certificate only at authentication. Close them.
 - Commands run via `/bin/sh -c`, not the account's login shell — a command
   relying on a login-shell dialect may need an explicit interpreter.
-- An approval-gated command gets **no envelope** until it is approved, so it
-  fails closed on a sealed host exactly as it does elsewhere.
+- **`require_approval` commands never get a session envelope.** The signer does
+  not mint an envelope while `RequireApproval` is set (session preflight never
+  carries `Approved`), and the broker refuses with "use `ssh_execute` for
+  approval-gated commands". Approving out-of-band does **not** unlock
+  `ssh_session_exec` for that command — use one-shot `ssh_execute` (or an
+  approve-and-learn waiver that clears `RequireApproval` before mint).
 - The shim refuses with exit **126** (the shell's "found but not executable"),
   which is how you tell a shim refusal from the inner command's own failure.
 - The nonce store is **shared by every account you name**. The sticky bit stops


### PR DESCRIPTION
## Summary

Closes #339.

OPERATIONS sealed-host constraints implied an approval-gated command would get an envelope after approval. Code never mints a session envelope while `RequireApproval` is set; broker permanently directs those commands to `ssh_execute`.

## Test plan

- [x] `make docs-check`