### PR TITLE
fix(signer): keep client-controlled host data out of the signed audit log

### DIFF
--- a/cmd/signer/grants.go
+++ b/cmd/signer/grants.go
@@ -263,9 +263,28 @@ func (s *server) appendAudit(e audit.Entry) error {
 	return nil
 }
 
+// safeAuditHost guards an audit Entry.Host value that has not passed a charset
+// gate yet — typically a host from r.PathValue on a mutation endpoint, echoed
+// before it is checked against the policy table, or an unknown host on a
+//
+// /v1/sign denial path. Valid names pass through unchanged; anything carrying
+// token-stream separators or control characters collapses to a marker.
+func safeAuditHost(host string) string {
+	if host == "" || signer.HasUnsafeTokenChar(host) {
+		return "(invalid-host)"
+	}
+	return host
+}
+
 // auditGrant records a grant operation in the signed audit log (best-effort: the
 // grant has already been applied by the time this runs).
 func (s *server) auditGrant(caller, host, id string, allow []string, outcome string, err error) {
+	// host may come from r.PathValue on the mutation endpoints (before the host
+	// is known to exist in the policy table) or be echoed on grant denial —
+	// neither path has charset-validated it. Collapse a value carrying
+	// whitespace/control characters to a marker so a rogue admin client cannot
+	// plant arbitrary text in the tamper-evident log's Host field.
+	host = safeAuditHost(host)
 	e := audit.Entry{Caller: caller, Host: host, Command: "grant " + id, Outcome: outcome}
 	if len(allow) > 0 {
 		e.PolicyRule = "allow:" + strings.Join(allow, ",")

--- a/cmd/signer/handlers_test.go
+++ b/cmd/signer/handlers_test.go
@@ -305,3 +305,48 @@ func TestHandleSignRateLimitPerCN(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleSignRejectsTokenInjectionInHost is the regression test for the
+// unvalidated-host audit gap: req.Host lands in Entry.Host verbatim on the
+// pre-policy denial paths (no policy for the host, frozen denial, end-user
+// unverified) where it is NOT replaced by the config-trusted hp.Addr. The
+// handler's input gate must reject a whitespace-bearing host with 400 before
+// any auditEmission and before the signer.
+func TestHandleSignRejectsTokenInjectionInHost(t *testing.T) {
+	t.Parallel()
+	cap := &captureLocalSigner{}
+	srv := &server{
+		local: cap,
+		hosts: signer.PolicyTable{"web01": {Addr: "10.0.0.1:22", User: "deploy", Principal: "host:web01"}},
+		audit: testAudit(t),
+	}
+	rec := httptest.NewRecorder()
+	srv.handleSign(rec, signRequestAs(t, "broker-1", signer.WireRequest{
+		Host: "web01 role=bastion user=victim", Role: signer.RoleTarget, Purpose: signer.PurposeOneshot, Command: "uptime",
+	}))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (token-injection host must be rejected): %s", rec.Code, rec.Body.String())
+	}
+	if cap.got.Host != "" {
+		t.Error("a token-injection host request must be rejected before reaching the signer")
+	}
+}
+
+// TestSafeAuditHostCollapsesUnsafeValues locks in the auditGrant/auditPolicy
+// guard: a host value reaching the signed audit log from a PathValue (echoed
+// before it is checked against the policy table) that carries whitespace or
+// control characters must collapse to the (invalid-host) marker; clean names
+// and empty pass through unchanged.
+func TestSafeAuditHostCollapsesUnsafeValues(t *testing.T) {
+	t.Parallel()
+	for tc, want := range map[string]string{
+		"web01":             "web01",
+		"":                  "(invalid-host)",
+		"web01 user=victim": "(invalid-host)",
+		"web\tx01":          "(invalid-host)",
+	} {
+		if got := safeAuditHost(tc); got != want {
+			t.Errorf("safeAuditHost(%q) = %q, want %q", tc, got, want)
+		}
+	}
+}

--- a/cmd/signer/k8s.go
+++ b/cmd/signer/k8s.go
@@ -133,6 +133,8 @@ func (s *server) auditK8s(caller string, req signer.WireRequest, serial uint64, 
 	host := req.Host
 	if cp, ok := s.currentClusters()[req.Host]; ok {
 		host = cp.APIServer
+	} else {
+		host = safeAuditHost(host)
 	}
 	resource := req.K8sResource
 	if req.K8sGroup != "" {

--- a/cmd/signer/main.go
+++ b/cmd/signer/main.go
@@ -867,6 +867,12 @@ func (s *server) handleSign(w http.ResponseWriter, r *http.Request) {
 		{"session_mode", req.SessionMode}, {"sudo_user", req.SudoUser},
 		{"k8s_verb", req.K8sVerb}, {"k8s_resource", req.K8sResource}, {"k8s_group", req.K8sGroup},
 		{"k8s_namespace", req.K8sNamespace}, {"k8s_name", req.K8sName},
+		// req.Host also lands in Entry.Host on the pre-policy denial paths
+		// below (no policy for host, unknown cluster, frozen- or end-user-
+		// denied), where it is NOT replaced by the config-trusted hp.Addr.
+		// Gate it here so it cannot carry token-stream separators or control
+		// characters into the tamper-evident log.
+		{"host", req.Host},
 	} {
 		if signer.HasUnsafeTokenChar(f.val) {
 			http.Error(w, "invalid "+f.name+": control or whitespace characters not allowed", http.StatusBadRequest)
@@ -1425,13 +1431,18 @@ func (s *server) auditEmission(caller string, req signer.WireRequest, hosts sign
 		cmd += " ft=1"
 	}
 	// Use the real address (FQDN) and policy metadata instead of the logical
-	// name, which does not uniquely identify the target in the log.
+	// name, which does not uniquely identify the target in the log. On an
+	// unknown host the raw req.Host is the only name available; it passed the
+	// charset gate at the top of handleSign, but guard the fallback anyway in
+	// case a future caller bypasses that gate.
 	host := req.Host
 	var user, principal string
 	if hp, ok := hosts[req.Host]; ok {
 		host = hp.Addr
 		user = hp.User
 		principal = hp.Principal
+	} else {
+		host = safeAuditHost(host)
 	}
 	e := audit.Entry{
 		Caller:    caller,

--- a/cmd/signer/policy.go
+++ b/cmd/signer/policy.go
@@ -268,7 +268,7 @@ func (s *server) auditPolicy(caller, host, pattern string, add bool, outcome str
 	// project's space-separated key=value token stream — where it could splice
 	// forged attribution tokens (user=/elev=/role=). It is recorded in the
 	// discrete, labeled PolicyRule field instead (shown as "[rule: ...]").
-	e := audit.Entry{Caller: caller, Host: host, Command: op, Outcome: outcome}
+	e := audit.Entry{Caller: caller, Host: safeAuditHost(host), Command: op, Outcome: outcome}
 	if pattern != "" {
 		e.PolicyRule = "allow:" + pattern
 	}


### PR DESCRIPTION
Closes #394

- The /v1/sign charset gate (cmd/signer/main.go) now also validates req.Host before any auditEmission on the pre-policy denial paths (no policy for host, unknown cluster, frozen- or end-user-denied), where it was never replaced by the config-trusted hp.Addr.
- auditGrant / auditPolicy (host comes from r.PathValue, echoed before existence checks) and the auditEmission / auditK8s unknown-host fallbacks collapse a non-conforming value to an (invalid-host) marker via safeAuditHost.
- Regression tests: TestHandleSignRejectsTokenInjectionInHost (400 before any audit, before the signer) and TestSafeAuditHostCollapsesUnsafeValues.
- Verified: CGO_ENABLED=1 make verify (gofmt, vet, build, race tests, govulncheck, docs gate, strict site).