### PR TITLE
fix(k8s): project MatchedRule on dry-run denials

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,13 @@
   Re-run now sets env files to `0600 root:root` and `broker-ctl.json` to
   `0640 root:infrabroker`. Empty env files are still not created.
 
+### Fixed
+- **k8s dry-run projects MatchedRule and stops leaking the regex in Reason (#379)** —
+  a Kubernetes dry-run denial discarded the policy result, so
+  `reason_code` was always the fallback `denied` and `Reason` embedded
+  `command_policy (deny:<regex>)`. Dry-run now carries `MatchedRule` like
+  SSH and uses a generic Reason for policy denials.
+
 ### Documentation
 - **THREAT_MODEL gap #1 names the cert-TTL session cap (#372)** — the
   "Mitigation today" paragraph still said the certificate TTL does not

--- a/internal/signer/k8spolicy.go
+++ b/internal/signer/k8spolicy.go
@@ -437,12 +437,31 @@ func (ct ClusterTable) resolveK8s(in Intent, grants GrantProvider) (Decision, co
 // The token plays the certificate's role in Issued; layer-B enforcement is
 // the SA's native RBAC in the cluster.
 func (l *Local) signK8s(ctx context.Context, in Intent) (*Issued, error) {
-	d, _, err := l.clusters.resolveK8s(in, l.grants)
+	d, res, err := l.clusters.resolveK8s(in, l.grants)
 	cp := l.clusters[in.Host]
 	ttl := time.Duration(cp.TokenTTLSeconds) * time.Second
 	if in.DryRun {
 		if err != nil {
-			return &Issued{Decision: &DecisionInfo{Allowed: false, Reason: err.Error()}}, nil
+			// Policy denials return a populated commandPolicyResult (MatchedRule
+			// etc.) plus an error whose text embeds the raw pattern. Project
+			// the result so reason_code classifies like SSH (#119) and keep
+			// the regex out of Reason (#379). Pre-policy errors (unknown
+			// cluster, validation) have an empty MatchedRule and keep the
+			// error text.
+			di := &DecisionInfo{
+				Allowed:              false,
+				MatchedRule:          res.MatchedRule,
+				Enforcement:          res.Enforcement,
+				Warning:              res.Warning,
+				WouldDeny:            res.WouldDeny,
+				WouldRequireApproval: res.WouldRequireApproval,
+			}
+			if res.MatchedRule != "" {
+				di.Reason = "not allowed by cluster policy"
+			} else {
+				di.Reason = err.Error()
+			}
+			return &Issued{Decision: di}, nil
 		}
 		di := decisionInfo(d, true)
 		di.TTLSeconds = int(ttl / time.Second)

--- a/internal/signer/k8spolicy_test.go
+++ b/internal/signer/k8spolicy_test.go
@@ -377,6 +377,46 @@ func TestSignK8sMintsBoundToken(t *testing.T) {
 	}
 }
 
+// TestSignK8sDryRunProjectsMatchedRule pins #379: a k8s dry-run denial must
+// carry MatchedRule (so reason_code classifies like SSH) and must not put the
+// raw policy pattern in Reason.
+func TestSignK8sDryRunProjectsMatchedRule(t *testing.T) {
+	t.Parallel()
+	cp := testCluster(t, []K8sRule{
+		{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"},
+		{Verbs: []string{"delete"}, Resources: []string{"pods"}, Effect: "deny"},
+	})
+	l := NewLocal(nil, nil, time.Minute).WithK8s(compileOne(t, cp), &fakeMinter{})
+
+	// Default-deny / allowlist miss.
+	miss := k8sIntent(K8sAction{Verb: "apply", Resource: "configmaps", Namespace: "p", Name: "x"})
+	miss.DryRun = true
+	issued, err := l.SignIntent(context.Background(), miss)
+	if err != nil || issued.Decision == nil || issued.Decision.Allowed {
+		t.Fatalf("allowlist miss: %+v, %v", issued, err)
+	}
+	if issued.Decision.MatchedRule != "allowlist:no-match" {
+		t.Errorf("allowlist miss MatchedRule = %q, want allowlist:no-match", issued.Decision.MatchedRule)
+	}
+	if issued.Decision.Reason != "not allowed by cluster policy" {
+		t.Errorf("allowlist miss Reason = %q, want generic (must not embed the rule)", issued.Decision.Reason)
+	}
+
+	// Explicit deny: MatchedRule carries the generated regex; Reason must not.
+	deny := k8sIntent(K8sAction{Verb: "delete", Resource: "pods", Namespace: "prod", Name: "web-1"})
+	deny.DryRun = true
+	issued, err = l.SignIntent(context.Background(), deny)
+	if err != nil || issued.Decision == nil || issued.Decision.Allowed {
+		t.Fatalf("deny: %+v, %v", issued, err)
+	}
+	if !strings.HasPrefix(issued.Decision.MatchedRule, "deny:") {
+		t.Errorf("deny MatchedRule = %q, want deny:…", issued.Decision.MatchedRule)
+	}
+	if strings.Contains(issued.Decision.Reason, issued.Decision.MatchedRule) || strings.Contains(issued.Decision.Reason, "deny:") {
+		t.Errorf("deny Reason leaked the rule: %q (MatchedRule=%q)", issued.Decision.Reason, issued.Decision.MatchedRule)
+	}
+}
+
 func TestSignK8sBindingSelection(t *testing.T) {
 	t.Parallel()
 	cp := testCluster(t, []K8sRule{{Verbs: []string{"get"}, Resources: []string{"pods"}, Effect: "allow"}})


### PR DESCRIPTION
## Summary

`signK8s` discarded the `commandPolicyResult` from `resolveK8s`. On a dry-run denial that left `MatchedRule` empty, so `reason_code` was always the fallback `denied`, and `Reason` was the `resolveCommandPolicy` error — which embeds `command_policy (deny:<regex>)`.

Dry-run now projects `MatchedRule` / `Enforcement` / `Warning` like SSH so `reason_code` classifies (`command_denied`, `allowlist_no_match`). Policy denials use a generic Reason; the regex stays on `MatchedRule` (and the audit `policy_rule`). Pre-policy errors (unknown cluster, validation) still surface their error text.

## Verification

- `make verify`

Closes #379