### PR TITLE
chore: v3.1.1 release (changelog + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [v3.1.1] - 2026-08-12
+
+Security and correctness audit fixes: shell-wrapper command-policy bypass,
+kill-switch durability, k8s response caps, bridge pending-only posts, and
+static installer builds — plus skill/demo doc accuracy.
 
 ### Security
 - **Command-policy shell_parse rejects command-hiding wrappers (#352)** — with
@@ -52,6 +56,10 @@
 - **Audit skill distribution invariants (#360)** — skill text now matches nine
   goreleaser/Makefile builds, a seven-binary image (deliberately omitting
   bridge+shim), and the demo's real allowlist/approval posture.
+
+### Internal
+- **Dependabot go-minor-patch** — `modernc.org/sqlite` and related transitive
+  bumps (#350, #351).
 
 ## [v3.1.0] - 2026-08-03
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,10 +1,17 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-08-03 (v3.1.0: sealed-exec host installer + rotación sin
-> downtime, sudo argv directo, fixes freeze/learn y audit path forgery).
+> actualización: 2026-08-12 (v3.1.1: audit security/correctness — shell wrappers,
+> freeze durability, k8s response cap, bridge pending-only, CGO=0 dist).
 >
 > Estado reciente:
+> - **v3.1.1** (patch): **audit #352–#360** — shell_parse rechaza wrappers que
+>   escondían el argv real a denylist/require_approval (`bash -c`, `env`, …);
+>   freeze instala en memoria aunque falle el checkpoint WAL y revoca grants
+>   all-or-nothing; k8s client falla cerrado si el body 2xx supera el cap;
+>   approval-bridge solo postea `pending`; `make dist` con `CGO_ENABLED=0`.
+>   Docs/skills: demo no sobreclama "nothing to steal", deploy skill sin
+>   `_default` vacío + agent CA, audit skill con 9 builds / 7 image.
 > - **v3.1.0** (minor): **ops de sealed-exec** — `deploy/install-shim.sh` (#291)
 >   instala el shim, pinnea `envelope.pub` (multi-key para rotación sin outage) y
 >   el nonce store; `broker-ctl envelope pubkey` imprime la clave entrante offline.

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:3.1.0",
+      "identifier": "ghcr.io/luisgf/infrabroker:3.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
Patch release **v3.1.1** after the post-v3.1.0 audit wave and dependabot merges.

**Why patch (not minor):** only `fix:` / `docs:` / `chore(deps)` since `v3.1.0` — no new user-facing surface.

### Ships
- Security: shell_parse rejects command-hiding wrappers (#352); freeze enforces on checkpoint lag (#353); freeze grant revoke all-or-nothing (#354)
- Logic: k8s oversized 2xx fail-closed (#355); approval-bridge pending-only (#356); `CGO_ENABLED=0` on `make dist` (#357)
- Docs/skills: deploy skill callers + agent CA (#358); demo volume honesty (#359); audit skill inventory (#360)
- Internal: modernc.org/sqlite bumps (#350, #351)

### Files
- `docs/CHANGELOG.md` — `[Unreleased]` → `[v3.1.1] - 2026-08-12`
- `server.json` — version + OCI tag `3.1.1`
- `docs/HANDOFF.md` — estado reciente

### Verified locally
- `make verify` (race tests, govulncheck, docs-check)
- `mcp-publisher validate server.json` ✅

## After merge
Tag `v3.1.1` on the merge commit and push to trigger `release.yml` (goreleaser + MCP Registry). **Release PRs are not auto-merged** — please review and merge, then authorize the tag push.