### PR TITLE
docs(freeze): session_id/serial freezes are broker-enforced only

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -703,6 +703,9 @@ broker-ctl freeze --caller broker-1 --reason incident-4821
 # Freeze one end user, or one specific live session / certificate:
 broker-ctl freeze --end-user alice --reason offboarding
 broker-ctl freeze --serial 12345
+# (session-id/serial freezes kill matching live sessions on the broker's
+# next revocation poll; they do not block NEW issuances — a caller or
+# end-user freeze is what turns off the supply of new certificates.)
 
 # Kill a single runaway session by id (sugar for freeze --session-id):
 broker-ctl session kill 7f3c...

--- a/internal/signer/freeze.go
+++ b/internal/signer/freeze.go
@@ -15,13 +15,18 @@ import (
 // restart may lose the freeze until the WAL is flushed (#353).
 var ErrFreezeNotDurable = errors.New("freeze enforced in-memory but not durable")
 
-// Freeze subject kinds. A frozen subject is denied on the signer decision path
-// (/v1/sign, /v1/hosts) and drives the broker's live-session kill (#117).
+// Freeze subject kinds. All kinds drive the broker's live-session kill (#117),
+// which polls /v1/revocations (latency: the broker's revocation_poll_seconds).
+// A frozen caller or end user is additionally denied on the signer decision
+// path (/v1/sign, /v1/hosts) — the signer has no way to map a session_id or a
+// certificate serial onto a NEW request, so kinds session_id and serial are
+// enforced broker-side only: they kill existing sessions, they do not block
+// new issuances.
 const (
 	FreezeCaller    = "caller"     // broker mTLS CN (or on_behalf_of identity)
 	FreezeEndUser   = "end_user"   // asserted end-user identity
-	FreezeSessionID = "session_id" // a specific live broker session
-	FreezeSerial    = "serial"     // a specific issued certificate serial
+	FreezeSessionID = "session_id" // a specific live broker session (broker-enforced)
+	FreezeSerial    = "serial"     // a specific issued certificate serial (broker-enforced)
 )
 
 // ValidFreezeKind reports whether kind is a recognised freeze subject kind.


### PR DESCRIPTION
Closes #404

- freeze.go header over-claimed: only caller/end_user freezes gate /v1/sign and /v1/hosts; session_id/serial are broker-side kill switch only (latency = the broker's revocation poll).
- Comment scoped per kind; OPERATIONS freeze example documents the distinction.
- Verified: CGO_ENABLED=1 make verify.