### PR TITLE
fix(recording): count only persisted bytes in the written counter

### DIFF
--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -215,7 +215,13 @@ func (r *Recorder) writeLine(eventType, data string) error {
 	if err != nil {
 		return fmt.Errorf("recording: marshal event: %w", err)
 	}
-	n, err := fmt.Fprintf(r.f, "%s\n", line)
-	r.written += int64(n)
-	return err
+	n, ferr := fmt.Fprintf(r.f, "%s\n", line)
+	// #403: count only bytes actually persisted — on a failed or partial
+	// write, incrementing r.written with n would inflate the byte-usage
+	// counter and trip the size cap early. (fmt.Fprintf returns the length
+	// that WOULD have been written, also on error.)
+	if ferr == nil {
+		r.written += int64(n)
+	}
+	return ferr
 }

--- a/internal/recording/write_error_test.go
+++ b/internal/recording/write_error_test.go
@@ -36,3 +36,29 @@ func TestRecordingWriteErrorMetric(t *testing.T) {
 		t.Errorf("empty write must not increment the counter: got %d, want %d", got, before+1)
 	}
 }
+
+// TestWrittenCounterNotInflatedByFailedWrite pins #403: a failed write must
+// not advance r.written — Fprintf returns the byte count that WOULD have been
+// written, and counting it inflates the byte-usage counter so the size cap
+// trips early.
+func TestWrittenCounterNotInflatedByFailedWrite(t *testing.T) {
+	r, err := Open(filepath.Join(t.TempDir(), "s.cast"), Meta{SessionID: "s"})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	r.mu.Lock()
+	before := r.written
+	r.f.Close() // break the fd; r.f stays non-nil, so the write path runs
+	r.mu.Unlock()
+
+	if err := r.WriteOutput("0123456789"); err == nil {
+		t.Fatal("expected a write error on a closed fd")
+	}
+	r.mu.Lock()
+	got := r.written
+	r.mu.Unlock()
+	if got != before {
+		t.Errorf("r.written advanced on a failed write: got %d, want %d", got, before)
+	}
+}


### PR DESCRIPTION
Closes #403

- r.written was advanced with Fprintf's would-be byte count even on error, tripping the size cap early.
- Now increments only when the write succeeded.
- Regression test: TestWrittenCounterNotInflatedByFailedWrite.
- Verified: CGO_ENABLED=1 make verify.