### PR TITLE
fix(ca): refuse to start the AKV signer unpinned

### DIFF
--- a/internal/ca/akv.go
+++ b/internal/ca/akv.go
@@ -78,6 +78,19 @@ func newAKVSignerWithOps(ctx context.Context, ops akvKeyOps, keyName, keyVersion
 			log.Printf("AKV key %q: pinned to version %s (key rotation requires a signer reload/restart)", keyName, keyVersion)
 		}
 	}
+	if keyVersion == "" {
+		// #398: with no pinned version, Sign would resolve "latest" on every
+		// call — the exact post-rotation public-key/signature desync the
+		// pinning exists to prevent (sshd would reject every cert after
+		// rotation). An empty KID version (or no KID at all) is an unexpected
+		// AKV response shape; fail construction rather than run with the
+		// per-call fallback.
+		var kidDesc string
+		if resp.Key.KID != nil {
+			kidDesc = string(*resp.Key.KID)
+		}
+		return nil, fmt.Errorf("AKV key %q: could not pin a key version (key_version unset and the returned KID %q has no version segment); refusing to start with per-call latest-version signing", keyName, kidDesc)
+	}
 	return &akvSigner{ops: ops, keyName: keyName, keyVersion: keyVersion, pubKey: pub}, nil
 }
 

--- a/internal/ca/akv_test.go
+++ b/internal/ca/akv_test.go
@@ -9,12 +9,27 @@ import (
 	"crypto/rsa"
 	"encoding/asn1"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 	"golang.org/x/crypto/ssh"
 )
+
+// defaultMockKID is a realistic key identifier with a version segment, returned
+// by both mocks so the constructor can pin the version from it (#398).
+var defaultMockKID = azkeys.ID("https://mock.vault.azure.net/keys/mock-key/mockversion01")
+
+func privP256Kty() *azkeys.KeyType {
+	kty := azkeys.KeyTypeEC
+	return &kty
+}
+
+func privP256Crv() *azkeys.CurveName {
+	crv := azkeys.CurveNameP256
+	return &crv
+}
 
 // mockAKVOps is a test double for akvKeyOps.
 type mockAKVOps struct {
@@ -49,6 +64,9 @@ func ecP256Mock(t *testing.T) (*mockAKVOps, *ecdsa.PrivateKey) {
 						Crv: &crv,
 						X:   priv.PublicKey.X.FillBytes(make([]byte, 32)),
 						Y:   priv.PublicKey.Y.FillBytes(make([]byte, 32)),
+						// A realistic KID with a version: the constructor pins
+						// the version from it (#398) or refuses to start.
+						KID: &defaultMockKID,
 					},
 				},
 			}, nil
@@ -86,6 +104,7 @@ func rsaMock(t *testing.T) (*mockAKVOps, *rsa.PrivateKey) {
 						Kty: &kty,
 						N:   priv.PublicKey.N.Bytes(),
 						E:   big.NewInt(int64(priv.PublicKey.E)).Bytes(),
+						KID: &defaultMockKID,
 					},
 				},
 			}, nil
@@ -359,14 +378,31 @@ func TestAKVSignerExplicitVersionKept(t *testing.T) {
 // (defensive case) does not crash and leaves the version empty.
 func TestAKVSignerNilKIDKeepsEmptyVersion(t *testing.T) {
 	t.Parallel()
-	mock, _ := ecP256Mock(t) // ecP256Mock returns no KID
-
-	s, err := newAKVSignerWithOps(context.Background(), mock, "my-key", "")
-	if err != nil {
-		t.Fatalf("newAKVSignerWithOps: %v", err)
+	mock, priv := ecP256Mock(t)
+	// Strip the default mock's KID to simulate a (defensive) response shape
+	// without one.
+	mock.getKeyFn = func(_ context.Context, _, _ string, _ *azkeys.GetKeyOptions) (azkeys.GetKeyResponse, error) {
+		return azkeys.GetKeyResponse{
+			KeyBundle: azkeys.KeyBundle{
+				Key: &azkeys.JSONWebKey{
+					Kty: privP256Kty(),
+					Crv: privP256Crv(),
+					X:   priv.PublicKey.X.FillBytes(make([]byte, 32)),
+					Y:   priv.PublicKey.Y.FillBytes(make([]byte, 32)),
+				},
+			},
+		}, nil
 	}
-	if s.keyVersion != "" {
-		t.Errorf("keyVersion = %q, want empty when KID is absent", s.keyVersion)
+
+	// #398: an empty pinned version means Sign would resolve "latest" on every
+	// call — the post-rotation desync the pinning exists to prevent. The
+	// constructor must refuse to return a signer rather than run unpinned.
+	_, err := newAKVSignerWithOps(context.Background(), mock, "my-key", "")
+	if err == nil {
+		t.Fatal("newAKVSignerWithOps with an unversioned KID must fail (refuses per-call latest-version signing)")
+	}
+	if !strings.Contains(err.Error(), "could not pin a key version") {
+		t.Errorf("error = %q, want a pin-failure message", err)
 	}
 }
 


### PR DESCRIPTION
Closes #398

- If `key_version` is unset and the KID returned by GetKey has no version segment, construction now fails instead of silently leaving the signer on per-call "latest" signing (post-rotation desync → sshd rejects every cert).
- AKV mocks carry a versioned KID by default; the nil/unversioned KID shape is regression-tested to fail construction.
- Verified: CGO_ENABLED=1 make verify.