### PR TITLE
fix(deploy): heal env-file and broker-ctl.json modes on re-run

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -183,6 +183,23 @@ if [[ -f "${ROOT}/broker-ctl.example.json" ]]; then
         echo "installed ${ETCDIR}/broker-ctl.json (from example — EDIT BEFORE USING)"
     fi
 fi
+# Re-run heals an existing client-config's ownership/mode (a leftover 0644
+# from a hand-copied file is readable by every service via the shared group).
+if [[ -f "${ETCDIR}/broker-ctl.json" ]]; then
+    chown root:infrabroker "${ETCDIR}/broker-ctl.json"
+    chmod 0640 "${ETCDIR}/broker-ctl.json"
+fi
+
+# EnvironmentFile secrets (AZURE_*, OIDC, webhook tokens). systemd reads them
+# as root; 0600 root:root is enough. A 0644 file is readable by every
+# infrabroker-* user because /etc/infrabroker is 0750 root:infrabroker.
+# Heal if present; never create an empty env file (absence is the no-creds case).
+for envf in signer.env control-plane.env mcp-http.env; do
+    if [[ -f "${ETCDIR}/${envf}" ]]; then
+        chown root:root "${ETCDIR}/${envf}"
+        chmod 0600 "${ETCDIR}/${envf}"
+    fi
+done
 
 # 4c. Migration check: a private key still sitting FLAT under pki/ (the
 # <= v1.34 single-user layout) is readable by every service via the shared

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,13 @@
   finish after a concurrent policy DELETE and swap memory back to the
   wide snapshot. Disk stayed narrow; the live signer did not. Reload now
   takes the same lock as `mutateAllow`.
+- **install.sh heals `*.env` and `broker-ctl.json` modes on re-run (#381)** —
+  service JSON was already converged to `0640`, but an existing
+  `signer.env` / `control-plane.env` / `mcp-http.env` (AZURE_*, OIDC,
+  webhook tokens) and `broker-ctl.json` were left as-is. A `0644` env
+  file is readable by every `infrabroker-*` user via the shared group.
+  Re-run now sets env files to `0600 root:root` and `broker-ctl.json` to
+  `0640 root:infrabroker`. Empty env files are still not created.
 
 ### Documentation
 - **THREAT_MODEL gap #1 names the cert-TTL session cap (#372)** — the


### PR DESCRIPTION
## Summary

`install.sh` already converges service JSON to `0640` on every run, but two secret-adjacent files were left as-is:

- `/etc/infrabroker/{signer,control-plane,mcp-http}.env` (`EnvironmentFile` for AZURE_*, OIDC, webhook tokens). A `0644` file is readable by every `infrabroker-*` user because `/etc/infrabroker` is `0750 root:infrabroker`.
- Existing `/etc/infrabroker/broker-ctl.json` was neither chown'd nor chmod'd (only a newly seeded copy got `0640`).

Re-run now sets env files to `0600 root:root` and `broker-ctl.json` to `0640 root:infrabroker`. Empty env files are still not created.

## Verification

- `bash -n deploy/install.sh`
- `make verify`

Closes #381