### PR TITLE
fix(signer): enforce freeze when durability checkpoint fails

### DIFF
--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -1273,12 +1273,20 @@ func (s *server) handleFreeze(w http.ResponseWriter, r *http.Request) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	newly, err := s.freezes.Add(subj, reason, caller, time.Now())
-	if err != nil {
+	// INSERT failure: nothing frozen. ErrFreezeNotDurable (#353): freeze is live
+	// in memory (and usually in the WAL) but not yet power-loss-durable — still
+	// revoke grants and audit, then surface the durability error.
+	if err != nil && !errors.Is(err, signer.ErrFreezeNotDurable) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	revoked, gerr := s.grants.RevokeForSubject(subj.Kind, subj.Value)
 	s.auditFreeze(caller, "frozen", subj, reason, revoked, gerr)
+	if err != nil {
+		// Subject is frozen for this process; tell the operator durability lagged.
+		http.Error(w, fmt.Sprintf("subject frozen (enforced), but durability checkpoint failed: %v", err), http.StatusInternalServerError)
+		return
+	}
 	if gerr != nil {
 		http.Error(w, fmt.Sprintf("subject frozen, but revoking its grants failed: %v", gerr), http.StatusInternalServerError)
 		return

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,12 @@
   quoting once did (#175, #277, #308). Those wrappers are now rejected at parse
   time (fail-closed). Prefer allowlist for production; denylist remains
   best-effort against unknown path/alias tricks.
+- **Freeze Add enforces kill switch even if durability checkpoint fails (#353)** —
+  after a successful freeze INSERT, a failed `wal_checkpoint(FULL)` used to
+  return an error without updating the in-memory set, so `/v1/sign` kept
+  admitting the subject while the operator saw a freeze failure. Memory is now
+  updated before the checkpoint; a durability failure still freezes the process
+  (and still revokes grants) and surfaces `ErrFreezeNotDurable`.
 
 ## [v3.1.0] - 2026-08-03
 

--- a/internal/signer/freeze.go
+++ b/internal/signer/freeze.go
@@ -2,10 +2,18 @@ package signer
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 )
+
+// ErrFreezeNotDurable is returned by [FreezeStore.Add] when the freeze is live
+// in the in-memory set (and thus enforced on /v1/sign and /v1/hosts) but the
+// durability checkpoint after the INSERT failed. Callers must treat the subject
+// as frozen for enforcement and still run grant revocation; the error means a
+// restart may lose the freeze until the WAL is flushed (#353).
+var ErrFreezeNotDurable = errors.New("freeze enforced in-memory but not durable")
 
 // Freeze subject kinds. A frozen subject is denied on the signer decision path
 // (/v1/sign, /v1/hosts) and drives the broker's live-session kill (#117).
@@ -122,6 +130,11 @@ func NewFreezeStoreDB(db *sql.DB) (*FreezeStore, error) {
 // one, and production deployments should set state_db instead.
 func (s *FreezeStore) Volatile() bool { return s.db == nil }
 
+// freezeCheckpoint is the durability hook for freeze Add/Remove. Tests replace
+// it to simulate a post-INSERT checkpoint failure (#353). Production always
+// uses [checkpointDurable].
+var freezeCheckpoint = checkpointDurable
+
 // checkpointDurable forces the just-committed freeze mutation all the way to disk.
 // The state db runs synchronous=NORMAL (fsync only at a checkpoint), which is
 // crash-safe against an application crash but NOT against a power loss / kernel
@@ -145,10 +158,16 @@ func checkpointDurable(db *sql.DB) error {
 	return nil
 }
 
-// Add freezes subj. Write-through, insert-first: if it cannot be persisted the
-// call fails and the in-memory set does not diverge from disk (an in-memory-only
-// freeze would vanish on restart — fail-open). Re-freezing a subject refreshes
-// its reason/provenance. Returns whether the subject was newly frozen.
+// Add freezes subj. Write-through, insert-first: if the INSERT cannot be written
+// the call fails and the in-memory set is left untouched (an in-memory-only
+// freeze would vanish on restart — fail-open). After a successful INSERT the
+// in-memory set is updated BEFORE the durability checkpoint, so a checkpoint
+// failure still leaves the kill switch enforced for the life of this process
+// (#353 — the prior order returned an error with memory unfrozen while the row
+// sat in the WAL). Checkpoint failure returns [ErrFreezeNotDurable] wrapped
+// with the cause; callers must treat the subject as frozen. Re-freezing a
+// subject refreshes its reason/provenance. Returns whether the subject was
+// newly frozen.
 func (s *FreezeStore) Add(subj FreezeSubject, reason, by string, now time.Time) (bool, error) {
 	if !ValidFreezeKind(subj.Kind) {
 		return false, fmt.Errorf("invalid freeze kind %q", subj.Kind)
@@ -167,12 +186,16 @@ func (s *FreezeStore) Add(subj FreezeSubject, reason, by string, now time.Time) 
 			subj.Kind, subj.Value, reason, by, e.FrozenAt.Unix()); err != nil {
 			return false, fmt.Errorf("persisting freeze: %w", err)
 		}
-		if err := checkpointDurable(s.db); err != nil {
-			return false, fmt.Errorf("persisting freeze: %w", err)
-		}
 	}
+	// Install memory as soon as the row is written (or when memory-only): kill
+	// switch enforcement must not depend on the durability checkpoint.
 	_, existed := s.frozen[subj]
 	s.frozen[subj] = e
+	if s.db != nil {
+		if err := freezeCheckpoint(s.db); err != nil {
+			return !existed, fmt.Errorf("%w: %v", ErrFreezeNotDurable, err)
+		}
+	}
 	return !existed, nil
 }
 
@@ -190,7 +213,7 @@ func (s *FreezeStore) Remove(subj FreezeSubject) (bool, error) {
 		if _, err := s.db.Exec(`DELETE FROM freezes WHERE kind = ? AND value = ?`, subj.Kind, subj.Value); err != nil {
 			return false, fmt.Errorf("removing freeze in state db: %w", err)
 		}
-		if err := checkpointDurable(s.db); err != nil {
+		if err := freezeCheckpoint(s.db); err != nil {
 			return false, fmt.Errorf("removing freeze in state db: %w", err)
 		}
 	}

--- a/internal/signer/freeze_test.go
+++ b/internal/signer/freeze_test.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -207,5 +208,34 @@ func TestGrantStoreRevokeForSubject(t *testing.T) {
 	// session_id/serial kinds match no grants.
 	if n, err := s.RevokeForSubject(FreezeSessionID, "sess-1"); err != nil || n != 0 {
 		t.Fatalf("RevokeForSubject(session_id) = %d, %v; want 0, nil", n, err)
+	}
+}
+
+// TestFreezeAddCheckpointFailureStillEnforces pins #353: if the durability
+// checkpoint fails after a successful INSERT, Add must still install the
+// in-memory freeze (kill switch enforced) and return ErrFreezeNotDurable —
+// not leave the subject admitted while the operator sees a freeze failure.
+func TestFreezeAddCheckpointFailureStillEnforces(t *testing.T) {
+	// Not parallel: swaps the package-level freezeCheckpoint hook.
+	path := filepath.Join(t.TempDir(), "state.db")
+	fs, err := NewFreezeStoreDB(openStateDB(t, path))
+	if err != nil {
+		t.Fatalf("NewFreezeStoreDB: %v", err)
+	}
+
+	prev := freezeCheckpoint
+	freezeCheckpoint = func(*sql.DB) error { return errors.New("simulated checkpoint busy") }
+	t.Cleanup(func() { freezeCheckpoint = prev })
+
+	subj := FreezeSubject{Kind: FreezeCaller, Value: "brk-compromised"}
+	newly, err := fs.Add(subj, "incident", "admin", time.Now())
+	if !errors.Is(err, ErrFreezeNotDurable) {
+		t.Fatalf("Add: err=%v, want ErrFreezeNotDurable", err)
+	}
+	if !newly {
+		t.Error("first Add must report newly frozen even when durability fails")
+	}
+	if _, frozen := fs.Frozen("brk-compromised", ""); !frozen {
+		t.Fatal("kill switch must be enforced in-memory after a post-INSERT checkpoint failure (#353)")
 	}
 }


### PR DESCRIPTION
## Summary
- `FreezeStore.Add` used to update memory only after a successful `wal_checkpoint(FULL)`.
- If the checkpoint failed after INSERT, the API returned an error and `/v1/sign` kept admitting the subject — kill-switch fail-open for the live process.
- Memory is now updated immediately after INSERT; checkpoint failure returns `ErrFreezeNotDurable`. `handleFreeze` still revokes grants and surfaces the durability error.

Closes #353

## Test plan
- [x] `TestFreezeAddCheckpointFailureStillEnforces`
- [x] `go test -race ./internal/signer/ ./cmd/signer/`
- [x] `make docs-check`