### PR TITLE
fix(deploy): rewrite unit ExecStart when --bindir is set

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -54,6 +54,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ $(id -u) -eq 0 ]] || { echo "must run as root" >&2; exit 1; }
+# Tab-completion often leaves a trailing slash; strip it so --bindir and
+# the unit ExecStart rewrite agree (#382).
+BINDIR="${BINDIR%/}"
 
 # Locate the source tree: a dist tarball has deploy/install.sh with bin/ and
 # the example configs at its root; in a git checkout binaries come from
@@ -232,11 +235,30 @@ EOF
     echo >&2
 fi
 
-# 5. systemd units.
+# 5. systemd units. The shipped files hard-code ExecStart=/usr/local/bin/<bin>.
+# When --bindir is not that default, rewrite the ExecStart path so the unit
+# launches the binary just installed (#382).
 for svc in ${SERVICES}; do
     unit="$(svc_unit "${svc}")"
-    install -m 0644 "${SCRIPT_DIR}/systemd/${unit}" "/etc/systemd/system/${unit}"
-    echo "installed /etc/systemd/system/${unit}"
+    bin="$(svc_binary "${svc}")"
+    src="${SCRIPT_DIR}/systemd/${unit}"
+    dest="/etc/systemd/system/${unit}"
+    if [[ "${BINDIR}" == "/usr/local/bin" ]]; then
+        install -m 0644 "${src}" "${dest}"
+    else
+        tmp="$(mktemp)"
+        bindir_esc="$(printf '%s\n' "${BINDIR}" | sed 's/[&|]/\\&/g')"
+        sed "s|^ExecStart=/usr/local/bin/${bin}|ExecStart=${bindir_esc}/${bin}|" "${src}" > "${tmp}"
+        if ! grep -q "^ExecStart=${BINDIR}/${bin}" "${tmp}"; then
+            echo "failed to rewrite ExecStart in ${unit} for --bindir ${BINDIR}" >&2
+            rm -f "${tmp}"
+            exit 1
+        fi
+        install -m 0644 "${tmp}" "${dest}"
+        rm -f "${tmp}"
+        echo "rewrote ExecStart to ${BINDIR}/${bin}"
+    fi
+    echo "installed ${dest}"
 done
 systemctl daemon-reload
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,10 @@
   grant section and the signer mux comment still said grants are
   memory-only and die on restart. They persist with `state_db` and expire
   on TTL or revoke.
+- **install.sh `--bindir` rewrites unit ExecStart (#382)** — binaries
+  went to `$BINDIR` but the shipped systemd units still exec
+  `/usr/local/bin/…`. A non-default `--bindir` now rewrites `ExecStart`
+  to match.
 
 ## [v3.1.1] - 2026-08-12
 


### PR DESCRIPTION
## Summary

`--bindir DIR` installed `signer` / `control-plane` / `mcp-broker-http` to `$BINDIR`, but the units copied in step 5 hard-coded `ExecStart=/usr/local/bin/…`. A non-default bindir produced enabled units that exec missing binaries.

When `--bindir` is not `/usr/local/bin`, the installer now rewrites `ExecStart` to `${BINDIR}/<binary>` (and fails closed if the rewrite misses). Trailing slashes from tab-completion are stripped so binaries and units agree.

## Verification

- `bash -n deploy/install.sh`
- Simulated rewrite: `ExecStart=/opt/ib/signer -config …`
- `make verify`

Closes #382