### PR TITLE
docs(threat): name the cert-TTL session cap in gap #1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,13 @@
   intent flag over putting `sudo` in the command; denylist remains
   best-effort against unknown path/alias tricks.
 
+### Documentation
+- **THREAT_MODEL gap #1 names the cert-TTL session cap (#372)** — the
+  "Mitigation today" paragraph still said the certificate TTL does not
+  bound an open session (pre-#124 wording). It now matches USAGE: the
+  broker reaper closes a session at cert expiry, idle timeout, or
+  `session_max_seconds`, whichever comes first.
+
 ## [v3.1.1] - 2026-08-12
 
 Security and correctness audit fixes: shell-wrapper command-policy bypass,

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -183,11 +183,13 @@ host's sudoers/principal allow.
 - **Mitigation today:** prefer `ssh_execute` on sensitive hosts when you need the
   host-enforced `force-command` guarantee; use `mode=exec` sessions only when
   connection reuse matters and broker-side preflight is an acceptable control.
-  Keep `source-address` + principal + restrictive sudoers. Note the certificate
-  TTL bounds *one-shot* exposure but **not** an open session: OpenSSH validates
-  the certificate only at authentication, so an established session lives until
-  the reaper closes it — bound by `session_idle_seconds` / `session_max_seconds`,
-  which is the value to set as the session exposure window.
+  Keep `source-address` + principal + restrictive sudoers. OpenSSH validates
+  the certificate only at authentication, so an established connection would
+  itself outlive expiry; the broker reaper enforces the bound and closes the
+  session at certificate expiry, after `session_idle_seconds` of inactivity,
+  or after `session_max_seconds` of total lifetime — whichever comes first
+  (#124, #225). A session's exposure is therefore capped at the certificate
+  TTL (≤ `max_ttl_seconds`); set `session_max_seconds` to tighten it further.
 - **Mitigation (opt-in per host) — "sealed exec" (#144):** makes session-exec
   filtering host-enforced, the way one-shot already is. Set `"sealed_exec": true`
   on a host in `signer.json` and configure `envelope_key` (a dedicated Ed25519


### PR DESCRIPTION
## Summary

USAGE.md already documents that the broker reaper closes a session at certificate expiry, idle timeout, or `session_max_seconds` (tracked in #124 / #225). THREAT_MODEL.md gap #1 "Mitigation today" still said the opposite — that the cert TTL bounds one-shot only and the session window is only idle/max.

Rewrite that sentence to match USAGE so operators sizing session exposure from the threat model see the control that actually ships.

## Verification

- `make verify` (gofmt, vet, build, race tests, govulncheck, docs-check / strict site)

Closes #372