### PR TITLE
docs(readme): name the ssh-agent CA backend in Multi-CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ This README is a landing page. The detail lives in focused, single-source docs:
 - **Controlled escalation:** `allow_sudo` / `allowed_sudo_users` live in the
   signer; a compromised broker cannot escalate where policy forbids it.
 - **CA compromise bounded:** one CA per host group (`ca_keys`), each key
-  optionally in Azure Key Vault — the private key never leaves the HSM.
+  optionally in Azure Key Vault or ssh-agent (YubiKey PIV / SoftHSM / TPM)
+  — the private key never leaves the HSM.
 - **Audit / non-repudiation:** append-only, Ed25519-chained log correlated by
   `serial` across signer, broker, and `sshd`.
 
@@ -98,7 +99,7 @@ the design decisions, and the per-hop ProxyJump certificate diagrams.
 |---|---|---|
 | **Ephemeral certificates** | Ed25519 pair in RAM per operation; minutes-long, scoped cert. No reusable secret. | [ARCHITECTURE](docs/ARCHITECTURE.md) |
 | **External signer** | A separate `cmd/signer` holds the CA key and policy; the broker never does. | [ARCHITECTURE](docs/ARCHITECTURE.md) |
-| **Multi-CA + HSM** | One CA key per host group via `ca_keys`; local PEM or Azure Key Vault. | [ARCHITECTURE](docs/ARCHITECTURE.md#multi-ca--azure-key-vault-v1110) |
+| **Multi-CA + HSM** | One CA key per host group via `ca_keys`; local PEM, Azure Key Vault, or ssh-agent/HSM. | [ARCHITECTURE](docs/ARCHITECTURE.md#multi-ca--ca-custody-v1110-agent-backend-122) |
 | **AI-action firewall** | Per-host or **composable-by-group** command policy (allow/deny/`require_approval`), POSIX-sh AST parsing, dry-run. Authoritative for one-shot. | [ARCHITECTURE](docs/ARCHITECTURE.md#ai-action-firewall) · [USAGE](docs/USAGE.md) |
 | **Human-in-the-loop approval** | Optional control plane gates `require_approval` commands behind out-of-band approval; the signer enforces it. | [ARCHITECTURE](docs/ARCHITECTURE.md#human-in-the-loop--control-plane) · [API](docs/API.md#control-plane-api) |
 | **Action budgets** (behaviour guardrails) | Budget *how much* an agent can do: per-CN sign-rate cap plus per-subject rate limit and novelty escalation (a subsequent new host / novel command → approval); observe or enforce. Network tools budget what an agent can *reach* or *spend*; this budgets the actions themselves. | [OPERATIONS](docs/OPERATIONS.md#action-budgets-rate-limits--behavior-guardrails) · [ARCHITECTURE](docs/ARCHITECTURE.md#human-in-the-loop--control-plane) |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,10 @@
   bound an open session (pre-#124 wording). It now matches USAGE: the
   broker reaper closes a session at cert expiry, idle timeout, or
   `session_max_seconds`, whichever comes first.
+- **README Multi-CA names the ssh-agent backend (#373)** — the feature
+  table still said "local PEM or Azure Key Vault" and linked a stale
+  ARCHITECTURE anchor. It now lists PEM / AKV / ssh-agent/HSM and points
+  at the current Multi-CA heading.
 
 ## [v3.1.1] - 2026-08-12
 


### PR DESCRIPTION
## Summary

README's Multi-CA row still described custody as "local PEM or Azure Key Vault" and linked `docs/ARCHITECTURE.md#multi-ca--azure-key-vault-v1110`. The `agent` backend has shipped since #122, and the ARCHITECTURE heading was renamed, so that slug no longer resolves.

The table now lists PEM / Azure Key Vault / ssh-agent/HSM and points at the current heading. The "CA compromise bounded" bullet is updated the same way.

README is not in the mkdocs nav, so docs-check did not catch the broken anchor.

## Verification

- `make verify` (gofmt, vet, build, race tests, govulncheck, docs-check / strict site)

Closes #373