### PR TITLE
fix(build): set CGO_ENABLED=0 for make build/dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ PKG     := github.com/luisgf/infrabroker/internal/version
 LDFLAGS := -X $(PKG).Version=$(VERSION)
 BINDIR  ?= $(HOME)/bin
 CMDS    := infrabroker signer broker broker-ctl mcp-broker mcp-broker-http control-plane approval-bridge infrabroker-shim
+# Pure-Go / static builds (modernc sqlite, no cgo). Must match .goreleaser.yaml
+# so `make dist` installer binaries stay static like the release archives (#357).
+export CGO_ENABLED ?= 0
 # MkDocs runner: prefer a local mkdocs, else fall back to `python3 -m mkdocs`.
 MKDOCS  ?= $(shell command -v mkdocs 2>/dev/null || echo "python3 -m mkdocs")
 
@@ -28,7 +31,7 @@ build: $(CMDS)
 install: build
 
 $(CMDS):
-	go build -ldflags "$(LDFLAGS)" -o $(BINDIR)/$@ ./cmd/$@
+	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINDIR)/$@ ./cmd/$@
 
 test:
 	go test -race ./...

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,10 @@
   restart the dedupe map is empty, and `GET /v1/approvals` returns decided
   requests too, so already-approved/denied items were re-posted to chat.
   Non-pending statuses are now skipped.
+- **`make build`/`make dist` set `CGO_ENABLED=0` (#357)** — goreleaser archives
+  were static while the installer tarball from `make dist` used default CGO
+  (glibc-dynlinked when a C compiler is present). The Makefile now exports
+  `CGO_ENABLED=0` (and `-trimpath`) to match goreleaser.
 
 ## [v3.1.0] - 2026-08-03
 


### PR DESCRIPTION
## Summary
- Goreleaser builds every binary with `CGO_ENABLED=0`; `make dist` used plain `go build`.
- Installer tarball binaries could be glibc-dynlinked while platform archives are static.
- Makefile now exports `CGO_ENABLED=0` and builds with `-trimpath`.

Closes #357

## Test plan
- [x] `go build` with CGO_ENABLED=0