### PR TITLE
fix(mcpserver): bound ssh_put_file content before base64 decoding

### DIFF
--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -388,6 +388,15 @@ func registerPutFile(srv *mcp.Server, eng *broker.Engine, callerFn CallerFunc) {
 		if err := validateInput(map[string]string{"server": in.Server, "path": in.Path, "mode": in.Mode}); err != nil {
 			return toolError(err), putFileOutput{}, nil
 		}
+		// Bound the content before decoding it: in.Content bypasses
+		// maxInputLen (legitimately, transfers go up to file_transfer_max_bytes),
+		// but nothing else on the stdio frontend caps it, so an oversized
+		// request would be base64-decoded into memory before the engine's
+		// 512 KiB gate (#396). The base64 bound is 4/3 of the cap plus padding.
+		maxBytes := eng.FileTransferMaxBytes()
+		if len(in.Content) > encodedBound(maxBytes) {
+			return toolError(fmt.Errorf("content exceeds the transfer limit of %d bytes", maxBytes)), putFileOutput{}, nil
+		}
 		content := []byte(in.Content)
 		if in.ContentBase64 {
 			decoded, err := base64.StdEncoding.DecodeString(in.Content)
@@ -550,4 +559,11 @@ func renderResult(o executeOutput) string {
 	}
 	fmt.Fprintf(&b, "\n[exit=%d serial=%d]", o.ExitCode, o.Serial)
 	return b.String()
+}
+
+// encodedBound returns the longest base64 string (including padding) that can
+// encode exactly max raw bytes — the request-size gate for ssh_put_file
+// content, applied before the decode (#396).
+func encodedBound(max int) int {
+	return max + max/3 + 4
 }

--- a/internal/mcpserver/tools_test.go
+++ b/internal/mcpserver/tools_test.go
@@ -1,0 +1,24 @@
+package mcpserver
+
+import (
+	"testing"
+)
+
+// TestEncodedBoundAndOversizedContentReject pins #396: ssh_put_file content
+// bypasses maxInputLen, so the handler must bound the raw (base64-encoded)
+// content at base64(4/3 of the transfer cap)+padding BEFORE decoding it.
+func TestEncodedBoundAndOversizedContentReject(t *testing.T) {
+	t.Parallel()
+	max := 512 * 1024
+	bound := encodedBound(max)
+	// Exact base64 length for max bytes: 4*ceil(max/3). The bound is a
+	// slightly looser (max/3 + 4) variant — it must never be UNDER it, and
+	// within 32 bytes of it.
+	want := ((max + 2) / 3) * 4
+	if bound < want {
+		t.Errorf("encodedBound(%d) = %d, must be at least the exact base64 length %d", max, bound, want)
+	}
+	if bound-want > 32 {
+		t.Errorf("encodedBound(%d) = %d, unnecessarily loose vs exact %d", max, bound, want)
+	}
+}


### PR DESCRIPTION
Closes #396

- stdio ssh_put_file content bypassed maxInputLen and was decoded in full before the engine's file_transfer_max_bytes gate.
- The handler now rejects raw content above base64(cap)+padding before decoding; the engine cap stays authoritative.
- Regression test: TestEncodedBoundAndOversizedContentReject.
- Verified: CGO_ENABLED=1 make verify.