### PR TITLE
docs(api): say runtime grants persist when state_db is set

### DIFF
--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -306,7 +306,8 @@ func main() {
 	mux.HandleFunc("POST /v1/policy/hosts/{host}/allow", srv.handlePolicyAllow)
 	mux.HandleFunc("DELETE /v1/policy/hosts/{host}/allow", srv.handlePolicyAllow)
 	// Runtime widen-only grants: time-boxed allow rules on an allowlist host that
-	// expire on their own (auth: reload_callers). Held in memory; never persisted.
+	// expire on their own (auth: reload_callers). Persisted when state_db is set;
+	// memory-only (lost on restart) otherwise.
 	mux.HandleFunc("POST /v1/policy/hosts/{host}/grants", srv.handleGrantCreate)
 	mux.HandleFunc("GET /v1/policy/grants", srv.handleGrantList)
 	mux.HandleFunc("DELETE /v1/policy/grants/{id}", srv.handleGrantRevoke)

--- a/docs/API.md
+++ b/docs/API.md
@@ -318,11 +318,13 @@ tier as `/v1/reload`). **Request body:** `{ "pattern": "<RE2 regex>" }`.
 
 A **runtime grant** temporarily **widens** a host's allowlist without editing
 `signer.json`: a set of `allow` patterns that **expire on their own** after a TTL.
-Unlike the mutation API above (which edits the durable file), grants live **in
-memory only** — they are the dynamic overlay on top of the file baseline, intended
-for "let this command through on `web01` for the next 2 hours" without a config
-change. They are lost on a signer restart (TTL'd anyway), and they survive config
-reloads.
+Unlike the mutation API above (which edits the durable file), grants are a
+dynamic overlay on the file baseline — "let this command through on `web01`
+for the next 2 hours" without a config change. With `state_db` set (the
+production recommendation) they are write-through SQLite and restored at
+startup; they expire on TTL or revoke. Without `state_db` they live in
+memory only and are lost on a signer restart. They survive config reloads
+either way.
 
 **Widen-only, by construction.** A grant carries only `allow` patterns (never
 `deny` / `require_approval`), and the signer applies it **only on a host that is

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,10 @@
   table still said "local PEM or Azure Key Vault" and linked a stale
   ARCHITECTURE anchor. It now lists PEM / AKV / ssh-agent/HSM and points
   at the current Multi-CA heading.
+- **API.md runtime grants persist when `state_db` is set (#380)** — the
+  grant section and the signer mux comment still said grants are
+  memory-only and die on restart. They persist with `state_db` and expire
+  on TTL or revoke.
 
 ## [v3.1.1] - 2026-08-12
 


### PR DESCRIPTION
## Summary

`docs/API.md` (Runtime grants) and the mux comment in `cmd/signer/main.go` still said grants live in memory only and are lost on a signer restart. With `state_db` they are write-through SQLite and restored at startup. An operator who treated restart as revocation would leave widen-only policy live.

## Verification

- `make verify`

Closes #380