### PR TITLE
fix(k8s): fail closed when an API response exceeds the size cap

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,13 @@
   untouched on failure), and unfreeze re-sweeps residual grants as defense in
   depth.
 
+### Fixed
+- **Kubernetes client fails closed on oversized API responses (#355)** — a 2xx
+  body larger than the read cap (4 MiB get/list/apply; 512 KiB logs) was
+  silently truncated and returned as success, so truncated lists/secrets/logs
+  looked complete to the model. The client now reads one byte past the cap and
+  errors when exceeded.
+
 ## [v3.1.0] - 2026-08-03
 
 Sealed-exec ops: host installer, no-downtime envelope-key rotation, and sudoers-

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -122,9 +122,16 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 		return "", 0, fmt.Errorf("k8s: %s %s: %s", method, path, transportErrorCause(err))
 	}
 	defer resp.Body.Close()
-	rb, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	// Read one past the cap so a truncated body is distinguishable from a full
+	// response of exactly maxBytes. Returning a silent partial 2xx would look
+	// complete to the model (truncated lists/secrets/logs) — fail closed like
+	// GetFile (#355).
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
 	if err != nil {
 		return "", resp.StatusCode, fmt.Errorf("k8s: reading response: %w", err)
+	}
+	if int64(len(rb)) > maxBytes {
+		return "", resp.StatusCode, fmt.Errorf("k8s: %s %s: response exceeds %d-byte limit", method, path, maxBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", resp.StatusCode, fmt.Errorf("k8s: %s %s: %s", method, path, statusMessage(rb, resp.StatusCode))

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -164,6 +164,28 @@ func TestClientSurfacesStatusMessage(t *testing.T) {
 	}
 }
 
+// TestClientRejectsOversizedResponse pins #355: a 2xx body larger than the
+// response cap must error rather than return a silent truncated success.
+func TestClientRejectsOversizedResponse(t *testing.T) {
+	f := newFakeAPI(t)
+	// apiMaxBytes is 4 MiB; one byte over must fail closed.
+	f.respond = strings.Repeat("x", apiMaxBytes+1)
+	c := f.client(t)
+
+	_, err := c.Get(context.Background(), mustDef(t, "pods"), "prod", "big")
+	if err == nil {
+		t.Fatal("oversized 2xx body must not succeed as a truncated response")
+	}
+	if !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("want exceed-limit error, got %v", err)
+	}
+	// Exact cap still succeeds.
+	f.respond = strings.Repeat("y", apiMaxBytes)
+	if _, err := c.Get(context.Background(), mustDef(t, "pods"), "prod", "exact"); err != nil {
+		t.Fatalf("body of exactly the cap must succeed: %v", err)
+	}
+}
+
 func TestClientRequiresParsableCA(t *testing.T) {
 	// No system roots and no TOFU: a client without a parsable cluster CA must
 	// not be constructible at all (fail-closed).


### PR DESCRIPTION
## Summary
- `Client.do` used `LimitReader` without detecting truncation on 2xx.
- Oversized get/list/logs responses returned partial JSON as success.
- Now reads `maxBytes+1` and errors with a clear limit message when exceeded.

Closes #355

## Test plan
- [x] `TestClientRejectsOversizedResponse`
- [x] `go test -race ./internal/k8s/`