### PR TITLE
fix(signer): reject command-hiding wrappers in shell_parse

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **Command-policy shell_parse rejects command-hiding wrappers (#352)** — with
+  `shell_parse` on (the default), denylist and `require_approval` rules that
+  anchor on the real binary (e.g. `^rm `) could be dodged by wrapping it:
+  `bash -c 'rm …'`, `env rm …`, `timeout 1 rm …`, `python3 -c '…'`, and the
+  same class of pure wrappers/interpreters. `extractCommands` only saw the outer
+  CallExpr, so the policy under-matched the same way inline env assignments and
+  quoting once did (#175, #277, #308). Those wrappers are now rejected at parse
+  time (fail-closed). Prefer allowlist for production; denylist remains
+  best-effort against unknown path/alias tricks.
+
 ## [v3.1.0] - 2026-08-03
 
 Sealed-exec ops: host installer, no-downtime envelope-key rotation, and sudoers-

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -3,6 +3,7 @@ package signer
 import (
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -130,6 +131,9 @@ func (cp CommandPolicy) Validate() error {
 //   - ProcSubst   <(...)   — process substitution
 //   - ArithmCmd   $((...)) — arithmetic with side effects
 //   - file Redirect        — arbitrary write to the filesystem
+//   - env/export/declare and inline FOO=bar prefixes — mutate execution
+//   - command-hiding wrappers (bash -c, env, timeout, python -c, …) — the
+//     outer CallExpr would under-match denylist/require_approval (#352)
 //
 // Allowed: pipes (|), sequences (&&, ||, ;) and fd→fd redirections (2>&1).
 // Each CallExpr is returned as its DECODED literal command (quoting and
@@ -208,6 +212,16 @@ func extractCommands(command string) ([]string, error) {
 			lit, err2 := literalArgs(n.Args)
 			if err2 != nil {
 				walkErr = err2
+				return false
+			}
+			// Command-hiding wrappers (#352): extractCommands returns the OUTER
+			// CallExpr only, so a denylist/require_approval rule anchored on the
+			// real binary ("^rm ") never sees "bash -c 'rm …'" / "env rm …" /
+			// "timeout 1 rm …". Reject the known wrapper/interpreter set the same
+			// way we reject inline env assignments — the policy cannot know which
+			// inner argv[0] will run, so fail closed rather than under-match.
+			if w, ok := commandHidingWrapper(lit); ok {
+				walkErr = fmt.Errorf("command-hiding wrapper %q not allowed (policy cannot see the inner command; quote a direct binary or use an explicit path)", w)
 				return false
 			}
 			cmds = append(cmds, lit)
@@ -321,6 +335,50 @@ func directArgv(command string) ([]string, bool) {
 		return nil, false
 	}
 	return argv, true
+}
+
+// commandHidingWrappers are argv[0] basenames that re-introduce a different
+// real command after the outer CallExpr the policy matches. Under shell_parse,
+// denylist and require_approval regexes see only the outer string — so
+// "bash -c 'rm -rf /'" would dodge a "^rm " deny the way FOO=bar rm once did
+// (#175). Rejecting the wrapper class at extract time is fail-closed for both
+// denylist and allowlist (operators who need an interpreter use a direct path
+// to a script file, or opt out with shell_parse:false for that host).
+//
+// The set is the common shells, pure wrappers that always exec another argv,
+// and scripting interpreters whose -c/-e forms are the usual smuggle path.
+// Path forms (/bin/bash, /usr/bin/env) match via path.Base.
+var commandHidingWrappers = map[string]bool{
+	// Shells / login shells
+	"sh": true, "bash": true, "dash": true, "zsh": true, "ksh": true,
+	"csh": true, "tcsh": true, "fish": true,
+	// Pure wrappers (always run another command)
+	"env": true, "eval": true, "exec": true, "command": true,
+	"nice": true, "nohup": true, "timeout": true, "stdbuf": true,
+	"xargs": true, "busybox": true, "ionice": true, "chrt": true,
+	"setarch": true, "linux32": true, "linux64": true, "catchsegv": true,
+	"rlwrap": true,
+	// Scripting interpreters (typical -c/-e smuggle)
+	"python": true, "python2": true, "python3": true,
+	"perl": true, "ruby": true, "node": true, "nodejs": true,
+	"php": true, "lua": true, "tclsh": true,
+}
+
+// commandHidingWrapper reports whether the decoded simple-command string begins
+// with a known wrapper/interpreter basename. lit is the space-joined form from
+// literalArgs; the first field is argv[0] (static words only, so no IFS tricks).
+func commandHidingWrapper(lit string) (string, bool) {
+	argv0, _, _ := strings.Cut(lit, " ")
+	if argv0 == "" {
+		return "", false
+	}
+	base := path.Base(argv0)
+	// Login shells may appear as "-bash"; strip one leading dash.
+	base = strings.TrimPrefix(base, "-")
+	if commandHidingWrappers[base] {
+		return base, true
+	}
+	return "", false
 }
 
 // unquotedBackslash returns the first UNQUOTED literal part of w that carries a

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -257,6 +258,58 @@ func TestSignIntentApprovalGate(t *testing.T) {
 // field (nil = parse on by default; &false = explicit opt-out).
 func boolPtr(b bool) *bool { return &b }
 
+// TestShellParseRejectsCommandHidingWrappers pins #352: with shell_parse on,
+// denylist and require_approval must not be dodged by wrapping the real binary
+// in bash -c / env / timeout / … . extractCommands rejects the wrapper class
+// with a parse error (same fail-closed class as env-assignment / quoting).
+func TestShellParseRejectsCommandHidingWrappers(t *testing.T) {
+	t.Parallel()
+	denyRM := CommandPolicy{Mode: CmdPolicyDenylist, Deny: []string{`^rm `}}
+	reqRM := CommandPolicy{
+		Mode:            CmdPolicyAllowlist,
+		Allow:           []string{`.*`}, // broad allow so only the approval gate matters
+		RequireApproval: []string{`^rm `},
+	}
+	wrappers := []string{
+		"bash -c 'rm -rf /tmp/x'",
+		"sh -c \"rm -rf /tmp/x\"",
+		"/bin/bash -c 'rm -rf /tmp/x'",
+		"env rm -rf /tmp/x",
+		"/usr/bin/env rm -rf /tmp/x",
+		"timeout 1 rm -rf /tmp/x",
+		"nice rm -rf /tmp/x",
+		"nohup rm -rf /tmp/x",
+		"stdbuf -o0 rm -rf /tmp/x",
+		"xargs rm -rf /tmp/x",
+		"command rm -rf /tmp/x",
+		"exec rm -rf /tmp/x",
+		"eval 'rm -rf /tmp/x'",
+		"busybox rm -rf /tmp/x",
+		"python3 -c 'import os; os.system(\"rm -rf /tmp/x\")'",
+	}
+	for _, cmd := range wrappers {
+		// Denylist: must NOT soft-allow (the pre-#352 bug).
+		ok, _, rule, err := (PolicySet{denyRM}).Decide(cmd)
+		if err == nil || ok {
+			t.Errorf("denylist Decide(%q) = allowed=%v rule=%q err=%v; want parse error / denied", cmd, ok, rule, err)
+		}
+		// require_approval on a broad allowlist: must not silently skip the gate.
+		ok, need, _, err := (PolicySet{reqRM}).Decide(cmd)
+		if err == nil {
+			t.Errorf("require_approval Decide(%q) = allowed=%v needApp=%v err=nil; want parse error so the gate cannot be skipped", cmd, ok, need)
+		}
+	}
+	// Direct form still matches deny / require_approval as before.
+	ok, _, rule, err := (PolicySet{denyRM}).Decide("rm -rf /tmp/x")
+	if err != nil || ok || !strings.HasPrefix(rule, "deny:") {
+		t.Errorf("direct rm denylist: allowed=%v rule=%q err=%v; want denied with deny: rule", ok, rule, err)
+	}
+	ok, need, rule, err := (PolicySet{reqRM}).Decide("rm -rf /tmp/x")
+	if err != nil || !ok || !need || !strings.HasPrefix(rule, "require_approval:") {
+		t.Errorf("direct rm require_approval: allowed=%v need=%v rule=%q err=%v", ok, need, rule, err)
+	}
+}
+
 func TestCommandPolicyShellParse(t *testing.T) {
 	t.Parallel()
 
@@ -318,6 +371,13 @@ func TestCommandPolicyShellParse(t *testing.T) {
 		{"denylist pipeline kill", denylistParse, "ps aux | kill -9 1", false, true},
 		// Denylist con shell_parse: comando limpio → permitido.
 		{"denylist pipeline clean", denylistParse, "ps aux | grep nginx", true, true},
+		// #352: wrappers hide the real argv[0] from deny/require_approval. A
+		// denylist "^kill " must not be dodged via bash -c / env / timeout / …
+		// (parse error, not a soft allow).
+		{"wrapper bash -c hides deny (#352)", denylistParse, "bash -c 'kill -9 1'", false, false},
+		{"wrapper env hides deny (#352)", denylistParse, "env kill -9 1", false, false},
+		{"wrapper timeout hides deny (#352)", denylistParse, "timeout 1 kill -9 1", false, false},
+		{"wrapper /bin/bash path (#352)", denylistParse, "/bin/bash -c 'kill -9 1'", false, false},
 		// Explicit opt-out: shell_parse=false restores raw-string matching, so a
 		// compound command rides past an allowlist that only matches its prefix.
 		{"explicit opt-out (shell_parse:false)", CommandPolicy{


### PR DESCRIPTION
## Summary
- With `shell_parse` on (default), denylist and `require_approval` rules anchored on the real binary (e.g. `^rm `) could be dodged via wrappers: `bash -c 'rm …'`, `env rm …`, `timeout 1 rm …`, `python3 -c '…'`, etc.
- `extractCommands` only saw the outer CallExpr, so policy under-matched — same class as #175 / #277 / #308.
- Reject known shells, pure wrappers, and common interpreters fail-closed at parse time.

Closes #352

## Test plan
- [x] `go test ./internal/signer/ -run 'TestShellParseRejectsCommandHidingWrappers|TestCommandPolicyShellParse|TestDirectArgv'`
- [x] `go test -race ./...`
- [x] `make docs-check` (local venv)