### PR TITLE
fix(signer): reject sudo/su/source wrappers in shell_parse

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **Command-policy shell_parse rejects sudo/su/source wrappers (#371)** — the
+  #352 wrapper set missed the privilege wrappers this product uses for
+  elevation (`sudo`, `su`, `doas`, `pkexec`, `runuser`, `sg`), the eval-class
+  source builtins (`.`, `source`), and a few remaining wrappers/interpreters
+  (`script`, `watch`, `awk`/`gawk`/`nawk`/`mawk`). With `shell_parse` on, an
+  anchored denylist or `require_approval` (`^rm `) was dodged by `sudo rm …`
+  or `. /tmp/evil`. Those names are now rejected at parse time (fail-closed),
+  the same way `bash -c` / `env` / `eval` already are. Prefer the `sudo`
+  intent flag over putting `sudo` in the command; denylist remains
+  best-effort against unknown path/alias tricks.
+
 ## [v3.1.1] - 2026-08-12
 
 Security and correctness audit fixes: shell-wrapper command-policy bypass,

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -346,8 +346,11 @@ func directArgv(command string) ([]string, bool) {
 // to a script file, or opt out with shell_parse:false for that host).
 //
 // The set is the common shells, pure wrappers that always exec another argv,
-// and scripting interpreters whose -c/-e forms are the usual smuggle path.
-// Path forms (/bin/bash, /usr/bin/env) match via path.Base.
+// privilege wrappers (sudo/su/… — the product's own elevation path), the
+// eval-class source builtins (. / source), and scripting interpreters whose
+// -c/-e forms are the usual smuggle path. Path forms (/bin/bash, /usr/bin/sudo)
+// match via path.Base. "." is listed so ` . /tmp/evil` is rejected the same
+// way eval is (#371, sibling of #352).
 var commandHidingWrappers = map[string]bool{
 	// Shells / login shells
 	"sh": true, "bash": true, "dash": true, "zsh": true, "ksh": true,
@@ -357,11 +360,20 @@ var commandHidingWrappers = map[string]bool{
 	"nice": true, "nohup": true, "timeout": true, "stdbuf": true,
 	"xargs": true, "busybox": true, "ionice": true, "chrt": true,
 	"setarch": true, "linux32": true, "linux64": true, "catchsegv": true,
-	"rlwrap": true,
+	"rlwrap": true, "script": true, "watch": true,
+	// Privilege wrappers: the outer argv[0] is sudo/su/… so an anchored
+	// deny/require_approval on the real binary ("^rm ") never matches.
+	// Elevation belongs on the Sudo intent flag, not in the command string.
+	"sudo": true, "su": true, "doas": true, "pkexec": true,
+	"runuser": true, "sg": true,
+	// Source builtins — same class as eval (already listed): they run a
+	// file the policy cannot see.
+	".": true, "source": true,
 	// Scripting interpreters (typical -c/-e smuggle)
 	"python": true, "python2": true, "python3": true,
 	"perl": true, "ruby": true, "node": true, "nodejs": true,
 	"php": true, "lua": true, "tclsh": true,
+	"awk": true, "gawk": true, "nawk": true, "mawk": true,
 }
 
 // commandHidingWrapper reports whether the decoded simple-command string begins

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -286,6 +286,19 @@ func TestShellParseRejectsCommandHidingWrappers(t *testing.T) {
 		"eval 'rm -rf /tmp/x'",
 		"busybox rm -rf /tmp/x",
 		"python3 -c 'import os; os.system(\"rm -rf /tmp/x\")'",
+		// #371: privilege wrappers, source builtins, remaining interpreters.
+		"sudo rm -rf /tmp/x",
+		"/usr/bin/sudo rm -rf /tmp/x",
+		"sudo -n rm -rf /tmp/x",
+		"su -c 'rm -rf /tmp/x'",
+		"doas rm -rf /tmp/x",
+		"pkexec rm -rf /tmp/x",
+		"runuser -u root -- rm -rf /tmp/x",
+		". /tmp/evil.sh",
+		"source /tmp/evil.sh",
+		"script -c 'rm -rf /tmp/x' /dev/null",
+		"watch rm -rf /tmp/x",
+		"awk 'BEGIN{system(\"rm -rf /tmp/x\")}'",
 	}
 	for _, cmd := range wrappers {
 		// Denylist: must NOT soft-allow (the pre-#352 bug).
@@ -378,6 +391,10 @@ func TestCommandPolicyShellParse(t *testing.T) {
 		{"wrapper env hides deny (#352)", denylistParse, "env kill -9 1", false, false},
 		{"wrapper timeout hides deny (#352)", denylistParse, "timeout 1 kill -9 1", false, false},
 		{"wrapper /bin/bash path (#352)", denylistParse, "/bin/bash -c 'kill -9 1'", false, false},
+		{"wrapper sudo hides deny (#371)", denylistParse, "sudo kill -9 1", false, false},
+		{"wrapper su -c hides deny (#371)", denylistParse, "su -c 'kill -9 1'", false, false},
+		{"wrapper source hides deny (#371)", denylistParse, "source /tmp/evil.sh", false, false},
+		{"wrapper dot-source hides deny (#371)", denylistParse, ". /tmp/evil.sh", false, false},
 		// Explicit opt-out: shell_parse=false restores raw-string matching, so a
 		// compound command rides past an allowlist that only matches its prefix.
 		{"explicit opt-out (shell_parse:false)", CommandPolicy{


### PR DESCRIPTION
## Summary

`shell_parse` already rejects `bash -c` / `env` / `timeout` / `python -c` so an anchored denylist or `require_approval` (`^rm `) cannot be dodged by wrapping the real binary (tracked in #352). That set omitted:

- privilege wrappers this product uses for elevation: `sudo`, `su`, `doas`, `pkexec`, `runuser`, `sg`
- eval-class source builtins (`.`, `source` — `eval` was already blocked)
- remaining wrappers/interpreters: `script`, `watch`, `awk`/`gawk`/`nawk`/`mawk`

A live `Decide()` against denylist `^rm ` allowed `sudo rm -rf /tmp/x`, `su -c 'rm …'`, `. /tmp/evil.sh`, and `source /tmp/evil.sh`. Those now fail closed at parse time, same as `bash -c`. Elevation stays on the `sudo` intent flag, not in the command string. Denylist remains best-effort against unknown path/alias tricks.

## Verification

- `gofmt -l .` clean
- `go vet ./...`
- `go build ./...`
- `go test -race ./...`
- `govulncheck ./...` (0 vulns in our code)
- `make docs-check` (docgen, example configs, strict site)

Closes #371