### PR TITLE
fix(signer): hold writeMu across reload so policy narrowing cannot revert

### DIFF
--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -524,8 +524,9 @@ type server struct {
 	endUserVerifier *oauth.Verifier
 	endUserOIDCCfg  *EndUserOIDCConfig
 
-	// writeMu serialises config mutations (POST/DELETE /v1/policy) so two
-	// concurrent edits cannot interleave the file read-modify-write.
+	// writeMu serialises config mutations (POST/DELETE /v1/policy) AND reload()
+	// so a SIGHUP/auto-reload that started on an older file cannot swap memory
+	// back over a concurrent narrowing (#378).
 	writeMu sync.Mutex
 
 	// Immutable after startup.
@@ -765,10 +766,21 @@ func (s *server) frozenSubject(peerCN, resolved, endUser string) (signer.FreezeS
 	return signer.FreezeSubject{}, false
 }
 
+// afterReloadLock is invoked by reload after writeMu is held. Tests replace
+// it to prove a concurrent mutateAllow cannot proceed until reload finishes.
+var afterReloadLock = func() {}
+
 // reload re-reads the config file and, if valid, atomically replaces the
 // signer, the host policy, and the reload allowlist. On failure it leaves the
 // state unchanged and returns an error. Returns the number of loaded hosts.
+//
+// writeMu is held for the whole read+build+swap so a concurrent mutateAllow
+// cannot persist a narrowing that this reload then overwrites with the
+// pre-mutation file it already read (#378).
 func (s *server) reload() (int, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	afterReloadLock()
 	cfg, err := loadConfig(s.cfgPath)
 	if err != nil {
 		return 0, fmt.Errorf("config: %w", err)

--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -89,9 +89,10 @@ func policyErrStatus(err error) int {
 }
 
 // mutateAllow edits the host's command_policy allowlist in signer.json and
-// applies it. writeMu serialises mutations (read-modify-write of the file);
-// buildState runs outside the state lock (it may load CA keys), and only the
-// final swap takes s.mu — mirroring reload().
+// applies it. writeMu serialises mutations with each other AND with reload()
+// so a SIGHUP/auto-reload cannot swap memory back to a file snapshot taken
+// before this write (#378). buildState runs outside s.mu (it may load CA
+// keys); only the final swap takes the state lock.
 func (s *server) mutateAllow(host, pattern string, add bool) (int, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()

--- a/cmd/signer/reload_lock_test.go
+++ b/cmd/signer/reload_lock_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestReloadSerializesWithMutateAllow pins #378: reload holds writeMu for
+// the whole read+build+swap, so a concurrent mutateAllow cannot persist a
+// narrowing that this reload would then overwrite with a stale snapshot.
+func TestReloadSerializesWithMutateAllow(t *testing.T) {
+	// Not parallel: replaces the package-level afterReloadLock hook.
+	srv := &server{cfgPath: filepath.Join(t.TempDir(), "missing.json")}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	afterReloadLock = func() {
+		close(entered)
+		<-release
+	}
+	t.Cleanup(func() { afterReloadLock = func() {} })
+
+	reloaded := make(chan struct{})
+	go func() {
+		_, _ = srv.reload()
+		close(reloaded)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload did not acquire writeMu")
+	}
+
+	mutated := make(chan struct{})
+	go func() {
+		_, _ = srv.mutateAllow("web01", "^x$", true)
+		close(mutated)
+	}()
+	select {
+	case <-mutated:
+		t.Fatal("mutateAllow ran while reload held writeMu")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	<-reloaded
+	select {
+	case <-mutated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("mutateAllow did not proceed after reload released writeMu")
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,11 @@
   now match a trailing version suffix (`python3.12`, `ruby3.2`, `node18`);
   `ash` and `time` join the wrapper set. Hyphenated helpers
   (`python3-config`) stay unmatched.
+- **reload() holds writeMu for the whole read+build+swap (#378)** — a
+  SIGHUP or auto-reload that started on an older `signer.json` could
+  finish after a concurrent policy DELETE and swap memory back to the
+  wide snapshot. Disk stayed narrow; the live signer did not. Reload now
+  takes the same lock as `mutateAllow`.
 
 ### Documentation
 - **THREAT_MODEL gap #1 names the cert-TTL session cap (#372)** — the


### PR DESCRIPTION
## Summary

`mutateAllow` (POST/DELETE `/v1/policy`) already holds `writeMu` for its read-modify-write. `reload()` — SIGHUP, POST `/v1/reload`, and the mtime watcher — read `signer.json` and swapped `s.local` under `s.mu` only. `buildState` can take seconds (CA/AKV), so:

1. reload reads the wide file
2. DELETE persists a narrowing and swaps memory to it
3. reload swaps memory back to the wide snapshot

Disk stayed narrow; the live signer did not. Reload now takes `writeMu` for the whole read+build+swap. A test holds the lock after acquire and checks `mutateAllow` cannot proceed.

## Verification

- `make verify` (gofmt, vet, build, race tests, govulncheck, docs-check)

Closes #378