### PR TITLE
fix(signer): match versioned interpreters in shell_parse wrappers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,12 @@
   the same way `bash -c` / `env` / `eval` already are. Prefer the `sudo`
   intent flag over putting `sudo` in the command; denylist remains
   best-effort against unknown path/alias tricks.
+- **Command-policy wrapper gate matches versioned interpreters (#377)** —
+  the exact-basename map still allowed `python3.12 -c`, `ash -c`, and
+  `/usr/bin/time rm` past an anchored `^rm ` deny. Interpreter families
+  now match a trailing version suffix (`python3.12`, `ruby3.2`, `node18`);
+  `ash` and `time` join the wrapper set. Hyphenated helpers
+  (`python3-config`) stay unmatched.
 
 ### Documentation
 - **THREAT_MODEL gap #1 names the cert-TTL session cap (#372)** — the

--- a/internal/signer/cmdpolicy.go
+++ b/internal/signer/cmdpolicy.go
@@ -354,13 +354,13 @@ func directArgv(command string) ([]string, bool) {
 var commandHidingWrappers = map[string]bool{
 	// Shells / login shells
 	"sh": true, "bash": true, "dash": true, "zsh": true, "ksh": true,
-	"csh": true, "tcsh": true, "fish": true,
+	"csh": true, "tcsh": true, "fish": true, "ash": true,
 	// Pure wrappers (always run another command)
 	"env": true, "eval": true, "exec": true, "command": true,
 	"nice": true, "nohup": true, "timeout": true, "stdbuf": true,
 	"xargs": true, "busybox": true, "ionice": true, "chrt": true,
 	"setarch": true, "linux32": true, "linux64": true, "catchsegv": true,
-	"rlwrap": true, "script": true, "watch": true,
+	"rlwrap": true, "script": true, "watch": true, "time": true,
 	// Privilege wrappers: the outer argv[0] is sudo/su/… so an anchored
 	// deny/require_approval on the real binary ("^rm ") never matches.
 	// Elevation belongs on the Sudo intent flag, not in the command string.
@@ -390,7 +390,65 @@ func commandHidingWrapper(lit string) (string, bool) {
 	if commandHidingWrappers[base] {
 		return base, true
 	}
+	// Versioned interpreters (#377): python3.12, ruby3.2, node18, php8.3.
+	// Exact unversioned names live in the map; a trailing version suffix is
+	// the same smuggle path and is what current distros actually ship.
+	if fam, ok := versionedInterpreter(base); ok {
+		return fam, true
+	}
 	return "", false
+}
+
+// versionedInterpreterPrefixes are argv[0] families whose unversioned
+// basename is already in commandHidingWrappers. Longer prefixes first so
+// python3.12 matches python3, not python.
+var versionedInterpreterPrefixes = []string{
+	// python is not listed: python3 would otherwise look like python+"3".
+	// Unversioned `python` lives in the exact map; versioned CPython is
+	// always python2.N / python3.N.
+	"python3", "python2",
+	"nodejs", "node",
+	"ruby", "php", "perl", "lua",
+}
+
+// versionedInterpreter reports whether base is a known interpreter plus a
+// version suffix (python3.12, ruby3.2, node18). It does not match
+// python3-config or other hyphenated helpers.
+func versionedInterpreter(base string) (string, bool) {
+	for _, p := range versionedInterpreterPrefixes {
+		if !strings.HasPrefix(base, p) || base == p {
+			continue
+		}
+		if isVersionSuffix(base[len(p):]) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// isVersionSuffix reports whether s is a trailing interpreter version:
+// optional leading '.', then digits and dots only (".12", "18", "3.2", "5.36").
+func isVersionSuffix(s string) bool {
+	if s == "" {
+		return false
+	}
+	i := 0
+	if s[0] == '.' {
+		if len(s) < 2 {
+			return false
+		}
+		i = 1
+	}
+	if s[i] < '0' || s[i] > '9' {
+		return false
+	}
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c != '.' && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
 }
 
 // unquotedBackslash returns the first UNQUOTED literal part of w that carries a

--- a/internal/signer/cmdpolicy_test.go
+++ b/internal/signer/cmdpolicy_test.go
@@ -299,6 +299,13 @@ func TestShellParseRejectsCommandHidingWrappers(t *testing.T) {
 		"script -c 'rm -rf /tmp/x' /dev/null",
 		"watch rm -rf /tmp/x",
 		"awk 'BEGIN{system(\"rm -rf /tmp/x\")}'",
+		// #377: versioned interpreters, Alpine ash, GNU time binary.
+		"python3.12 -c 'import os; os.system(\"rm -rf /tmp/x\")'",
+		"/usr/bin/python3.12 -c 'pass'",
+		"ruby3.2 -e 'system(\"rm -rf /tmp/x\")'",
+		"node18 -e 'process.exit(0)'",
+		"ash -c 'rm -rf /tmp/x'",
+		"/usr/bin/time rm -rf /tmp/x",
 	}
 	for _, cmd := range wrappers {
 		// Denylist: must NOT soft-allow (the pre-#352 bug).
@@ -320,6 +327,25 @@ func TestShellParseRejectsCommandHidingWrappers(t *testing.T) {
 	ok, need, rule, err := (PolicySet{reqRM}).Decide("rm -rf /tmp/x")
 	if err != nil || !ok || !need || !strings.HasPrefix(rule, "require_approval:") {
 		t.Errorf("direct rm require_approval: allowed=%v need=%v rule=%q err=%v", ok, need, rule, err)
+	}
+}
+
+func TestVersionedInterpreter(t *testing.T) {
+	t.Parallel()
+	// Distro defaults and explicit versioned names must match the family.
+	for _, name := range []string{"python3.12", "python3.11", "ruby3.2", "php8.3", "node18", "perl5.36", "lua5.4"} {
+		if fam, ok := versionedInterpreter(name); !ok {
+			t.Errorf("%q must be a versioned interpreter", name)
+		} else if fam == "" {
+			t.Errorf("%q matched with empty family", name)
+		}
+	}
+	// Helpers and unversioned names must not trip the suffix matcher
+	// (unversioned names live in the exact map instead).
+	for _, name := range []string{"python3", "python3-config", "python3-coverage", "nodejs", "ruby", "php-fpm"} {
+		if fam, ok := versionedInterpreter(name); ok {
+			t.Errorf("%q must not be a versioned interpreter, got family %q", name, fam)
+		}
 	}
 }
 
@@ -395,6 +421,9 @@ func TestCommandPolicyShellParse(t *testing.T) {
 		{"wrapper su -c hides deny (#371)", denylistParse, "su -c 'kill -9 1'", false, false},
 		{"wrapper source hides deny (#371)", denylistParse, "source /tmp/evil.sh", false, false},
 		{"wrapper dot-source hides deny (#371)", denylistParse, ". /tmp/evil.sh", false, false},
+		{"wrapper python3.12 hides deny (#377)", denylistParse, "python3.12 -c 'pass'", false, false},
+		{"wrapper ash hides deny (#377)", denylistParse, "ash -c 'kill -9 1'", false, false},
+		{"wrapper /usr/bin/time hides deny (#377)", denylistParse, "/usr/bin/time kill -9 1", false, false},
 		// Explicit opt-out: shell_parse=false restores raw-string matching, so a
 		// compound command rides past an allowlist that only matches its prefix.
 		{"explicit opt-out (shell_parse:false)", CommandPolicy{


### PR DESCRIPTION
## Summary

After the #371 wrapper set, `Decide()` against denylist `^rm ` still allowed:

- `python3.12 -c` / `/usr/bin/python3.12` (the name current Debian/Ubuntu ship)
- `ash -c` (Alpine when invoked by that name)
- `/usr/bin/time rm …` (GNU time execs the next argv; the shell keyword `time` was already stripped)

Interpreter families now match a trailing version suffix (`python3.12`, `ruby3.2`, `node18`). `ash` and `time` join the exact map. Hyphenated helpers (`python3-config`) stay unmatched.

## Verification

- `make verify` (gofmt, vet, build, race tests, govulncheck, docs-check)

Closes #377