### PR TITLE
fix(auth): require the clientAuth EKU in CallerCN

### DIFF
--- a/internal/auth/mtls.go
+++ b/internal/auth/mtls.go
@@ -76,12 +76,20 @@ func ClientTLSConfig(certFile, keyFile, serverCAFile string) (*tls.Config, error
 
 // CallerCN extracts the Common Name from the verified client certificate.
 // Assumes the TLS handshake has already validated the chain
-// (RequireAndVerifyClientCert).
+// (RequireAndVerifyClientCert). The leaf must carry the clientAuth EKU
+// (#399): the client CA may also issue non-client certs (server, broker-ctl,
+// operator tooling), and CN-based RBAC would otherwise be satisfied by any
+// cert of the same CA with a colliding CN — a server cert is not a caller
+// identity.
 func CallerCN(r *http.Request) (string, error) {
 	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 		return "", fmt.Errorf("no client certificate")
 	}
-	cn := r.TLS.PeerCertificates[0].Subject.CommonName
+	cert := r.TLS.PeerCertificates[0]
+	if !hasClientAuthEKU(cert) {
+		return "", fmt.Errorf("client certificate lacks the clientAuth extended key usage")
+	}
+	cn := cert.Subject.CommonName
 	// Fail closed on an empty or malformed CN: with the default-open caller
 	// tables an empty CN would otherwise be accepted as an (unlisted) identity
 	// and inherit broad access; control characters could also corrupt audit
@@ -95,4 +103,21 @@ func CallerCN(r *http.Request) (string, error) {
 		}
 	}
 	return cn, nil
+}
+
+// hasClientAuthEKU reports whether the certificate is valid for TLS client
+// authentication: it has no EKU extension (any usage, per RFC 5280) or it
+// includes ExtKeyUsageClientAuth. A certificate restricted to serverAuth (a
+// server cert from the same CA) is not a caller identity, no matter what CN
+// it carries.
+func hasClientAuthEKU(cert *x509.Certificate) bool {
+	if len(cert.ExtKeyUsage) == 0 {
+		return true
+	}
+	for _, ku := range cert.ExtKeyUsage {
+		if ku == x509.ExtKeyUsageClientAuth {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/auth/mtls_test.go
+++ b/internal/auth/mtls_test.go
@@ -34,3 +34,35 @@ func TestCallerCN(t *testing.T) {
 		t.Error("missing client certificate must be rejected")
 	}
 }
+
+// TestCallerCNRequiresClientAuthEKU pins #399: the client CA can issue certs
+// for other purposes (serverAuth, code signing...), and CN-based RBAC must
+// not be satisfied by such a cert with a colliding CN. A leaf with no EKU
+// extension is unconstrained (RFC 5280) and still accepted; a leaf restricted
+// to serverAuth is rejected even with a valid CN.
+func TestCallerCNRequiresClientAuthEKU(t *testing.T) {
+	t.Parallel()
+	req := func(eku []x509.ExtKeyUsage) (string, error) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.TLS = &tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{{
+				Subject:     pkix.Name{CommonName: "broker-1"},
+				ExtKeyUsage: eku,
+			}},
+		}
+		return CallerCN(r)
+	}
+
+	if cn, err := req(nil); err != nil || cn != "broker-1" {
+		t.Errorf("no EKU extension (any usage): got cn=%q err=%v", cn, err)
+	}
+	if cn, err := req([]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}); err != nil || cn != "broker-1" {
+		t.Errorf("clientAuth among EKUs: got cn=%q err=%v", cn, err)
+	}
+	if _, err := req([]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err == nil {
+		t.Error("a serverAuth-only cert must be rejected as a caller identity")
+	}
+	if _, err := req([]x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning}); err == nil {
+		t.Error("a codeSigning-only cert must be rejected as a caller identity")
+	}
+}


### PR DESCRIPTION
Closes #399

- Caller identity was CN-only; a cert of the same client CA with a colliding CN (serverAuth server cert, operator tooling) satisfied CN-based RBAC. CallerCN now rejects leaves restricted to non-clientAuth EKUs.
- Leaves with no EKU extension (any-usage) remain accepted — lab certs generated with plain `openssl x509 -req` keep working; no config or PKI migration needed.
- Regression test: TestCallerCNRequiresClientAuthEKU.
- Verified: CGO_ENABLED=1 make verify.