### PR TITLE
chore: v3.1.2 release (changelog + version bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [v3.1.2] - 2026-08-13
+
+Security and correctness audit: remaining command-hiding wrappers, reload
+vs policy-mutation race, installer mode/`--bindir` healing, k8s dry-run
+classification, and docs drift.
 
 ### Security
 - **Command-policy shell_parse rejects sudo/su/source wrappers (#371)** — the
@@ -38,6 +42,10 @@
   `reason_code` was always the fallback `denied` and `Reason` embedded
   `command_policy (deny:<regex>)`. Dry-run now carries `MatchedRule` like
   SSH and uses a generic Reason for policy denials.
+- **install.sh `--bindir` rewrites unit ExecStart (#382)** — binaries
+  went to `$BINDIR` but the shipped systemd units still exec
+  `/usr/local/bin/…`. A non-default `--bindir` now rewrites `ExecStart`
+  to match.
 
 ### Documentation
 - **THREAT_MODEL gap #1 names the cert-TTL session cap (#372)** — the
@@ -53,10 +61,6 @@
   grant section and the signer mux comment still said grants are
   memory-only and die on restart. They persist with `state_db` and expire
   on TTL or revoke.
-- **install.sh `--bindir` rewrites unit ExecStart (#382)** — binaries
-  went to `$BINDIR` but the shipped systemd units still exec
-  `/usr/local/bin/…`. A non-default `--bindir` now rewrites `ExecStart`
-  to match.
 
 ## [v3.1.1] - 2026-08-12
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,10 +1,17 @@
 # Handoff: infrabroker — broker de acceso a infraestructura para agentes de IA
 
 > Documento de traspaso para retomar la sesión de desarrollo. Última
-> actualización: 2026-08-12 (v3.1.1: audit security/correctness — shell wrappers,
-> freeze durability, k8s response cap, bridge pending-only, CGO=0 dist).
+> actualización: 2026-08-13 (v3.1.2: audit — wrappers restantes, reload/writeMu,
+> installer env/`--bindir`, k8s dry-run MatchedRule, docs).
 >
 > Estado reciente:
+> - **v3.1.2** (patch): **audit #371–#382** — shell_parse rechaza sudo/su/source
+>   y wrappers versionados (`python3.12`, `ash`, `/usr/bin/time`); reload toma
+>   `writeMu` para no revertir un DELETE concurrente; k8s dry-run proyecta
+>   `MatchedRule` y no filtra el regex en Reason; `install.sh` sana `*.env` /
+>   `broker-ctl.json` y reescribe `ExecStart` si `--bindir` no es el default.
+>   Docs: THREAT_MODEL cap de sesión en TTL del cert, README agent CA, grants
+>   persistentes con `state_db`.
 > - **v3.1.1** (patch): **audit #352–#360** — shell_parse rechaza wrappers que
 >   escondían el argv real a denylist/require_approval (`bash -c`, `env`, …);
 >   freeze instala en memoria aunque falle el checkpoint WAL y revoca grants

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/luisgf/infrabroker",
     "source": "github"
   },
-  "version": "3.1.1",
+  "version": "3.1.2",
   "websiteUrl": "https://luisgf.github.io/infrabroker/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/luisgf/infrabroker:3.1.1",
+      "identifier": "ghcr.io/luisgf/infrabroker:3.1.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Version

**v3.1.2** (patch). Last tag is `v3.1.1`. Everything since is `fix:` / `docs:` — no `feat:`, no `!` breaking change.

## What ships

Audit follow-up after v3.1.1:

- **Security** — `shell_parse` rejects `sudo`/`su`/`source` and versioned interpreters (`python3.12`, `ash`, `/usr/bin/time`); `reload()` holds `writeMu` so a concurrent policy DELETE cannot be reverted in memory; `install.sh` heals `*.env` / `broker-ctl.json` modes.
- **Fixed** — k8s dry-run projects `MatchedRule` (and stops leaking the deny regex in `Reason`); `--bindir` rewrites unit `ExecStart`.
- **Docs** — THREAT_MODEL session cap at cert TTL; README agent CA backend; API.md grants persist with `state_db`.

## Files

- `docs/CHANGELOG.md` — folded `[Unreleased]` into `[v3.1.2] - 2026-08-13`
- `server.json` — `version` + OCI identifier `3.1.2` (`mcp-publisher validate` ✅)
- `docs/HANDOFF.md` — header + estado reciente

## Verify

`make verify` green locally (gofmt, vet, build, race, govulncheck, docs-check).

Release PRs are **not** auto-merged. After checks pass (`build` / `govulncheck` / `check`), please review and say **merge #NN** (or merge in the UI). Tag `v3.1.2` is a separate, irreversible publish step — I will not push it without explicit authorization.