### PR TITLE
fix(bridge): drop Slack decisions after shutdown instead of blocking

### DIFF
--- a/cmd/approval-bridge/main.go
+++ b/cmd/approval-bridge/main.go
@@ -71,6 +71,9 @@ func main() {
 		guard = "on"
 	}
 	log.Printf("approval-bridge: polling %s every %s, presenting on slack; self-approval guard %s", *cpURL, *poll, guard)
+	// Release the adapter's senders on shutdown so a click that arrives after
+	// Run exits cannot wedge the socket-mode goroutine (#402).
+	defer adapter.Stop()
 	if err := bridge.New(cp, adapter, *poll, identityMap).Run(ctx); err != nil && err != context.Canceled {
 		log.Fatalf("approval-bridge: %v", err)
 	}

--- a/internal/bridge/slack.go
+++ b/internal/bridge/slack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/socketmode"
@@ -26,6 +27,11 @@ type SlackAdapter struct {
 	sm        *socketmode.Client
 	channel   string
 	decisions chan Decision
+	// done is closed by Stop: decision sends select on it so a click arriving
+	// after the bridge's Run has exited cannot block the socket-mode loop
+	// forever (the decisions channel is buffered, not unbounded, #402).
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // NewSlackAdapter connects with a bot token (xoxb-) and an app-level token
@@ -40,9 +46,16 @@ func NewSlackAdapter(botToken, appToken, channel string) (*SlackAdapter, error) 
 		sm:        socketmode.New(api),
 		channel:   channel,
 		decisions: make(chan Decision, 32),
+		done:      make(chan struct{}),
 	}
 	go a.listen()
 	return a, nil
+}
+
+// Stop releases the adapter: pending and future decision sends are dropped and
+// the socket-mode event loop drains. Idempotent.
+func (a *SlackAdapter) Stop() {
+	a.stopOnce.Do(func() { close(a.done) })
 }
 
 // Name identifies the platform.
@@ -115,10 +128,21 @@ func (a *SlackAdapter) listen() {
 		for _, action := range cb.ActionCallback.BlockActions {
 			switch action.ActionID {
 			case actionApprove:
-				a.decisions <- Decision{ID: action.Value, Approve: true, By: cb.User.ID}
+				a.sendDecision(Decision{ID: action.Value, Approve: true, By: cb.User.ID})
 			case actionDeny:
-				a.decisions <- Decision{ID: action.Value, Approve: false, By: cb.User.ID}
+				a.sendDecision(Decision{ID: action.Value, Approve: false, By: cb.User.ID})
 			}
 		}
+	}
+}
+
+// sendDecision pushes a click onto the decisions channel without ever blocking
+// past shutdown (#402): once Stop has closed done (the bridge exited, e.g. on
+// ctx cancellation with queued clicks), the send is dropped instead of wedging
+// the socket-mode loop goroutine.
+func (a *SlackAdapter) sendDecision(d Decision) {
+	select {
+	case a.decisions <- d:
+	case <-a.done:
 	}
 }

--- a/internal/bridge/slack_test.go
+++ b/internal/bridge/slack_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack"
 
@@ -35,5 +36,33 @@ func TestSlackApprovalRendersUntrustedFieldsAsPlainText(t *testing.T) {
 	}
 	if !strings.Contains(plainText, inject) {
 		t.Errorf("the command must render literally in a plain_text block; got %q", plainText)
+	}
+}
+
+// TestSlackSendDecisionDropsAfterStop pins #402: once the bridge has shut down
+// (Stop), a click arriving with a full decisions buffer must be dropped rather
+// than block the socket-mode goroutine forever. The send fills the buffer, Stop
+// fires, and a further send must return immediately instead of wedging.
+func TestSlackSendDecisionDropsAfterStop(t *testing.T) {
+	t.Parallel()
+	a := &SlackAdapter{
+		decisions: make(chan Decision, 32),
+		done:      make(chan struct{}),
+	}
+	for i := range 32 {
+		a.sendDecision(Decision{ID: string(rune('a' + i))})
+	}
+	// Buffer full: a pre-Stop send would block. Stop must un-wedge it.
+	done := make(chan struct{})
+	go func() {
+		a.sendDecision(Decision{ID: "spill"})
+		close(done)
+	}()
+	a.Stop()
+	select {
+	case <-done:
+		// send returned (dropped after Stop) — good
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendDecision blocked past Stop: the socket-mode goroutine would leak (#402)")
 	}
 }


### PR DESCRIPTION
Closes #402

- Unguarded send on the 32-buffered decisions channel could wedge the socket-mode goroutine after the bridge's Run exits.
- Send now selects on a `done` channel (`SlackAdapter.Stop`, idempotent); approval-bridge defers Stop on shutdown.
- Regression test: TestSlackSendDecisionDropsAfterStop.
- Verified: CGO_ENABLED=1 make verify.